### PR TITLE
Removed unused package import from Java example

### DIFF
--- a/java/hello-world/src/main/java/software/amazon/awscdk/examples/HelloJavaApp.java
+++ b/java/hello-world/src/main/java/software/amazon/awscdk/examples/HelloJavaApp.java
@@ -2,8 +2,6 @@ package software.amazon.awscdk.examples;
 
 import software.amazon.awscdk.App;
 
-import java.util.Arrays;
-
 public class HelloJavaApp {
     public static void main(final String[] args) {
         App app = new App();


### PR DESCRIPTION
Deleted the following import statement from HelloJavaApp.java:

import java.util.Arrays


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
