### PR TITLE
Add Java version of the Lambda Cron example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ $ cdk destroy
 | Example | Description |
 |---------|-------------|
 | [hello-world](https://github.com/aws-samples/aws-cdk-examples/tree/master/java/hello-world/) | A demo application that uses the CDK in Java |
+| [lambda-cron](https://github.com/aws-samples/aws-cdk-examples/tree/master/java/lambda-cron/) | Running a Lambda on a schedule |
 
 ## Python examples
 

--- a/java/lambda-cron/README.md
+++ b/java/lambda-cron/README.md
@@ -1,0 +1,32 @@
+# CDK Java Example
+
+This an example of a CDK program written in Java.
+
+## Building
+
+To build this app, run `mvn compile`. This will download the required
+dependencies compile the Java code.
+
+You can use your IDE to write code and unit tests, but you will need to use the
+CDK toolkit if you wish to synthesize/deploy stacks.
+
+## CDK Toolkit
+
+The [`cdk.json`](./cdk.json) file in the root of this repository includes
+instructions for the CDK toolkit on how to execute this program.
+
+Specifically, it will tell the toolkit to use the `mvn exec:java` command as the
+entry point of your application. After changing your Java code, you will be able
+to run the CDK toolkits commands as usual (Maven will recompile as needed):
+
+    $ cdk ls
+    <list all stacks in this program>
+
+    $ cdk synth
+    <cloudformation template>
+
+    $ cdk deploy
+    <deploy stack to your account>
+
+    $ cdk diff
+    <diff against deployed stack>

--- a/java/lambda-cron/cdk.json
+++ b/java/lambda-cron/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "mvn exec:java -Dexec.mainClass=software.amazon.awscdk.examples.LambdaCronApp"
+}

--- a/java/lambda-cron/pom.xml
+++ b/java/lambda-cron/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.amazonaws.cdk</groupId>
+    <artifactId>lambda-cron</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.amazonaws.cdk.examples.LambdaCronApp</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                            <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+              </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.jsii</groupId>
+            <artifactId>jsii-runtime</artifactId>
+            <version>0.7.14</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>cdk</artifactId>
+            <version>0.23.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>lambda</artifactId>
+            <version>0.23.0</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>[2.9.8,)</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>[2.9.8,)</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/junit/junit -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronApp.java
+++ b/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronApp.java
@@ -1,0 +1,13 @@
+package software.amazon.awscdk.examples;
+
+import software.amazon.awscdk.App;
+
+public class LambdaCronApp {
+    public static void main(final String[] args) {
+        App app = new App();
+
+        new LambdaCronStack(app, "cdk-lambda-cron-example");
+
+        app.run();
+    }
+}

--- a/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
+++ b/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
@@ -1,0 +1,44 @@
+package software.amazon.awscdk.examples;
+
+import software.amazon.awscdk.App;
+import software.amazon.awscdk.Stack;
+import software.amazon.awscdk.services.events.EventRule;
+import software.amazon.awscdk.services.events.EventRuleProps;
+import software.amazon.awscdk.services.lambda.Code;
+import software.amazon.awscdk.services.lambda.Runtime;
+import software.amazon.awscdk.services.lambda.SingletonFunction;
+import software.amazon.awscdk.services.lambda.SingletonFunctionProps;
+
+import java.util.UUID;
+
+/**
+ * Lambda Cron CDK example for Java!
+ */
+class LambdaCronStack extends Stack {
+    public LambdaCronStack(final App parent, final String name) {
+        super(parent, name);
+
+        SingletonFunction lambdaFunction = new SingletonFunction(this, "cdk-lambda-cron",
+                SingletonFunctionProps.builder()
+                        .withFunctionName("CDK Lambda Cron Example")
+                        .withDescription("Lambda which prints \"I'm running\"")
+                        .withCode(Code.inline(
+                                "def main(event, context):\n" +
+                                        "    print(\"I'm running!\")\n"))
+                        .withHandler("index.main")
+                        .withTimeout(300)
+                        .withRuntime(Runtime.PYTHON27)
+                        .withUuid(UUID.randomUUID().toString())
+                        .build()
+        );
+
+        EventRule rule = new EventRule(this, "cdk-lambda-cron-rule",
+                EventRuleProps.builder()
+                        .withDescription("Run every day at 6PM UTC")
+                        .withScheduleExpression("cron(0 18 ? * MON-FRI *)")
+                        .build()
+        );
+
+        rule.addTarget(lambdaFunction);
+    }
+}

--- a/java/lambda-cron/src/test/java/software/amazon/awscdk/examples/LambdaCronStackTest.java
+++ b/java/lambda-cron/src/test/java/software/amazon/awscdk/examples/LambdaCronStackTest.java
@@ -1,0 +1,81 @@
+package software.amazon.awscdk.examples;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awscdk.App;
+import software.amazon.awscdk.Stack;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static software.amazon.awscdk.examples.TestUtils.toCloudFormationJson;
+
+public class LambdaCronStackTest {
+    private App app;
+    private Stack stack;
+    private JsonNode actualStack;
+    private JsonNode expectedStack;
+
+    @Before
+    public void setUp() throws IOException {
+        app = new App();
+        stack = new LambdaCronStack(app, "lambdaResource-cdk-lambda-cron");
+        actualStack = toCloudFormationJson(stack).path("Resources");
+        expectedStack = TestUtils.fromFileResource(getClass().getResource("testCronLambdaExpected.json")).path("Resources");
+    }
+
+    @Test()
+    public void testTypes() {
+        List<JsonNode> actual = actualStack.findValues("Type");
+        List<JsonNode> expected = expectedStack.findValues("Type");
+        containsInAnyOrder(actual, expected);
+    }
+
+    @Test
+    public void testPermission() {
+        final String type = "AWS::Lambda::Permission";
+        JsonNode actual = TestUtils.getJsonNode(actualStack, type);
+        JsonNode expected = TestUtils.getJsonNode(expectedStack, type);
+        String[] keys = {"ManagedPolicyArns", "AssumeRolePolicyDocument"};
+        for (String key : keys) {
+            assertEquals(actual.get(key), expected.get(key));
+        }
+    }
+
+    @Test
+    public void testRole() {
+        final String type = "AWS::IAM::Role";
+        JsonNode actual = TestUtils.getJsonNode(actualStack, type);
+        JsonNode expected = TestUtils.getJsonNode(expectedStack, type);
+        String[] keys = {"ManagedPolicyArns", "AssumeRolePolicyDocument"};
+        for (String key : keys) {
+            assertEquals(actual.get(key), expected.get(key));
+        }
+    }
+
+    @Test
+    public void testLambda() {
+        final String type = "AWS::Lambda::Function";
+        JsonNode actual = TestUtils.getJsonNode(actualStack, type);
+        JsonNode expected = TestUtils.getJsonNode(expectedStack, type);
+        String[] keys = {"Runtime", "Description", "Timeout", "Handler", "Code"};
+        for (String key : keys) {
+            assertEquals(actual.get(key), expected.get(key));
+        }
+    }
+
+    @Test
+    public void testRule() {
+        final String type = "AWS::Events::Rule";
+        JsonNode actual = TestUtils.getJsonNode(actualStack, type);
+        JsonNode expected = TestUtils.getJsonNode(expectedStack, type);
+        String[] keys = {"ScheduleExpression", "Description", "State"};
+        for (String key : keys) {
+            assertEquals(actual.get(key), expected.get(key));
+        }
+    }
+
+}

--- a/java/lambda-cron/src/test/java/software/amazon/awscdk/examples/TestUtils.java
+++ b/java/lambda-cron/src/test/java/software/amazon/awscdk/examples/TestUtils.java
@@ -1,0 +1,54 @@
+package software.amazon.awscdk.examples;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import software.amazon.awscdk.Stack;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestUtils {
+    private static ObjectMapper JSON = new ObjectMapper();
+
+    static JsonNode fromFileResource(final URL fileResource) throws IOException {
+        return JSON.readTree(fileResource);
+    }
+
+    static JsonNode toCloudFormationJson(final Stack stack) throws IOException {
+        JsonNode n = JSON.valueToTree(stack.toCloudFormation());
+        System.out.println(JSON.writerWithDefaultPrettyPrinter().writeValueAsString(n));
+        return n;
+    }
+
+    static void assertTemplate(final Stack stack, final URL expectedResource) throws IOException {
+        assertTemplate(stack, JSON.readTree(expectedResource));
+    }
+
+    static void assertTemplate(final Stack stack, final String expectedTemplate) throws IOException {
+        assertTemplate(stack, JSON.readTree(expectedTemplate));
+    }
+
+    private static void assertTemplate(final Stack stack, final JsonNode expected) throws IOException {
+        JsonNode actual = toCloudFormationJson(stack);
+
+        // print to stderr if non-equal, so it will be easy to grab
+        if (expected == null || !expected.equals(actual)) {
+            String prettyActual = JSON.writerWithDefaultPrettyPrinter().writeValueAsString(actual);
+            System.err.println(prettyActual);
+        }
+
+        assertEquals(expected, actual);
+    }
+
+    static JsonNode getJsonNode(JsonNode stackJson, String type) {
+        Iterable<JsonNode> iterable = stackJson::elements;
+        Optional<JsonNode> maybe = StreamSupport.stream(iterable.spliterator(), false)
+                .filter(jn -> jn.get("Type").textValue().equals(type)).findFirst();
+        return maybe.map(jn -> jn.path("Properties")).orElseThrow(NoSuchElementException::new);
+    }
+}

--- a/java/lambda-cron/src/test/resources/software/amazon/awscdk/examples/testCronLambdaExpected.json
+++ b/java/lambda-cron/src/test/resources/software/amazon/awscdk/examples/testCronLambdaExpected.json
@@ -1,0 +1,67 @@
+{
+  "Resources" : {
+    "cdklambdacronrule709B40EE" : {
+      "Type" : "AWS::Events::Rule",
+      "Properties" : {
+        "ScheduleExpression" : "cron(0 18 ? * MON-FRI *)",
+        "Description" : "Run every day at 6PM UTC",
+        "State" : "ENABLED",
+        "Targets" : [ {
+          "Id" : "cdk-lambda-cron",
+          "Arn" : {
+            "Fn::GetAtt" : [ "SingletonLambda0dc9f04c622c4059b399834a2c1ac15f9CB1DC29", "Arn" ]
+          }
+        } ]
+      }
+    },
+    "SingletonLambda0dc9f04c622c4059b399834a2c1ac15fServiceRoleD59355BD" : {
+      "Type" : "AWS::IAM::Role",
+      "Properties" : {
+        "ManagedPolicyArns" : [ {
+          "Fn::Join" : [ "", [ "arn:", {
+            "Ref" : "AWS::Partition"
+          }, ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole" ] ]
+        } ],
+        "AssumeRolePolicyDocument" : {
+          "Version" : "2012-10-17",
+          "Statement" : [ {
+            "Action" : "sts:AssumeRole",
+            "Effect" : "Allow",
+            "Principal" : {
+              "Service" : "lambda.amazonaws.com"
+            }
+          } ]
+        }
+      }
+    },
+    "SingletonLambda0dc9f04c622c4059b399834a2c1ac15fAllowEventRulelambdaResourcecdklambdacroncdklambdacronruleD22C5DC3B70D87DC" : {
+      "Type" : "AWS::Lambda::Permission",
+      "Properties" : {
+        "FunctionName" : {
+          "Ref" : "SingletonLambda0dc9f04c622c4059b399834a2c1ac15f9CB1DC29"
+        },
+        "Action" : "lambda:InvokeFunction",
+        "SourceArn" : {
+          "Fn::GetAtt" : [ "cdklambdacronrule709B40EE", "Arn" ]
+        },
+        "Principal" : "events.amazonaws.com"
+      }
+    },
+    "SingletonLambda0dc9f04c622c4059b399834a2c1ac15f9CB1DC29" : {
+      "Type" : "AWS::Lambda::Function",
+      "Properties" : {
+        "Role" : {
+          "Fn::GetAtt" : [ "SingletonLambda0dc9f04c622c4059b399834a2c1ac15fServiceRoleD59355BD", "Arn" ]
+        },
+        "FunctionName" : "CDK Lambda Cron Example",
+        "Runtime" : "python2.7",
+        "Description" : "Lambda which prints \"I'm running\"",
+        "Timeout" : 300,
+        "Handler" : "index.main",
+        "Code" : {
+          "ZipFile" : "def main(event, context):\n    print(\"I'm running!\")\n"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
No issue. I just thought the Java section looked a bit sad.

*Description of changes:*
Creates a Java copy of the Lambda Cron example present in the Python and Typescript examples (using the same Python code as that seemed simplest).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
