### PR TITLE
Python examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.swp
 cdk.context.json
 package-lock.json
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ package-lock.json
 __pycache__
 .env
 *~
-

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules
 cdk.context.json
 package-lock.json
 __pycache__
+.env
+*~
+

--- a/python/application-load-balancer/app.py
+++ b/python/application-load-balancer/app.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from aws_cdk import (
+    aws_autoscaling as autoscaling,
+    aws_ec2 as ec2,
+    aws_elasticloadbalancingv2 as elbv2,
+    cdk,
+)
+
+
+class LoadBalancerStack(cdk.Stack):
+    def __init__(self, app: cdk.App, id: str) -> None:
+        super().__init__(app, id)
+
+        vpc = ec2.VpcNetwork(self, "VPC")
+
+        asg = autoscaling.AutoScalingGroup(
+            self,
+            "ASG",
+            vpc=vpc,
+            instance_type=ec2.InstanceTypePair(
+                ec2.InstanceClass.Burstable2, ec2.InstanceSize.Micro
+            ),
+            machine_image=ec2.AmazonLinuxImage(),
+        )
+
+        lb = elbv2.ApplicationLoadBalancer(self, "LB", vpc=vpc, internet_facing=True)
+
+        listener = lb.add_listener("Listener", port=80)
+        listener.add_targets("Target", port=80, targets=[asg])
+        listener.connections.allow_default_port_from_any_ipv4("Open to the world")
+
+        asg.scale_on_request_count("AModestLoad", target_requests_per_second=1)
+
+
+app = cdk.App()
+LoadBalancerStack(app, "LoadBalancerStack")
+app.run()

--- a/python/application-load-balancer/cdk.json
+++ b/python/application-load-balancer/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/application-load-balancer/requirements.txt
+++ b/python/application-load-balancer/requirements.txt
@@ -1,0 +1,8 @@
+aws-cdk.cdk
+
+aws-cdk.aws-autoscaling
+aws-cdk.aws-ec2
+aws-cdk.aws-elasticloadbalancingv2
+
+# Work around for jsii#413
+aws-cdk.aws-autoscaling-common

--- a/python/chat-app/app.py
+++ b/python/chat-app/app.py
@@ -1,0 +1,107 @@
+from aws_cdk import cdk
+from aws_cdk import aws_lambda as lambda_, aws_s3 as s3
+
+from cognito_chat_room_pool import CognitoChatRoomPool
+from dynamodb_posts_table import DynamoPostsTable
+
+
+class ChatAppFunction(lambda_.Function):
+    def __init__(
+        self, scope: cdk.Construct, id: str, *, bucket: s3.IBucket, zip_file: str
+    ):
+        super().__init__(
+            scope,
+            id,
+            code=lambda_.S3Code(bucket, zip_file),
+            runtime=lambda_.Runtime.NODE_J_S610,
+            handler="index.handler",
+        )
+
+
+class MyStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str, **kwargs):
+        super().__init__(scope, id, **kwargs)
+
+        DynamoPostsTable(self, "Posts")
+        CognitoChatRoomPool(self, "UserPool")
+
+        bucket = s3.Bucket.import_(self, "DougsBucket", bucket_name="dogs-chat-app")
+
+        ChatAppFunction(
+            self,
+            "StartAddBucket",
+            bucket=bucket,
+            zip_file="StartAddingPendingCognitoUser.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "FinishAddBucket",
+            bucket=bucket,
+            zip_file="FinishAddingPendingCognitoUser.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "SignInUserBucket",
+            bucket=bucket,
+            zip_file="SignInCognitoUser.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "VerifyBucket",
+            bucket=bucket,
+            zip_file="VerifyCognitoSignIn.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "StartChangeBucket",
+            bucket=bucket,
+            zip_file="StartChangingForgottenCognitoUserPassword.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "FinishChangeBucket",
+            bucket=bucket,
+            zip_file="FinishChangingForgottenCognitoUserPassword.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "GetPostsBucket",
+            bucket=bucket,
+            zip_file="GetPosts.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "AddPostBucket",
+            bucket=bucket,
+            zip_file="AddPost.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "DeletePostBucket",
+            bucket=bucket,
+            zip_file="DeletePost.zip",
+        )
+
+        ChatAppFunction(
+            self,
+            "DeleteUserBucket",
+            bucket=bucket,
+            zip_file="DeleteCognitoUser.zip",
+        )
+
+
+app = cdk.App()
+
+# Add the stack to the app
+# (Apps can hot many stacks, for example, one for each region)
+MyStack(app, "ChatAppStack", env={"region": "us-west-2"})
+
+app.run()

--- a/python/chat-app/cdk.json
+++ b/python/chat-app/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/chat-app/cognito_chat_room_pool.py
+++ b/python/chat-app/cognito_chat_room_pool.py
@@ -1,0 +1,26 @@
+from aws_cdk import aws_cognito as cognito, cdk
+
+
+class CognitoChatRoomPool(cdk.Construct):
+    def __init__(self, scope: cdk.Construct, id: str) -> None:
+        super().__init__(scope, id)
+
+        # Create chat room user pool
+        chat_pool = cognito.CfnUserPool(
+            self,
+            "UserPool",
+            admin_create_user_config={"allowAdminCreateUserOnly": False},
+            policies={"passwordPolicy": {"minimumLength": 6, "requireNumbers": True}},
+            schema=[{"attributeDataType": "String", "name": "email", "required": True}],
+            auto_verified_attributes=["email"],
+        )
+
+        # Now for the client
+        cognito.CfnUserPoolClient(
+            self,
+            "UserPoolClient",
+            client_name="Chat-Room",
+            explicit_auth_flows=["ADMIN_NO_SRP_AUTH"],
+            refresh_token_validity=30,
+            user_pool_id=chat_pool.ref,
+        )

--- a/python/chat-app/dynamodb_posts_table.py
+++ b/python/chat-app/dynamodb_posts_table.py
@@ -1,0 +1,16 @@
+from aws_cdk import cdk
+from aws_cdk import aws_dynamodb as dynanodb
+
+
+class DynamoPostsTable(cdk.Construct):
+    def __init__(self, scope: cdk.Construct, id: str) -> None:
+        super().__init__(scope, id)
+
+        dynanodb.Table(
+            self,
+            "Table",
+            partition_key={"name": "Alias", "type": dynanodb.AttributeType.String},
+            sort_key={"name": "Timestamp", "type": dynanodb.AttributeType.String},
+            read_capacity=5,
+            write_capacity=5,
+        )

--- a/python/chat-app/requirements.txt
+++ b/python/chat-app/requirements.txt
@@ -1,0 +1,9 @@
+aws-cdk.cdk
+
+aws-cdk.aws-cognito
+aws-cdk.aws-lambda
+aws-cdk.aws-dynamodb
+aws-cdk.aws-s3
+
+# Work around for jsii#413
+aws-cdk.aws-autoscaling-common

--- a/python/classic-load-balancer/app.py
+++ b/python/classic-load-balancer/app.py
@@ -1,0 +1,36 @@
+from aws_cdk import cdk
+from aws_cdk import (
+    aws_autoscaling as autoscaling,
+    aws_ec2 as ec2,
+    aws_elasticloadbalancing as elb,
+)
+
+
+class LoadBalancerStack(cdk.Stack):
+    def __init__(self, app: cdk.App, id: str, **kwargs) -> None:
+        super().__init__(app, id, **kwargs)
+
+        vpc = ec2.VpcNetwork(self, "VPC")
+
+        asg = autoscaling.AutoScalingGroup(
+            self,
+            "ASG",
+            vpc=vpc,
+            instance_type=ec2.InstanceTypePair(
+                ec2.InstanceClass.Burstable2, ec2.InstanceSize.Micro
+            ),
+            machine_image=ec2.AmazonLinuxImage(),
+        )
+
+        lb = elb.LoadBalancer(
+            self, "LB", vpc=vpc, internet_facing=True, health_check={"port": 80}
+        )
+        lb.add_target(asg)
+
+        listener = lb.add_listener(external_port=80)
+        listener.connections.allow_default_port_from_any_ipv4("Open to the world")
+
+
+app = cdk.App()
+LoadBalancerStack(app, "LoadBalancerStack")
+app.run()

--- a/python/classic-load-balancer/cdk.json
+++ b/python/classic-load-balancer/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/classic-load-balancer/requirements.txt
+++ b/python/classic-load-balancer/requirements.txt
@@ -1,0 +1,8 @@
+aws-cdk.cdk
+
+aws-cdk.aws-autoscaling
+aws-cdk.aws-ec2
+aws-cdk.aws-elasticloadbalancing
+
+# Work around for jsii#413
+aws-cdk.aws-autoscaling-common

--- a/python/custom-resource/app.py
+++ b/python/custom-resource/app.py
@@ -1,0 +1,26 @@
+from aws_cdk import cdk
+
+from my_custom_resource import MyCustomResource
+
+
+# A Stack that sets up MyCustomResource and shows how to get an attribute from it.
+class MyStack(cdk.Stack):
+    def __init__(self, scope: cdk.App, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        resource = MyCustomResource(
+            self, "DemoResource", message="CustomResource says hello"
+        )
+
+        # Publish the custom resource output
+        cdk.CfnOutput(
+            self,
+            "ResponseMessage",
+            description="The message that came back from the Custom Resource",
+            value=resource.response,
+        )
+
+
+app = cdk.App()
+MyStack(app, "CustomResourceDemoStack")
+app.run()

--- a/python/custom-resource/cdk.json
+++ b/python/custom-resource/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/custom-resource/custom-resource-handler.py
+++ b/python/custom-resource/custom-resource-handler.py
@@ -1,0 +1,26 @@
+def main(event, context):
+    import logging as log
+    import cfnresponse
+    log.getLogger().setLevel(log.INFO)
+
+    # This needs to change if there are to be multiple resources in the same stack
+    physical_id = 'TheOnlyCustomResource'
+
+    try:
+        log.info('Input event: %s', event)
+
+        # Check if this is a Create and we're failing Creates
+        if event['RequestType'] == 'Create' and event['ResourceProperties'].get('FailCreate', False):
+            raise RuntimeError('Create failure requested')
+
+        # Do the thing
+        message = event['ResourceProperties']['Message']
+        attributes = {
+            'Response': 'You said "%s"' % message
+        }
+
+        cfnresponse.send(event, context, cfnresponse.SUCCESS, attributes, physical_id)
+    except Exception as e:
+        log.exception(e)
+        # cfnresponse's error message is always "see CloudWatch"
+        cfnresponse.send(event, context, cfnresponse.FAILED, {}, physical_id)

--- a/python/custom-resource/my_custom_resource.py
+++ b/python/custom-resource/my_custom_resource.py
@@ -1,0 +1,25 @@
+from aws_cdk import cdk
+from aws_cdk import aws_cloudformation as cfn, aws_lambda as lambda_
+
+
+class MyCustomResource(cdk.Construct):
+    def __init__(self, scope: cdk.Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id,)
+
+        with open("custom-resource-handler.py", encoding="utf-8") as fp:
+            code_body = fp.read()
+
+        resource = cfn.CustomResource(
+            self, "Resource", lambda_provider=lambda_.SingletonFunction(
+                self,
+                "Singleton",
+                uuid="f7d4f730-4ee1-11e8-9c2d-fa7ae01bbebc",
+                code=lambda_.InlineCode(code_body),
+                handler="index.main",
+                timeout=300,
+                runtime=lambda_.Runtime.PYTHON27,
+            ),
+            properties=kwargs,
+        )
+
+        self.response = resource.get_att("Response").to_string()

--- a/python/custom-resource/requirements.txt
+++ b/python/custom-resource/requirements.txt
@@ -1,0 +1,4 @@
+aws-cdk.cdk
+
+aws-cdk.aws-cloudformation
+aws-cdk.aws-lambda

--- a/python/ecs/cluster/README.txt
+++ b/python/ecs/cluster/README.txt
@@ -1,0 +1,3 @@
+Not currently working.
+
+See https://github.com/aws-samples/aws-cdk-examples/issues/23 for details.

--- a/python/ecs/cluster/app.py
+++ b/python/ecs/cluster/app.py
@@ -1,0 +1,40 @@
+from aws_cdk import (
+    aws_autoscaling as autoscaling,
+    aws_ec2 as ec2,
+    aws_ecs as ecs,
+    cdk,
+)
+
+
+class ECSCluster(cdk.Stack):
+
+    def __init__(self, scope: cdk.Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, *kwargs)
+
+        vpc = ec2.VpcNetwork(
+            self, "MyVpc",
+            max_a_zs=2
+        )
+
+        asg = autoscaling.AutoScalingGroup(
+            self, "MyFleet",
+            instance_type=ec2.InstanceType("t2.xlarge"),
+            machine_image=ecs.EcsOptimizedAmi(),
+            associate_public_ip_address=True,
+            update_type=autoscaling.UpdateType.ReplacingUpdate,
+            desired_capacity=3,
+            vpc=vpc
+        )
+
+        cluster = ecs.Cluster(
+            self, 'EcsCluster',
+            vpc=vpc
+        )
+
+        cluster.add_autoscaling_group(asg)
+        cluster.add_capacity("DefaultAutoScalingGroup",
+                             instance_type=ec2.InstanceType("t2.micro"))
+
+app = cdk.App()
+ECSCluster(app, "MyFirstEcsCluster")
+app.run()

--- a/python/ecs/cluster/cdk.json
+++ b/python/ecs/cluster/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/ecs/cluster/requirements.txt
+++ b/python/ecs/cluster/requirements.txt
@@ -1,0 +1,7 @@
+aws-cdk.cdk
+aws-cdk.aws_autoscaling
+aws-cdk.aws_ec2
+aws-cdk.aws_ecs
+
+# Work around for jsii#413
+aws-cdk.aws-autoscaling-common

--- a/python/ecs/ecs-load-balanced-service/app.py
+++ b/python/ecs/ecs-load-balanced-service/app.py
@@ -1,0 +1,40 @@
+from aws_cdk import (
+    aws_ec2 as ec2,
+    aws_ecs as ecs,
+    cdk,
+)
+
+
+class BonjourECS(cdk.Stack):
+
+    def __init__(self, scope: cdk.Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, *kwargs)
+
+        vpc = ec2.VpcNetwork(
+            self, "MyVpc",
+            max_a_zs=2
+        )
+
+        cluster = ecs.Cluster(
+            self, 'Ec2Cluster',
+            vpc=vpc
+        )
+
+        cluster.add_capacity("DefaultAutoScalingGroup",
+                             instance_type=ec2.InstanceType("t2.micro"))
+
+        ecsService = ecs.LoadBalancedEc2Service(
+            self, "Ec2Service",
+            cluster=cluster,
+            memory_limit_mi_b=512,
+            image=ecs.ContainerImage.from_registry("amazon/amazon-ecs-sample")
+        )
+
+        cdk.CfnOutput(
+            self, "LoadBalancerDNS",
+            value=ecsService.load_balancer.dns_name
+        )
+
+app = cdk.App()
+BonjourECS(app, "Bonjour")
+app.run()

--- a/python/ecs/ecs-load-balanced-service/cdk.json
+++ b/python/ecs/ecs-load-balanced-service/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/ecs/ecs-load-balanced-service/requirements.txt
+++ b/python/ecs/ecs-load-balanced-service/requirements.txt
@@ -1,0 +1,6 @@
+aws-cdk.cdk
+aws-cdk.aws_ec2
+aws-cdk.aws_ecs
+
+# Work around for jsii#413
+aws-cdk.aws-autoscaling-common

--- a/python/ecs/ecs-service-with-advanced-alb-config/app.py
+++ b/python/ecs/ecs-service-with-advanced-alb-config/app.py
@@ -5,10 +5,10 @@ from aws_cdk import (
     cdk,
 )
 
-# Create a cluster
 app = cdk.App()
 stack = cdk.Stack(app, "aws-ec2-integ-ecs")
 
+# Create a cluster
 vpc = ec2.VpcNetwork(
     stack, "MyVpc",
     max_a_zs=2
@@ -22,7 +22,8 @@ cluster.add_capacity("DefaultAutoScalingGroup",
                      instance_type=ec2.InstanceType("t2.micro"))
 
 # Create Task Definition
-task_definition = ecs.Ec2TaskDefinition(stack, "TaskDef")
+task_definition = ecs.Ec2TaskDefinition(
+    stack, "TaskDef")
 container = task_definition.add_container(
     "web",
     image=ecs.ContainerImage.from_registry("amazon/amazon-ecs-sample"),

--- a/python/ecs/ecs-service-with-advanced-alb-config/app.py
+++ b/python/ecs/ecs-service-with-advanced-alb-config/app.py
@@ -1,0 +1,73 @@
+from aws_cdk import (
+    aws_ec2 as ec2,
+    aws_ecs as ecs,
+    aws_elasticloadbalancingv2 as elbv2,
+    cdk,
+)
+
+# Create a cluster
+app = cdk.App()
+stack = cdk.Stack(app, "aws-ec2-integ-ecs")
+
+vpc = ec2.VpcNetwork(
+    stack, "MyVpc",
+    max_a_zs=2
+)
+
+cluster = ecs.Cluster(
+    stack, 'EcsCluster',
+    vpc=vpc
+)
+cluster.add_capacity("DefaultAutoScalingGroup",
+                     instance_type=ec2.InstanceType("t2.micro"))
+
+# Create Task Definition
+task_definition = ecs.Ec2TaskDefinition(stack, "TaskDef")
+container = task_definition.add_container(
+    "web",
+    image=ecs.ContainerImage.from_registry("amazon/amazon-ecs-sample"),
+    memory_limit_mi_b=256
+)
+container.add_port_mappings(
+    container_port=80,
+    host_port=8080,
+    protocol=ecs.Protocol.Tcp
+)
+
+# Create Service
+service = ecs.Ec2Service(
+    stack, "Service",
+    cluster=cluster,
+    task_definition=task_definition
+)
+
+# Create ALB
+lb = elbv2.ApplicationLoadBalancer(
+    stack, "LB",
+    vpc=vpc,
+    internet_facing=True
+)
+listener = lb.add_listener(
+    "PublicListener",
+    port=80,
+    open=True
+)
+
+# Attach ALB to ECS Service
+listener.add_targets(
+    "ECS",
+    port=80,
+    targets=[service],
+    health_check={
+        "interval_secs": 60,
+        "path": "/health",
+        "timeout_seconds": 5
+    }
+)
+
+cdk.CfnOutput(
+    stack, "LoadBalancerDNS",
+    value=lb.dns_name
+)
+
+app.run()

--- a/python/ecs/ecs-service-with-advanced-alb-config/cdk.json
+++ b/python/ecs/ecs-service-with-advanced-alb-config/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/ecs/ecs-service-with-advanced-alb-config/requirements.txt
+++ b/python/ecs/ecs-service-with-advanced-alb-config/requirements.txt
@@ -1,0 +1,7 @@
+aws-cdk.cdk
+aws-cdk.aws_ec2
+aws-cdk.aws_ecs
+aws-cdk.aws_elasticloadbalancingv2
+
+# Work around for jsii#413
+aws-cdk.aws-autoscaling-common

--- a/python/ecs/ecs-service-with-task-networking/app.py
+++ b/python/ecs/ecs-service-with-task-networking/app.py
@@ -1,0 +1,64 @@
+from aws_cdk import (
+    aws_ec2 as ec2,
+    aws_ecs as ecs,
+    aws_elasticloadbalancingv2 as elbv2,
+    cdk,
+)
+
+# Based on https://aws.amazon.com/blogs/compute/introducing-cloud-native-networking-for-ecs-containers/
+
+app = cdk.App()
+stack = cdk.Stack(app, "ec2-service-with-task-networking")
+
+# Create a cluster
+vpc = ec2.VpcNetwork(
+    stack, "Vpc",
+    max_a_zs=2
+)
+
+cluster = ecs.Cluster(
+    stack, "awsvpc-ecs-demo-cluster",
+    vpc=vpc
+)
+cluster.add_capacity("DefaultAutoScalingGroup",
+                     instance_type=ec2.InstanceType("t2.micro"))
+
+# Create a task definition with its own elastic network interface
+task_definition = ecs.Ec2TaskDefinition(
+    stack, "nginx-awsvpc",
+    network_mode=ecs.NetworkMode.AwsVpc
+)
+
+web_container = task_definition.add_container(
+    "nginx",
+    image=ecs.ContainerImage.from_registry("nginx:latest"),
+    cpu=100,
+    memory_limit_mi_b=256,
+    essential=True
+)
+web_container.add_port_mappings(
+    container_port=80,
+    protocol=ecs.Protocol.Tcp
+)
+
+# Create a security group that allows HTTP traffic on port 80 for our
+# containers without modifying the security group on the instance
+security_group = ec2.SecurityGroup(
+    stack, "nginx--7623",
+    vpc=vpc,
+    allow_all_outbound=False
+)
+security_group.add_ingress_rule(
+    ec2.AnyIPv4(),
+    ec2.TcpPort(80)
+)
+
+# Create the service
+service = ecs.Ec2Service(
+    stack, "awsvpc-ecs-demo-service",
+    cluster=cluster,
+    task_definition=task_definition,
+    security_group=security_group
+)
+
+app.run()

--- a/python/ecs/ecs-service-with-task-networking/cdk.json
+++ b/python/ecs/ecs-service-with-task-networking/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/ecs/ecs-service-with-task-networking/requirements.txt
+++ b/python/ecs/ecs-service-with-task-networking/requirements.txt
@@ -1,0 +1,7 @@
+aws-cdk.cdk
+aws-cdk.aws_ec2
+aws-cdk.aws_ecs
+aws-cdk.aws_elasticloadbalancingv2
+
+# Work around for jsii#413
+aws-cdk.aws-autoscaling-common

--- a/python/ecs/ecs-service-with-task-placement/README.txt
+++ b/python/ecs/ecs-service-with-task-placement/README.txt
@@ -1,0 +1,1 @@
+Not currently working.  Seems to be some issue with ecs.BuiltInAttributes.

--- a/python/ecs/ecs-service-with-task-placement/app.py
+++ b/python/ecs/ecs-service-with-task-placement/app.py
@@ -1,0 +1,52 @@
+from aws_cdk import (
+    aws_ec2 as ec2,
+    aws_ecs as ecs,
+    aws_elasticloadbalancingv2 as elbv2,
+    cdk,
+)
+
+app = cdk.App()
+stack = cdk.Stack(app, "aws-ecs-integ-ecs")
+
+# Create a cluster
+vpc = ec2.VpcNetwork(
+    stack, "Vpc",
+    max_a_zs=2
+)
+
+cluster = ecs.Cluster(
+    stack, "EcsCluster",
+    vpc=vpc
+)
+cluster.add_capacity("DefaultAutoScalingGroup",
+                     instance_type=ec2.InstanceType("t2.micro"))
+
+# Create a task definition with placement constraints
+task_definition = ecs.Ec2TaskDefinition(
+    stack, "TaskDef",
+    placement_constraints=[
+        {"type": ecs.PlacementConstraintType.DistinctInstance}
+    ]
+)
+
+container = task_definition.add_container(
+    "web",
+    image=ecs.ContainerImage.from_registry("nginx:latest"),
+    memory_limit_mi_b=256,
+)
+container.add_port_mappings(
+    container_port=80,
+    host_port=8080,
+    protocol=ecs.Protocol.Tcp
+)
+
+# Create Service
+service = ecs.Ec2Service(
+    stack, "Service",
+    cluster=cluster,
+    task_definition=task_definition,
+)
+service.place_packed_by(ecs.BinPackResource.Memory)
+service.place_spread_across(ecs.BuiltInAttributes.AVAILABILITY_ZONE)
+
+app.run()

--- a/python/ecs/ecs-service-with-task-placement/cdk.json
+++ b/python/ecs/ecs-service-with-task-placement/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/ecs/ecs-service-with-task-placement/requirements.txt
+++ b/python/ecs/ecs-service-with-task-placement/requirements.txt
@@ -1,0 +1,7 @@
+aws-cdk.cdk
+aws-cdk.aws_ec2
+aws-cdk.aws_ecs
+aws-cdk.aws_elasticloadbalancingv2
+
+# Work around for jsii#413
+aws-cdk.aws-autoscaling-common

--- a/python/ecs/fargate-load-balanced-service/app.py
+++ b/python/ecs/fargate-load-balanced-service/app.py
@@ -5,11 +5,13 @@ from aws_cdk import (
 )
 
 
-class BonjourECS(cdk.Stack):
+class BonjourFargate(cdk.Stack):
 
     def __init__(self, scope: cdk.Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, *kwargs)
 
+        # Create VPC and Fargate Cluster
+        # NOTE: Limit AZs to avoid reaching resource quotas
         vpc = ec2.VpcNetwork(
             self, "MyVpc",
             max_a_zs=2
@@ -20,21 +22,17 @@ class BonjourECS(cdk.Stack):
             vpc=vpc
         )
 
-        cluster.add_capacity("DefaultAutoScalingGroup",
-                             instance_type=ec2.InstanceType("t2.micro"))
-
-        ecs_service = ecs.LoadBalancedEc2Service(
-            self, "Ec2Service",
+        fargate_service = ecs.LoadBalancedFargateService(
+            self, "FargateService",
             cluster=cluster,
-            memory_limit_mi_b=512,
             image=ecs.ContainerImage.from_registry("amazon/amazon-ecs-sample")
         )
 
         cdk.CfnOutput(
             self, "LoadBalancerDNS",
-            value=ecs_service.load_balancer.dns_name
+            value=fargate_service.load_balancer.dns_name
         )
 
 app = cdk.App()
-BonjourECS(app, "Bonjour")
+BonjourFargate(app, "Bonjour")
 app.run()

--- a/python/ecs/fargate-load-balanced-service/cdk.json
+++ b/python/ecs/fargate-load-balanced-service/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/ecs/fargate-load-balanced-service/requirements.txt
+++ b/python/ecs/fargate-load-balanced-service/requirements.txt
@@ -1,0 +1,6 @@
+aws-cdk.cdk
+aws-cdk.aws_ec2
+aws-cdk.aws_ecs
+
+# Work around for jsii#413
+aws-cdk.aws-autoscaling-common

--- a/python/ecs/fargate-service-with-autoscaling/app.py
+++ b/python/ecs/fargate-service-with-autoscaling/app.py
@@ -1,0 +1,49 @@
+from aws_cdk import (
+    aws_ec2 as ec2,
+    aws_ecs as ecs,
+    cdk,
+)
+
+
+class AutoScalingFargateService(cdk.Stack):
+
+    def __init__(self, scope: cdk.Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, *kwargs)
+
+        # Create a cluster
+        vpc = ec2.VpcNetwork(
+            self, "Vpc",
+            max_a_zs=2
+        )
+
+        cluster = ecs.Cluster(
+            self, 'fargate-service-autoscaling',
+            vpc=vpc
+        )
+
+        # Create Fargate Service
+        fargate_service = ecs.LoadBalancedFargateService(
+            self, "sample-app",
+            cluster=cluster,
+            image=ecs.ContainerImage.from_registry("amazon/amazon-ecs-sample")
+        )
+
+        # Setup AutoScaling policy
+        scaling = fargate_service.service.auto_scale_task_count(
+            max_capacity=2
+        )
+        scaling.scale_on_cpu_utilization(
+            "CpuScaling",
+            target_utilization_percent=50,
+            scale_in_cooldown_sec=60,
+            scale_out_cooldown_sec=60,
+        )
+
+        cdk.CfnOutput(
+            self, "LoadBalancerDNS",
+            value=fargate_service.load_balancer.dns_name
+        )
+
+app = cdk.App()
+AutoScalingFargateService(app, "aws-fargate-application-autoscaling")
+app.run()

--- a/python/ecs/fargate-service-with-autoscaling/cdk.json
+++ b/python/ecs/fargate-service-with-autoscaling/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/ecs/fargate-service-with-autoscaling/requirements.txt
+++ b/python/ecs/fargate-service-with-autoscaling/requirements.txt
@@ -1,0 +1,7 @@
+aws-cdk.cdk
+aws-cdk.aws_ec2
+aws-cdk.aws_ecs
+aws-cdk.aws_elasticloadbalancingv2
+
+# Work around for jsii#413
+aws-cdk.aws-autoscaling-common

--- a/python/lambda-cron/app.py
+++ b/python/lambda-cron/app.py
@@ -1,0 +1,30 @@
+from aws_cdk import aws_events as events, aws_lambda as lambda_, cdk
+
+
+class LambdaCronStack(cdk.Stack):
+    def __init__(self, app: cdk.App, id: str) -> None:
+        super().__init__(app, id)
+
+        with open("lambda-handler.py", encoding="utf8") as fp:
+            handler_code = fp.read()
+
+        lambdaFn = lambda_.Function(
+            self,
+            "Singleton",
+            code=lambda_.InlineCode(handler_code),
+            handler="index.main",
+            timeout=300,
+            runtime=lambda_.Runtime.PYTHON27,
+        )
+
+        # Run every day at 6PM UTC
+        # See https://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html
+        rule = events.EventRule(
+            self, "Rule", schedule_expression="cron(0 18 ? * MON-FRI *)"
+        )
+        rule.add_target(lambdaFn)
+
+
+app = cdk.App()
+LambdaCronStack(app, "LambdaCronExample")
+app.run()

--- a/python/lambda-cron/cdk.json
+++ b/python/lambda-cron/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/lambda-cron/lambda-handler.py
+++ b/python/lambda-cron/lambda-handler.py
@@ -1,0 +1,2 @@
+def main(event, context):
+    print("I'm running!")

--- a/python/lambda-cron/requirements.txt
+++ b/python/lambda-cron/requirements.txt
@@ -1,0 +1,3 @@
+aws-cdk.aws-events
+aws-cdk.aws-lambda
+aws-cdk.cdk

--- a/python/stepfunctions/app.py
+++ b/python/stepfunctions/app.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from aws_cdk import (
+    aws_stepfunctions as sfn,
+    cdk,
+)
+
+
+class JobPollerStack(cdk.Stack):
+    def __init__(self, app: cdk.App, id: str, **kwargs) -> None:
+        super().__init__(app, id, **kwargs)
+
+        submit_job_activity = sfn.Activity(
+            self, "SubmitJob"
+        )
+        check_job_activity = sfn.Activity(
+            self, "CheckJob"
+        )
+
+        submit_job = sfn.Task(
+            self, "Submit Job",
+            resource=submit_job_activity,
+            result_path="$.guid",
+        )
+        wait_x = sfn.Wait(
+            self, "Wait X Seconds",
+            seconds_path="$.wait_time",
+        )
+        get_status = sfn.Task(
+            self, "Get Job Status",
+            resource=check_job_activity,
+            input_path="$.guid",
+            result_path="$.status",
+        )
+        is_complete = sfn.Choice(
+            self, "Job Complete?"
+        )
+        job_failed = sfn.Fail(
+            self, "Job Failed",
+            cause="AWS Batch Job Failed",
+            error="DescribeJob returned FAILED"
+        )
+        final_status = sfn.Task(
+            self, "Get Final Job Status",
+            resource=check_job_activity,
+            input_path="$.guid",
+        )
+
+        definition = submit_job\
+            .next(wait_x)\
+            .next(get_status)\
+            .next(is_complete
+                  .when(sfn.Condition.string_equals(
+                      "$.status", "FAILED"), job_failed)
+                  .when(sfn.Condition.string_equals(
+                      "$.status", "SUCCEEDED"), final_status)
+                  .otherwise(wait_x))
+
+        sfn.StateMachine(
+            self, "StateMachine",
+            definition=definition,
+            timeout_sec=30,
+        )
+
+app = cdk.App()
+JobPollerStack(app, "aws-stepfunctions-integ")
+app.run()

--- a/python/stepfunctions/cdk.json
+++ b/python/stepfunctions/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/stepfunctions/requirements.txt
+++ b/python/stepfunctions/requirements.txt
@@ -1,0 +1,3 @@
+aws-cdk.cdk
+
+aws-cdk.aws-stepfunctions


### PR DESCRIPTION
This supersedes #21.  I have merged the branch started by @dstuffd and am extending it to include more examples.

- [x] application-load-balancer
- [x] chat-app
- [x] classic-load-balancer
- [x] custom-resource
- [ ] ecs
  - [x] cluster (ported but blocked by #23)
  - [x] ecs-loadbalanced-service
  - [x] ecs-service-with-advanced-alb-config
  - [x] ecs-service-with-task-networking
  - [x] ecs-service-with-task-placement (ported but issue with ecs.BuiltInAttributes)
  - [x] fargate-load-balanced-service
  - [x] fargate-service-with-auto-scaling
- [ ] elasticbeanstalk
  - [ ] elasticbeanstalk-bg-pipeline
  - [ ] elasticbeanstalk-environment
- [x] lambda-cron
- [ ] my-widget-service
- [ ] resource-overrides
- [ ] static-site
- [x] stepfunctions-job-poller

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.