### PR TITLE
Add ECS Service of Fargate launch type with Application Auto Scaling …

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ cdk destroy
 | [ecs-service-with-task-placement](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ecs/ecs-service-with-task-placement/) | Starting a container ECS with task placement specifications |
 | [ecs-service-with-advanced-alb-config](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ecs/ecs-service-with-advanced-alb-config/) | Starting a container fronted by a load balancer on ECS with added load balancer configuration |
 | [fargate-load-balanced-service](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ecs/fargate-load-balanced-service/) | Starting a container fronted by a load balancer on Fargate |
+| [fargate-service-with-auto-scaling](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ecs/fargate-service-with-auto-scaling/) | Starting an ECS service of FARGATE launch type that auto scales based on average CPU Utilization |
 | [lambda-cron](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/lambda-cron/) | Running a Lambda on a schedule |
 | [my-widget-service](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/my-widget-service/) | Use Lambda to serve up widgets |
 | [resource-overrides](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/resource-overrides/) | Shows how to override generated CloudFormation code |

--- a/typescript/ecs/fargate-service-with-auto-scaling/cdk.json
+++ b/typescript/ecs/fargate-service-with-auto-scaling/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node index"
+}

--- a/typescript/ecs/fargate-service-with-auto-scaling/index.ts
+++ b/typescript/ecs/fargate-service-with-auto-scaling/index.ts
@@ -1,0 +1,35 @@
+import ecs = require('@aws-cdk/aws-ecs');
+import ec2 = require('@aws-cdk/aws-ec2');
+import cdk = require('@aws-cdk/cdk');
+
+class AutoScalingFargateService extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // Create a cluster
+    const vpc = new ec2.VpcNetwork(this, 'Vpc', { maxAZs: 2 });
+    const cluster = new ecs.Cluster(this, 'fargate-service-autoscaling', { vpc });
+
+    // Create Fargate Service
+    const fargateService = new ecs.LoadBalancedFargateService(this, 'sample-app', {
+      cluster,
+      image: ecs.ContainerImage.fromDockerHub("amazon/amazon-ecs-sample")
+    });
+
+    // Setup AutoScaling policy
+    const scaling = fargateService.service.autoScaleTaskCount({ maxCapacity: 2 });
+    scaling.scaleOnCpuUtilization('CpuScaling', {
+      targetUtilizationPercent: 50,
+      scaleInCooldownSec: 60,
+      scaleOutCooldownSec: 60
+    });
+
+    new cdk.Output(this, 'LoadBalancerDNS', { value: fargateService.loadBalancer.dnsName, });
+  }
+}
+
+const app = new cdk.App();
+
+new AutoScalingFargateService(app, 'aws-fargate-application-autoscaling');
+
+app.run();

--- a/typescript/ecs/fargate-service-with-auto-scaling/package-lock.json
+++ b/typescript/ecs/fargate-service-with-auto-scaling/package-lock.json
@@ -1,0 +1,351 @@
+{
+  "name": "fargate-service-with-auto-scaling",
+  "version": "0.25.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@aws-cdk/assets": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-0.25.2.tgz",
+      "integrity": "sha512-EvaByixcxi2IFaOnv6ldQJ7CANOyqNXhl4DuaqegtH5N5XDJyo3jgQ7sOP4ZpY2TIzIxVOOEZIkUuAcb6r/I0Q==",
+      "requires": {
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/aws-s3": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2",
+        "@aws-cdk/cx-api": "^0.25.2"
+      }
+    },
+    "@aws-cdk/assets-docker": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets-docker/-/assets-docker-0.25.2.tgz",
+      "integrity": "sha512-K0Ew4Um6/3coWe9hdLpQFjcZZAPHm/E5XvXWFu9dFJIULM5UcdJHbZ+v9EXebo4NhgPh7qAePsF39SjtdAhViQ==",
+      "requires": {
+        "@aws-cdk/aws-cloudformation": "^0.25.2",
+        "@aws-cdk/aws-ecr": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/aws-lambda": "^0.25.2",
+        "@aws-cdk/aws-s3": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2",
+        "@aws-cdk/cx-api": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-applicationautoscaling": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-0.25.2.tgz",
+      "integrity": "sha512-fpEs4n1G3jmTHdxf20Q+g0ULHDuLBhZBzVZKpwsWa0qigEOBXNTyreLuAknYQHc2kErb0geQXL1hMXwiAHwHAg==",
+      "requires": {
+        "@aws-cdk/aws-autoscaling-common": "^0.25.2",
+        "@aws-cdk/aws-cloudwatch": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-autoscaling": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling/-/aws-autoscaling-0.25.2.tgz",
+      "integrity": "sha512-9BmhfxBZrBudlsPb8TZENpaaUOuhW754UKAmwH3LxbW1aZILRSHkQ+FdQoWze+IITWhjwtus6z1UrALFpVw6UQ==",
+      "requires": {
+        "@aws-cdk/aws-autoscaling-api": "^0.25.2",
+        "@aws-cdk/aws-autoscaling-common": "^0.25.2",
+        "@aws-cdk/aws-cloudwatch": "^0.25.2",
+        "@aws-cdk/aws-ec2": "^0.25.2",
+        "@aws-cdk/aws-elasticloadbalancing": "^0.25.2",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/aws-sns": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-autoscaling-api": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-api/-/aws-autoscaling-api-0.25.2.tgz",
+      "integrity": "sha512-F1XU7GBdYQZ2NZCnxvt3ptczwEdJgsH/xnY5q5kX8VVZVOBrrJ7xi0fKvPZzr2G4LMQBO9bLYVYP2jmlmwxPAg==",
+      "requires": {
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-autoscaling-common": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-0.25.2.tgz",
+      "integrity": "sha512-T33/UsScyQE96vrRqOJYkPNCNj96SbMa6zYNCMGi4zaNGveVRG5IZKzLzLZYHbUEXWGKKAcYOGl8wKzccJFc5g==",
+      "requires": {
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-certificatemanager": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-0.25.2.tgz",
+      "integrity": "sha512-4ymhX8UG4aQN9zb//6xCIo6S1A3UsShXMFj79lA7r5oqYdktq98jK6JUXSsvbFTiMBTKONTyNV2yrQGBXfqgZQ==",
+      "requires": {
+        "@aws-cdk/aws-cloudformation": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/aws-lambda": "^0.25.2",
+        "@aws-cdk/aws-route53": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-cloudformation": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-0.25.2.tgz",
+      "integrity": "sha512-wtScBYo7rC+302HmZAsT8LP1asXQBfTNoVbmPcfvc7ituO8RApd7IzUwbK/xuee0YU6CobYUJ/769nqvUzvERw==",
+      "requires": {
+        "@aws-cdk/aws-codepipeline-api": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/aws-lambda": "^0.25.2",
+        "@aws-cdk/aws-sns": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-cloudwatch": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-0.25.2.tgz",
+      "integrity": "sha512-besLjOd/uicKK6pPgKJ/J2UAPZd3GtbQ0c+OGLGVl29uKCUUpaf4DSrABdmw08YzR/SbTJDoiJqhLy992IGYFQ==",
+      "requires": {
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-codedeploy-api": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codedeploy-api/-/aws-codedeploy-api-0.25.2.tgz",
+      "integrity": "sha512-vtlTrquQBLAYRxupirnTJsiWST96aVsCVKGf7KEVYrNamlY8eWHkmURDZDp6fiDH1qNnXlUYhhx0l5sNznp/kA==",
+      "requires": {
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-codepipeline-api": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline-api/-/aws-codepipeline-api-0.25.2.tgz",
+      "integrity": "sha512-NVuHWZnYH6xh8wDvtLGrfOGRuzeUbQ12bdd56QOnnDnS2IB5dujUfCmTE0axlBxme3XfGHPD39XH2rJVBpYULg==",
+      "requires": {
+        "@aws-cdk/aws-events": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-ec2": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-0.25.2.tgz",
+      "integrity": "sha512-vJohi8jYHa/3Ji0gvyQiV5dPwqPXaxFZrfSYu8CDJQ6Ljc04lcDsQnUWiyUndMHGlcFBJ7tq6NklR7sT/9ODiA==",
+      "requires": {
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2",
+        "@aws-cdk/cx-api": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-ecr": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-0.25.2.tgz",
+      "integrity": "sha512-xEv9h/Q3EHKk2eDTDfA+8mixQyxTTGPFQ7vH8/r1c5dFTbuO+fzwfJ2/UcGoEiZ+NVmPlb7USVqx2bANmDr1tQ==",
+      "requires": {
+        "@aws-cdk/aws-codepipeline-api": "^0.25.2",
+        "@aws-cdk/aws-events": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-ecs": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs/-/aws-ecs-0.25.2.tgz",
+      "integrity": "sha512-lq6YfKyJ/UZeiOb/fK9MfAJtvrNmDjWrRJZHM04PIAyjEGTV3Rw9x7pj2eynDHOCE0p6tCMbPuJv8x6ot4SyGw==",
+      "requires": {
+        "@aws-cdk/assets-docker": "^0.25.2",
+        "@aws-cdk/aws-applicationautoscaling": "^0.25.2",
+        "@aws-cdk/aws-autoscaling": "^0.25.2",
+        "@aws-cdk/aws-certificatemanager": "^0.25.2",
+        "@aws-cdk/aws-cloudformation": "^0.25.2",
+        "@aws-cdk/aws-cloudwatch": "^0.25.2",
+        "@aws-cdk/aws-ec2": "^0.25.2",
+        "@aws-cdk/aws-ecr": "^0.25.2",
+        "@aws-cdk/aws-elasticloadbalancing": "^0.25.2",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.25.2",
+        "@aws-cdk/aws-events": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/aws-lambda": "^0.25.2",
+        "@aws-cdk/aws-logs": "^0.25.2",
+        "@aws-cdk/aws-route53": "^0.25.2",
+        "@aws-cdk/aws-sns": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2",
+        "@aws-cdk/cx-api": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-elasticloadbalancing": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-0.25.2.tgz",
+      "integrity": "sha512-4367cBdqom1XGTMrwqcGKhkK5LlEjZ03j9unTM30Uhl3YSfB1zo9mKO1ZESMZsu2oos3vHg+rQQVanr7TPcnRQ==",
+      "requires": {
+        "@aws-cdk/aws-codedeploy-api": "^0.25.2",
+        "@aws-cdk/aws-ec2": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-elasticloadbalancingv2": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-0.25.2.tgz",
+      "integrity": "sha512-+bxpTP8a8pHLJcouO0byz4PAomdwvfXn94LAvl3gxM9DbLfFjzCktiPZtCzmFCwXJURMOJlLySwMwYxjgcldbQ==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "^0.25.2",
+        "@aws-cdk/aws-codedeploy-api": "^0.25.2",
+        "@aws-cdk/aws-ec2": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/aws-route53": "^0.25.2",
+        "@aws-cdk/aws-s3": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-events": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-0.25.2.tgz",
+      "integrity": "sha512-swnXLoPzvKzqnlH+8RkbC2LUdyLVMyvqcRy36EPowC2Ka8Vr+NGKHz9pUDXXiYxh8dGXQG8260kBKkM13rHzNw==",
+      "requires": {
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-iam": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-0.25.2.tgz",
+      "integrity": "sha512-9tetNWnRueOPuOEW9MkyrbxfsvaIiNQ0c3YEXgXkHDWbsDEZO0yUzFp3ugKtWk8GjiVFQzDpcgkxBYTCBbsuWw==",
+      "requires": {
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-kms": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-0.25.2.tgz",
+      "integrity": "sha512-T46WX3oVqB1iLv46/Uu4eSa5ZCd0NLCQU2vW3oIlb6CZBgM4FVBtMl2nIvxF42ml2FOMXov46J4Tcv6LIdAxnw==",
+      "requires": {
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-lambda": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-0.25.2.tgz",
+      "integrity": "sha512-SWNUtC0bbafImm+PgNYVKlD54VSZx9VhP/yrj+b5YCxCm0bzQFXyaoJhiQET1zzTnOoprGX55GcHiQ/hIAkmAg==",
+      "requires": {
+        "@aws-cdk/assets": "^0.25.2",
+        "@aws-cdk/aws-cloudwatch": "^0.25.2",
+        "@aws-cdk/aws-codepipeline-api": "^0.25.2",
+        "@aws-cdk/aws-ec2": "^0.25.2",
+        "@aws-cdk/aws-events": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/aws-logs": "^0.25.2",
+        "@aws-cdk/aws-s3": "^0.25.2",
+        "@aws-cdk/aws-s3-notifications": "^0.25.2",
+        "@aws-cdk/aws-sqs": "^0.25.2",
+        "@aws-cdk/aws-stepfunctions": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2",
+        "@aws-cdk/cx-api": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-logs": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-0.25.2.tgz",
+      "integrity": "sha512-U7zJBt0x9aSRuzvYbPUTOfNZQdUXhTKRYAwm6WjL75f7/+UJ64qHFI6KL3klCfLrkqiZx5jaVrSDzfUlJ4ZQJg==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-route53": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-0.25.2.tgz",
+      "integrity": "sha512-uZ8aR4gWlL2KqFMiZKRT9iuQIkBNxsDcATpWAIGVC5SU3zUjIbKV/4Xl94JPzPEJZuDYPhDOq31inp0/l7WFiQ==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "^0.25.2",
+        "@aws-cdk/aws-logs": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2",
+        "@aws-cdk/cx-api": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-s3": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-0.25.2.tgz",
+      "integrity": "sha512-Y4Po1CYwj7VIPQV3xZcAQpiwvd4+M/eqTHa/y1vgn4P5K6CRjFDiN6UyJG1iD32h5gk79e3Bs59QbBiIPEGAXA==",
+      "requires": {
+        "@aws-cdk/aws-codepipeline-api": "^0.25.2",
+        "@aws-cdk/aws-events": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/aws-kms": "^0.25.2",
+        "@aws-cdk/aws-s3-notifications": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-s3-notifications": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-notifications/-/aws-s3-notifications-0.25.2.tgz",
+      "integrity": "sha512-r6vPkDIT83qEMdbOegKoQIwzxBFMaXUuACRNBirP5mdFf96g71SHpk8MQjMgkoWb2qh+HZ6uklVNPHX2KcJ3+w==",
+      "requires": {
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-sns": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-0.25.2.tgz",
+      "integrity": "sha512-mpGnVWFqoC/+6tkgecYc7V6HMveFZ8GBKh6pDFy2G4h6Uf9FvGLlwX/l8uOGo28d5dpqh5vYbrxryh8RqJV9gg==",
+      "requires": {
+        "@aws-cdk/aws-autoscaling-api": "^0.25.2",
+        "@aws-cdk/aws-cloudwatch": "^0.25.2",
+        "@aws-cdk/aws-events": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/aws-lambda": "^0.25.2",
+        "@aws-cdk/aws-s3-notifications": "^0.25.2",
+        "@aws-cdk/aws-sqs": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-sqs": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-0.25.2.tgz",
+      "integrity": "sha512-7grI6f5VXkYHKiFZJ1eImHlhYtbLcGvoJ0IykOSUP+KW35elGsHOtuBFIA583rHWPDtHKnIXVUGhat0m6AIRYg==",
+      "requires": {
+        "@aws-cdk/aws-autoscaling-api": "^0.25.2",
+        "@aws-cdk/aws-cloudwatch": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/aws-kms": "^0.25.2",
+        "@aws-cdk/aws-s3-notifications": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/aws-stepfunctions": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-0.25.2.tgz",
+      "integrity": "sha512-y0TOkyRTW3ONGr9KFUh47pn/p51Np5eVzz37qe7zZdDuQsbEJH4CMEYV9L2fmt15evMM3Y4qn0qTOvxEPHVQIg==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "^0.25.2",
+        "@aws-cdk/aws-events": "^0.25.2",
+        "@aws-cdk/aws-iam": "^0.25.2",
+        "@aws-cdk/cdk": "^0.25.2"
+      }
+    },
+    "@aws-cdk/cdk": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cdk/-/cdk-0.25.2.tgz",
+      "integrity": "sha512-oJLF50GPFL8zGBxCn5WZdAFEuhx+uXI0egbAsR32aqX3c0a3+SOAL0r/da/iNU7KkFdjUibt3cPSChay77YCvw==",
+      "requires": {
+        "@aws-cdk/cx-api": "^0.25.2"
+      }
+    },
+    "@aws-cdk/cx-api": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-0.25.2.tgz",
+      "integrity": "sha512-MHFnldhVYwjEb023PDzyaq1Uh+6Q2by8ZIGoEjEQIhvc3OidgQ6FrRMSgeT0r1wE7c2va7yi+rpPC3MHAkHf9A=="
+    },
+    "@types/node": {
+      "version": "8.10.40",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.40.tgz",
+      "integrity": "sha512-RRSjdwz63kS4u7edIwJUn8NqKLLQ6LyqF/X4+4jp38MBT3Vwetewi2N4dgJEshLbDwNgOJXNYoOwzVZUSSLhkQ==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz",
+      "integrity": "sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==",
+      "dev": true
+    }
+  }
+}

--- a/typescript/ecs/fargate-service-with-auto-scaling/package.json
+++ b/typescript/ecs/fargate-service-with-auto-scaling/package.json
@@ -19,9 +19,9 @@
     "typescript": "^3.2.4"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "^0.25.2",
-    "@aws-cdk/aws-ecs": "^0.25.2",
-    "@aws-cdk/aws-elasticloadbalancingv2": "^0.25.2",
-    "@aws-cdk/cdk": "^0.25.2"
+    "@aws-cdk/aws-ec2": "*",
+    "@aws-cdk/aws-ecs": "*",
+    "@aws-cdk/aws-elasticloadbalancingv2": "*",
+    "@aws-cdk/cdk": "*"
   }
 }

--- a/typescript/ecs/fargate-service-with-auto-scaling/package.json
+++ b/typescript/ecs/fargate-service-with-auto-scaling/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "fargate-service-with-auto-scaling",
+  "version": "0.25.2",
+  "description": "ECS Service of launch type FARGATE with Application Auto Scaling",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "cdk": "cdk"
+  },
+  "author": {
+    "name": "Amazon Web Services",
+    "url": "https://aws.amazon.com",
+    "organization": true
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/node": "^8.10.38",
+    "typescript": "^3.2.4"
+  },
+  "dependencies": {
+    "@aws-cdk/aws-ec2": "^0.25.2",
+    "@aws-cdk/aws-ecs": "^0.25.2",
+    "@aws-cdk/aws-elasticloadbalancingv2": "^0.25.2",
+    "@aws-cdk/cdk": "^0.25.2"
+  }
+}

--- a/typescript/ecs/fargate-service-with-auto-scaling/tsconfig.json
+++ b/typescript/ecs/fargate-service-with-auto-scaling/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "target":"ES2018",
+        "module": "commonjs",
+        "lib": ["es2016", "es2017.object", "es2017.string"],
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization":false
+    }
+}
+


### PR DESCRIPTION
Example for a Fargate Service with Application Auto Scaling using target tracking policies.

Follows the [AWS Docs example](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-autoscaling-targettracking.html#targettracking-tutorial) for setting up the service, scaling policy and performing a load test to trigger scaling activity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
