### PR TITLE
[WIP] Port TypeScript examples to Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.swp
 cdk.context.json
 package-lock.json
+__pycache__

--- a/python/application-load-balancer/app.py
+++ b/python/application-load-balancer/app.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from aws_cdk import (
+    aws_autoscaling as autoscaling,
+    aws_ec2 as ec2,
+    aws_elasticloadbalancingv2 as elbv2,
+    cdk,
+)
+
+
+class LoadBalancerStack(cdk.Stack):
+    def __init__(self, app: cdk.App, id: str) -> None:
+        super().__init__(app, id)
+
+        vpc = ec2.VpcNetwork(self, "VPC")
+
+        asg = autoscaling.AutoScalingGroup(
+            self,
+            "ASG",
+            vpc=vpc,
+            instance_type=ec2.InstanceTypePair(
+                ec2.InstanceClass.Burstable2, ec2.InstanceSize.Micro
+            ),
+            machine_image=ec2.AmazonLinuxImage(),
+        )
+
+        lb = elbv2.ApplicationLoadBalancer(self, "LB", vpc=vpc, internet_facing=True)
+
+        listener = lb.add_listener("Listener", port=80)
+        listener.add_targets("Target", port=80, targets=[asg])
+        listener.connections.allow_default_port_from_any_ipv4("Open to the world")
+
+        asg.scale_on_request_count("AModestLoad", target_requests_per_second=1)
+
+
+app = cdk.App()
+LoadBalancerStack(app, "LoadBalancerStack")
+app.run()

--- a/python/application-load-balancer/cdk.json
+++ b/python/application-load-balancer/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/application-load-balancer/requirements.txt
+++ b/python/application-load-balancer/requirements.txt
@@ -1,0 +1,8 @@
+aws-cdk.cdk
+
+aws-cdk.aws-autoscaling
+aws-cdk.aws-ec2
+aws-cdk.aws-elasticloadbalancingv2
+
+# Work around for jsii#413
+aws-cdk.aws-autoscaling-common

--- a/python/chat-app/app.py
+++ b/python/chat-app/app.py
@@ -1,0 +1,107 @@
+from aws_cdk import cdk
+from aws_cdk import aws_lambda as lambda_, aws_s3 as s3
+
+from cognito_chat_room_pool import CognitoChatRoomPool
+from dynamodb_posts_table import DynamoPostsTable
+
+
+class ChatAppFunction(lambda_.Function):
+    def __init__(
+        self, scope: cdk.Construct, id: str, *, bucket: s3.IBucket, zip_file: str
+    ):
+        super().__init__(
+            scope,
+            id,
+            code=lambda_.S3Code(bucket, zip_file),
+            runtime=lambda_.Runtime.NODE_J_S610,
+            handler="index.handler",
+        )
+
+
+class MyStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str, **kwargs):
+        super().__init__(scope, id, **kwargs)
+
+        DynamoPostsTable(self, "Posts")
+        CognitoChatRoomPool(self, "UserPool")
+
+        bucket = s3.Bucket.import_(self, "DougsBucket", bucket_name="dogs-chat-app")
+
+        ChatAppFunction(
+            self,
+            "StartAddBucket",
+            bucket=bucket,
+            zip_file="StartAddingPendingCognitoUser.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "FinishAddBucket",
+            bucket=bucket,
+            zip_file="FinishAddingPendingCognitoUser.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "SignInUserBucket",
+            bucket=bucket,
+            zip_file="SignInCognitoUser.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "VerifyBucket",
+            bucket=bucket,
+            zip_file="VerifyCognitoSignIn.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "StartChangeBucket",
+            bucket=bucket,
+            zip_file="StartChangingForgottenCognitoUserPassword.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "FinishChangeBucket",
+            bucket=bucket,
+            zip_file="FinishChangingForgottenCognitoUserPassword.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "GetPostsBucket",
+            bucket=bucket,
+            zip_file="GetPosts.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "AddPostBucket",
+            bucket=bucket,
+            zip_file="AddPost.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "DeletePostBucket",
+            bucket=bucket,
+            zip_file="DeletePost.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "DeleteUserBucket",
+            bucket=bucket,
+            zip_file="DeleteCognitoUser.zip",
+        )
+
+
+app = cdk.App()
+
+# Add the stack to the app
+# (Apps can hot many stacks, for example, one for each region)
+MyStack(app, "ChatAppStack", env={"region": "us-west-2"})
+
+app.run()

--- a/python/chat-app/cdk.json
+++ b/python/chat-app/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/chat-app/cognito_chat_room_pool.py
+++ b/python/chat-app/cognito_chat_room_pool.py
@@ -1,0 +1,26 @@
+from aws_cdk import aws_cognito as cognito, cdk
+
+
+class CognitoChatRoomPool(cdk.Construct):
+    def __init__(self, scope: cdk.Construct, id: str) -> None:
+        super().__init__(scope, id)
+
+        # Create chat room user pool
+        chat_pool = cognito.CfnUserPool(
+            self,
+            "UserPool",
+            admin_create_user_config={"allowAdminCreateUserOnly": False},
+            policies={"passwordPolicy": {"minimumLength": 6, "requireNumbers": True}},
+            schema=[{"attributeDataType": "String", "name": "email", "required": True}],
+            auto_verified_attributes=["email"],
+        )
+
+        # Now for the client
+        cognito.CfnUserPoolClient(
+            self,
+            "UserPoolClient",
+            client_name="Chat-Room",
+            explicit_auth_flows=["ADMIN_NO_SRP_AUTH"],
+            refresh_token_validity=30,
+            user_pool_id=chat_pool.ref,
+        )

--- a/python/chat-app/dynamodb_posts_table.py
+++ b/python/chat-app/dynamodb_posts_table.py
@@ -1,0 +1,16 @@
+from aws_cdk import cdk
+from aws_cdk import aws_dynamodb as dynanodb
+
+
+class DynamoPostsTable(cdk.Construct):
+    def __init__(self, scope: cdk.Construct, id: str) -> None:
+        super().__init__(scope, id)
+
+        dynanodb.Table(
+            self,
+            "Table",
+            partition_key={"name": "Alias", "type": dynanodb.AttributeType.String},
+            sort_key={"name": "Timestamp", "type": dynanodb.AttributeType.String},
+            read_capacity=5,
+            write_capacity=5,
+        )

--- a/python/chat-app/requirements.txt
+++ b/python/chat-app/requirements.txt
@@ -1,0 +1,9 @@
+aws-cdk.cdk
+
+aws-cdk.aws-cognito
+aws-cdk.aws-lambda
+aws-cdk.aws-dynamodb
+aws-cdk.aws-s3
+
+# Work around for jsii#413
+aws-cdk.aws-autoscaling-common

--- a/python/classic-load-balancer/app.py
+++ b/python/classic-load-balancer/app.py
@@ -1,0 +1,36 @@
+from aws_cdk import cdk
+from aws_cdk import (
+    aws_autoscaling as autoscaling,
+    aws_ec2 as ec2,
+    aws_elasticloadbalancing as elb,
+)
+
+
+class LoadBalancerStack(cdk.Stack):
+    def __init__(self, app: cdk.App, id: str, **kwargs) -> None:
+        super().__init__(app, id, **kwargs)
+
+        vpc = ec2.VpcNetwork(self, "VPC")
+
+        asg = autoscaling.AutoScalingGroup(
+            self,
+            "ASG",
+            vpc=vpc,
+            instance_type=ec2.InstanceTypePair(
+                ec2.InstanceClass.Burstable2, ec2.InstanceSize.Micro
+            ),
+            machine_image=ec2.AmazonLinuxImage(),
+        )
+
+        lb = elb.LoadBalancer(
+            self, "LB", vpc=vpc, internet_facing=True, health_check={"port": 80}
+        )
+        lb.add_target(asg)
+
+        listener = lb.add_listener(external_port=80)
+        listener.connections.allow_default_port_from_any_ipv4("Open to the world")
+
+
+app = cdk.App()
+LoadBalancerStack(app, "LoadBalancerStack")
+app.run()

--- a/python/classic-load-balancer/cdk.json
+++ b/python/classic-load-balancer/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/classic-load-balancer/requirements.txt
+++ b/python/classic-load-balancer/requirements.txt
@@ -1,0 +1,8 @@
+aws-cdk.cdk
+
+aws-cdk.aws-autoscaling
+aws-cdk.aws-ec2
+aws-cdk.aws-elasticloadbalancing
+
+# Work around for jsii#413
+aws-cdk.aws-autoscaling-common

--- a/python/custom-resource/app.py
+++ b/python/custom-resource/app.py
@@ -1,0 +1,26 @@
+from aws_cdk import cdk
+
+from my_custom_resource import MyCustomResource
+
+
+# A Stack that sets up MyCustomResource and shows how to get an attribute from it.
+class MyStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        resource = MyCustomResource(
+            self, "DemoResource", message="CustomResource says hello"
+        )
+
+        # Publish the custom resource output
+        cdk.CfnOutput(
+            self,
+            "ResponseMessage",
+            description="The message that came back from the Custom Resource",
+            value=resource.response,
+        )
+
+
+app = cdk.App()
+MyStack(app, "CustomResourceDemoStack")
+app.run()

--- a/python/custom-resource/cdk.json
+++ b/python/custom-resource/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/custom-resource/custom-resource-handler.py
+++ b/python/custom-resource/custom-resource-handler.py
@@ -1,0 +1,26 @@
+def main(event, context):
+    import logging as log
+    import cfnresponse
+    log.getLogger().setLevel(log.INFO)
+
+    # This needs to change if there are to be multiple resources in the same stack
+    physical_id = 'TheOnlyCustomResource'
+
+    try:
+        log.info('Input event: %s', event)
+
+        # Check if this is a Create and we're failing Creates
+        if event['RequestType'] == 'Create' and event['ResourceProperties'].get('FailCreate', False):
+            raise RuntimeError('Create failure requested')
+
+        # Do the thing
+        message = event['ResourceProperties']['Message']
+        attributes = {
+            'Response': 'You said "%s"' % message
+        }
+
+        cfnresponse.send(event, context, cfnresponse.SUCCESS, attributes, physical_id)
+    except Exception as e:
+        log.exception(e)
+        # cfnresponse's error message is always "see CloudWatch"
+        cfnresponse.send(event, context, cfnresponse.FAILED, {}, physical_id)

--- a/python/custom-resource/my_custom_resource.py
+++ b/python/custom-resource/my_custom_resource.py
@@ -1,0 +1,25 @@
+from aws_cdk import cdk
+from aws_cdk import aws_cloudformation as cfn, aws_lambda as lambda_
+
+
+class MyCustomResource(cdk.Construct):
+    def __init__(self, scope: cdk.Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id,)
+
+        with open("custom-resource-handler.py", encoding="utf-8") as fp:
+            code_body = fp.read()
+
+        resource = cfn.CustomResource(
+            self, "Resource", lambda_provider=lambda_.SingletonFunction(
+                self,
+                "Singleton",
+                uuid="f7d4f730-4ee1-11e8-9c2d-fa7ae01bbebc",
+                code=lambda_.InlineCode(code_body),
+                handler="index.main",
+                timeout=300,
+                runtime=lambda_.Runtime.PYTHON27,
+            ),
+            properties=kwargs,
+        )
+
+        self.response = resource.get_att("Response").to_string()

--- a/python/custom-resource/requirements.txt
+++ b/python/custom-resource/requirements.txt
@@ -1,0 +1,4 @@
+aws-cdk.cdk
+
+aws-cdk.aws-cloudformation
+aws-cdk.aws-lambda

--- a/python/lambda-cron/app.py
+++ b/python/lambda-cron/app.py
@@ -1,0 +1,30 @@
+from aws_cdk import aws_events as events, aws_lambda as lambda_, cdk
+
+
+class LambdaCronStack(cdk.Stack):
+    def __init__(self, app: cdk.App, id: str) -> None:
+        super().__init__(app, id)
+
+        with open("lambda-handler.py", encoding="utf8") as fp:
+            handler_code = fp.read()
+
+        lambdaFn = lambda_.Function(
+            self,
+            "Singleton",
+            code=lambda_.InlineCode(handler_code),
+            handler="index.main",
+            timeout=300,
+            runtime=lambda_.Runtime.PYTHON27,
+        )
+
+        # Run every day at 6PM UTC
+        # See https://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html
+        rule = events.EventRule(
+            self, "Rule", schedule_expression="cron(0 18 ? * MON-FRI *)"
+        )
+        rule.add_target(lambdaFn)
+
+
+app = cdk.App()
+LambdaCronStack(app, "LambdaCronExample")
+app.run()

--- a/python/lambda-cron/cdk.json
+++ b/python/lambda-cron/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/lambda-cron/lambda-handler.py
+++ b/python/lambda-cron/lambda-handler.py
@@ -1,0 +1,2 @@
+def main(event, context):
+    print("I'm running!")

--- a/python/lambda-cron/requirements.txt
+++ b/python/lambda-cron/requirements.txt
@@ -1,0 +1,3 @@
+aws-cdk.aws-events
+aws-cdk.aws-lambda
+aws-cdk.cdk


### PR DESCRIPTION
Ports the examples from TypeScript to Python.

- [x] ``application-load-balancer``
- [x] ``chat-app``
- [x] ``classic-load-balancer``
- [x] ``custom-resource``
- [ ] ``ecs``
- [ ] ``elasticbeanstalk``
- [x] ``lambda-cron``
  - This is ported, but broken due to https://github.com/awslabs/jsii/issues/411.
- [ ] ``my-widget-service``
- [ ] ``resource-overrides``
- [ ] ``static-site``
- [ ] ``stepfunctions-job-poller``


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
