### PR TITLE
Remove associatePublicIp

### DIFF
--- a/typescript/ecs/cluster/index.ts
+++ b/typescript/ecs/cluster/index.ts
@@ -13,7 +13,6 @@ class ECSCluster extends cdk.Stack {
     const asg = new autoscaling.AutoScalingGroup(this, 'MyFleet', {
       instanceType: new InstanceType("t2.xlarge"),
       machineImage: new ecs.EcsOptimizedAmi(),
-      associatePublicIpAddress: true,
       updateType: autoscaling.UpdateType.ReplacingUpdate,
       desiredCapacity: 3,
       vpc


### PR DESCRIPTION
Cluster was not using public subnets, so setting this field to true would throw error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
