### PR TITLE
Update for cdk0.34.0

### DIFF
--- a/typescript/api-cors-lambda-crud-dynamodb/index.ts
+++ b/typescript/api-cors-lambda-crud-dynamodb/index.ts
@@ -127,4 +127,4 @@ export function addCorsOptions(apiResource: apigateway.IResource) {
 
 const app = new cdk.App();
 new ApiLambdaCrudDynamoDBStack(app, 'ApiLambdaCrudDynamoDBExample');
-app.run();
+app.synth();

--- a/typescript/application-load-balancer/index.ts
+++ b/typescript/application-load-balancer/index.ts
@@ -40,4 +40,4 @@ class LoadBalancerStack extends cdk.Stack {
 
 const app = new cdk.App();
 new LoadBalancerStack(app, 'LoadBalancerStack');
-app.run();
+app.synth();

--- a/typescript/appsync-graphql-dynamodb/index.ts
+++ b/typescript/appsync-graphql-dynamodb/index.ts
@@ -142,4 +142,4 @@ export class AppSyncCdkStack extends cdk.Stack {
 
 const app = new cdk.App();
 new AppSyncCdkStack(app, 'AppSyncGraphQLDynamoDBExample');
-app.run();
+app.synth();

--- a/typescript/classic-load-balancer/index.ts
+++ b/typescript/classic-load-balancer/index.ts
@@ -33,4 +33,4 @@ class LoadBalancerStack extends cdk.Stack {
 
 const app = new cdk.App();
 new LoadBalancerStack(app, 'LoadBalancerStack');
-app.run();
+app.synth();

--- a/typescript/custom-resource/index.ts
+++ b/typescript/custom-resource/index.ts
@@ -22,4 +22,4 @@ class MyStack extends cdk.Stack {
 
 const app = new cdk.App();
 new MyStack(app, 'CustomResourceDemoStack');
-app.run();
+app.synth();

--- a/typescript/ecs/cluster/index.ts
+++ b/typescript/ecs/cluster/index.ts
@@ -32,4 +32,4 @@ const app = new cdk.App();
 
 new ECSCluster(app, 'MyFirstEcsCluster');
 
-app.run();
+app.synth();

--- a/typescript/ecs/ecs-load-balanced-service/index.ts
+++ b/typescript/ecs/ecs-load-balanced-service/index.ts
@@ -33,4 +33,4 @@ const app = new cdk.App();
 
 new BonjourECS(app, 'Bonjour');
 
-app.run();
+app.synth();

--- a/typescript/ecs/ecs-service-with-advanced-alb-config/index.ts
+++ b/typescript/ecs/ecs-service-with-advanced-alb-config/index.ts
@@ -54,4 +54,4 @@ listener.addTargets('ECS', {
 
 new cdk.CfnOutput(stack, 'LoadBalancerDNS', { value: lb.loadBalancerDnsName, });
 
-app.run();
+app.synth();

--- a/typescript/ecs/ecs-service-with-logging/index.ts
+++ b/typescript/ecs/ecs-service-with-logging/index.ts
@@ -36,4 +36,4 @@ const app = new cdk.App();
 
 new WillkommenECS(app, 'Willkommen');
 
-app.run();
+app.synth();

--- a/typescript/ecs/ecs-service-with-logging/package-lock.json
+++ b/typescript/ecs/ecs-service-with-logging/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "@aws-cdk/assets": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-0.33.0.tgz",
-      "integrity": "sha512-igv2d1Yl5II2lGAQdgBMVG9GDtN713QKpCc4GIvGoi+Ucz+pZ70AbUOCZhIQC3dZf1Thh4YFtVzBHmTIgl5M1A==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-0.34.0.tgz",
+      "integrity": "sha512-nXAAFb6EKhdVcNseZQnjiYYrpzbJu8tVCfSJiIbi6WjYw+7jygexj7YkrZY1jRnCHUIqWcGD2LeCUx/k8yY4aQ==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0",
         "minimatch": "^3.0.4"
       },
       "dependencies": {
@@ -42,94 +42,94 @@
       }
     },
     "@aws-cdk/assets-docker": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets-docker/-/assets-docker-0.33.0.tgz",
-      "integrity": "sha512-cwbKyAGXzYBWMToDZ8TBWOkK0lTtaCDsSnhJUXMrtNg7vleQz/Zl0CPEase2SOfNRax9EZheKThE/OdMFJLSyg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets-docker/-/assets-docker-0.34.0.tgz",
+      "integrity": "sha512-SMuDqZtr8eirZsUXG8gskteXRXLJ5Jsb1us5pg8NtVPzF1drgu2iW/E8YlSP1QBZF20nqLfjMm7C1cEy/NxPHg==",
       "requires": {
-        "@aws-cdk/assets": "^0.33.0",
-        "@aws-cdk/aws-cloudformation": "^0.33.0",
-        "@aws-cdk/aws-ecr": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/assets": "^0.34.0",
+        "@aws-cdk/aws-cloudformation": "^0.34.0",
+        "@aws-cdk/aws-ecr": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-applicationautoscaling": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-0.33.0.tgz",
-      "integrity": "sha512-zzmKvL2XFdjqp1ZYE/2KGPtKApId0LltZHSZKzVlUWJYQA4qCxqoMX8bh1sSJ7wzZRX58FGwsecK74rTNZndmQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-0.34.0.tgz",
+      "integrity": "sha512-XjZJHGDEW77l6kFAPuId8unr6FYX0E0d/qUq7BmjQEbdW/3ljSlZeDQb5sObvHjR7eTpyhaNzLEfePM6A3x2fw==",
       "requires": {
-        "@aws-cdk/aws-autoscaling-common": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-autoscaling-common": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-autoscaling": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling/-/aws-autoscaling-0.33.0.tgz",
-      "integrity": "sha512-ZgclpQvAj4mYo+7Sj/IAGMVvADXuJyV1JP1sjiXMhGWqibtrBYetgpD0yUEOVM9f6MiEGU+/D2PpaPkt7+1ubg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling/-/aws-autoscaling-0.34.0.tgz",
+      "integrity": "sha512-B+JXGjBm9hwbm4GAe0nmGvrrNGkjNdF9UvMqk1O4cXYr7gabIOcbemWGU3i7sLYUEvcjEgQYA8s9KsxIhlp99w==",
       "requires": {
-        "@aws-cdk/aws-autoscaling-common": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancing": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-sns": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-autoscaling-common": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancing": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-sns": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-autoscaling-common": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-0.33.0.tgz",
-      "integrity": "sha512-fdY3JcG7kLo6qNltQZWwBoyZF3pKDhLILuJQ94V86pHWTfntiucM4jgJBbU+gEzYDtmCUkYEIeorFIxYIBq/6A==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-0.34.0.tgz",
+      "integrity": "sha512-HmYDOACF1o3vR01IHgkY0BfXnZIFUCY8epBUUowYD5zbtqG2Cne/6TGaw9m7hBXJnuQmyGhvlPmtV+nW/aGnLQ==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-autoscaling-hooktargets": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-0.33.0.tgz",
-      "integrity": "sha512-mlUQsNt0zV9F2EepqQl9jJdren5ZV3ackpb9BCTvpvbD9PLNSMcDQ8s063M94E77xV+g40bsWPTWlYh9wA4fGQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-0.34.0.tgz",
+      "integrity": "sha512-JSnA4Fk+9olF2Gx6JgKqfjwevt6q2Xku01c1k7zI9Z53Jru2RZ/sG56jAYZarbB0YH9mJy6sOqzWOu9s5EPnwA==",
       "requires": {
-        "@aws-cdk/aws-autoscaling": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-sns": "^0.33.0",
-        "@aws-cdk/aws-sqs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-autoscaling": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-sns": "^0.34.0",
+        "@aws-cdk/aws-sqs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-certificatemanager": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-0.33.0.tgz",
-      "integrity": "sha512-KfKTHAX3o1wbmDsGLw23WBYv/cjtF8pbiQnISK1kDdVrfzM2LJUqzw09RtjBN56CFQ4Dpxn+3Yf9UJWvoAKGxA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-0.34.0.tgz",
+      "integrity": "sha512-tp0w0ifzlUPkaAYR9dJJZ8iwxgqucrRHXK5HoG5PY8WcBH1xSAIm6MtfP5R7Dh9s5hUwg1hz8wygEerN90SrzA==",
       "requires": {
-        "@aws-cdk/aws-cloudformation": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-route53": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudformation": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-route53": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-cloudformation": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-0.33.0.tgz",
-      "integrity": "sha512-x43Ynmz6s/7GnWpmdUZAsg0uK2bQVJxDezVeP6fTPmnXabC0ZB38/tiB7BCafOwRcKAZTeKVWQLX0+nEKmXaBw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-0.34.0.tgz",
+      "integrity": "sha512-F9W53h4Ho//2YrdEgBj7JIXbYo/LT7V2FL33SK9guBHAxYVWWNipFcu/rvuZtKm/8te7F102b9RZGE42yfjKIg==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-sns": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-sns": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
         "aws-sdk": "^2.409.0"
       },
       "dependencies": {
         "aws-sdk": {
-          "version": "2.409.0",
+          "version": "2.469.0",
           "bundled": true,
           "requires": {
             "buffer": "4.9.1",
@@ -211,259 +211,259 @@
       }
     },
     "@aws-cdk/aws-cloudfront": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-0.33.0.tgz",
-      "integrity": "sha512-xlwQzuNl3iWt3v0ChgvcRsZd0qfs3I05pqIYC4raQ0TeYVEF4YZhZnmsnU0Wy2IsFVajXC13HHYAaQYiunUP7A==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-0.34.0.tgz",
+      "integrity": "sha512-3zRJlKYAl0Z2C5ayyG5QjCPVOyDjf2/cf5NBRI1jznSu5Q+Rloal6NPj9t55MywY/54IeuTEQSy/UbtLSnLeiw==",
       "requires": {
-        "@aws-cdk/aws-certificatemanager": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-kms": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-certificatemanager": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-kms": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-cloudwatch": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-0.33.0.tgz",
-      "integrity": "sha512-TvQCLdBaBoPtmPKSDdkjpKriN2a89P5R2M2ZLHW7nED8BX0pe2rTy4pBdLVHMxRkCf1txwXlLa8IAEhQNq6Ixw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-0.34.0.tgz",
+      "integrity": "sha512-w8xWg4wA11g7MS/Cn5CFKv3R9egtsQbGSruoROLpLzI2HY5/MpZ0Is8Nnv2acTKY2unoCIexVo9Ee666NgTVdg==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-ec2": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-0.33.0.tgz",
-      "integrity": "sha512-JNbYU9WGwgW+J+bEH8LOk5wdN95j/bqhoPuktM6cd9cNs9J7uI+a2dXYLoelA+axYXgXMYRfmK0rjGNOUo1WDg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-0.34.0.tgz",
+      "integrity": "sha512-7LU3V8b00k8TXNT4j/WnC0qpAGk9LVvoRd0UgKJzrGTN6Cah0lnM5MpMirwfr0KwKeFL83NwgsCZwMJdV2hHNw==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-ecr": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-0.33.0.tgz",
-      "integrity": "sha512-gz51Ysvn6C0jDw0ZbvFAiX4HTqBRR+VjX+HbBG4kTMd8fOysW4ELQk+iCYrRBqsBjfHKgCEG9Kw/C/vyUdidVw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-0.34.0.tgz",
+      "integrity": "sha512-Q70M7NmqUuw9O3s3aO4nHwCkYJ0KWaxzKfz3Ng5AKgd1G9kDmH8kNrGSuQRefdXIkF2St00Zuq2HpnqEMR8l1g==",
       "requires": {
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-ecs": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs/-/aws-ecs-0.33.0.tgz",
-      "integrity": "sha512-tLa5IuNgbvzxvLsW9x7M50U9FTGDN1XEfG6UtOTGHEJvuDi8aHJqTGZp64EGvJF78+8Dsr6oil6cWK8TR+sO6Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs/-/aws-ecs-0.34.0.tgz",
+      "integrity": "sha512-UR8O509P4zjwrVA6IS4eednmUcbUVwvpTnyG2T76pHQ28StVXcGr9zBDO+l1iHSP83hrklAM+1uwaw9GgEj4gA==",
       "requires": {
-        "@aws-cdk/assets-docker": "^0.33.0",
-        "@aws-cdk/aws-applicationautoscaling": "^0.33.0",
-        "@aws-cdk/aws-autoscaling": "^0.33.0",
-        "@aws-cdk/aws-autoscaling-hooktargets": "^0.33.0",
-        "@aws-cdk/aws-certificatemanager": "^0.33.0",
-        "@aws-cdk/aws-cloudformation": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-ecr": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancing": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-logs": "^0.33.0",
-        "@aws-cdk/aws-route53": "^0.33.0",
-        "@aws-cdk/aws-route53-targets": "^0.33.0",
-        "@aws-cdk/aws-secretsmanager": "^0.33.0",
-        "@aws-cdk/aws-servicediscovery": "^0.33.0",
-        "@aws-cdk/aws-sns": "^0.33.0",
-        "@aws-cdk/aws-sqs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/assets-docker": "^0.34.0",
+        "@aws-cdk/aws-applicationautoscaling": "^0.34.0",
+        "@aws-cdk/aws-autoscaling": "^0.34.0",
+        "@aws-cdk/aws-autoscaling-hooktargets": "^0.34.0",
+        "@aws-cdk/aws-certificatemanager": "^0.34.0",
+        "@aws-cdk/aws-cloudformation": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-ecr": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancing": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-logs": "^0.34.0",
+        "@aws-cdk/aws-route53": "^0.34.0",
+        "@aws-cdk/aws-route53-targets": "^0.34.0",
+        "@aws-cdk/aws-secretsmanager": "^0.34.0",
+        "@aws-cdk/aws-servicediscovery": "^0.34.0",
+        "@aws-cdk/aws-sns": "^0.34.0",
+        "@aws-cdk/aws-sqs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-elasticloadbalancing": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-0.33.0.tgz",
-      "integrity": "sha512-07KB62CtvgrOpoKJdy51CMiwQHp+BQ1gsXmbomM1lDwPDn0ysNo/J3RjKpaAAAREpb9+GGlYGmbDiDA2xVFEuw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-0.34.0.tgz",
+      "integrity": "sha512-gUwOSuoHU4VR8DDIY+X+nRLVvZGGE9vJQH/f9iU5GuIoJGGLuYBpSGum8BP9wrjVfDjf9qHzadxINAaz4CoEKg==",
       "requires": {
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-elasticloadbalancingv2": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-0.33.0.tgz",
-      "integrity": "sha512-LNH8nppUxAcY+Mj0AF3uLn0ZhGql868RYr2BjxdsNpijFBN2sMzpKRxJUvQ1YBlPgrbn2U6Y5Ye1LAr8PchfRg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-0.34.0.tgz",
+      "integrity": "sha512-ImYrubUmxcxpAqChmxjJx4K8QQ3rWyhQrwnzMHQLSt9zQGoLV4SIiDC8LGpIJ/fYI7xKIj0cFUs2MLpxcTifvQ==",
       "requires": {
-        "@aws-cdk/aws-certificatemanager": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-certificatemanager": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-events": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-0.33.0.tgz",
-      "integrity": "sha512-mOoMqhw6YzR5Ly0+SdXqJOlTvlAB/+eTmJkhh/DRBOrDVdwVidDytUTCkmcKJcfzir9OqGUvuANdj8zPD4glQA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-0.34.0.tgz",
+      "integrity": "sha512-UeR9J/VeMN42LSfZvgwjGgl+JsPYl7ah3JLYBKBfxFf7Cee3oWPooJdjtzzmHIBsNkUybK8UJ5rFOxIP+o1sGg==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-iam": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-0.33.0.tgz",
-      "integrity": "sha512-d6HVkScJlG3a0rwWO0LgmZCTndze1c2cpoIezJINZ+sXPyMQiWWyFQDVTDC3LxPPUalG9t42gr2139d2zbfX6w==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-0.34.0.tgz",
+      "integrity": "sha512-C/cCuh7O+UdFUtClzqFRkiO+Tb/8xHRMMM1f6trQJf2BqbJY2TYHBAc47CwJTjhA+1zb1hTW6axNDTFkv+NoZg==",
       "requires": {
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/region-info": "^0.33.0"
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/region-info": "^0.34.0"
       }
     },
     "@aws-cdk/aws-kms": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-0.33.0.tgz",
-      "integrity": "sha512-Yj1i/kqcpLu4LMIfIrk8F1Znereh7kL05+j7Ho0gy+HjwMbODIxB0BcyTiJ/5CjHkJPsR8Tl2GPyerZ6OGk/Dw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-0.34.0.tgz",
+      "integrity": "sha512-p4UMsql0IbGgtbNkrYHlqoq6ne7dqKjIt4Xf3qGCWDAGiXWSlYntFHh6UBzKR0RzW6r0GODttSmypFolLkNUFw==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-lambda": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-0.33.0.tgz",
-      "integrity": "sha512-79q1ZGyNc6hWbZGJkzPs2lxK3/M8o6j7R5m3XZsKE/5KYTEdjM9oJdbWU32PaZ7QXaYDaMOdAR1arzekIG86bw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-0.34.0.tgz",
+      "integrity": "sha512-llndnoPan/uDAoamQzxC5FCzV7nLIkKeBiVHMCo+aokiJsIaDvxmaLpY6PxVvqo+bw5mP/fQeivDOenvAOYlcA==",
       "requires": {
-        "@aws-cdk/assets": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-logs": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/aws-sqs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/assets": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-logs": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/aws-sqs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-logs": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-0.33.0.tgz",
-      "integrity": "sha512-/VPZeb2eyB5uJbKteaM8QFy21Y2s7hsglAJFdWOWtEvQA5snOeJu8kVcsWm+UaYKG6Y+Ix3F5N+KRiyDlrqZFw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-0.34.0.tgz",
+      "integrity": "sha512-A2SPBYBYgLv7BacCxHmFMwFuCxZKe4TRE+M7mDplng6S6Fmq803neyCTPrOgznSGzJYFtfDoacFULuAXJ2hanQ==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-route53": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-0.33.0.tgz",
-      "integrity": "sha512-A+CJL0WSXPkftOWiryjXqumL4ZrqVC5Mc1lIxG8Ks4e/0G/sutlCbsoj2FaDq/reJvO/tQ99PeRgjFoN/FIPBg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-0.34.0.tgz",
+      "integrity": "sha512-jf8SF4wppJsRPCoVmvd6/votGxlbibDqlGP26IGLztIurAZ3ddxdXLHobDIaj1Y+/+8O6FnpFclmO2LNtGXL2g==",
       "requires": {
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-logs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-logs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-route53-targets": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-0.33.0.tgz",
-      "integrity": "sha512-rgCMpEBMoIG6ITo7pz/E0ZSft4NAbt3JunO88b5x/wEpSskQoweUNDN4MyFLxOGUbssyw1ZWZzHODqbhxuGB6g==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-0.34.0.tgz",
+      "integrity": "sha512-ORDUa13KnbkBW1w+SGogZ1IvtitiBaoZX7gvwfkgDIfGwvuFi8cojVqd2CuOVfcjbXcUHe+Ul67ezC0A7NjznA==",
       "requires": {
-        "@aws-cdk/aws-cloudfront": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-route53": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudfront": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-route53": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-s3": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-0.33.0.tgz",
-      "integrity": "sha512-9HWVrlzup8o9GbpjPxX9YKtiRj034pVf+MteVWkiRccVy07BGL8i4d/dpCJDiNsOxaFH4qXCrgdbpUzq/tIcyw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-0.34.0.tgz",
+      "integrity": "sha512-TT1eQFI7cenFHphMtouPVlKTyEQk8bigHL5r6ljLewWWMSp+ai6PS0RECjfJZ9rDwKj0IwGmqq+1H6xjPnbJUQ==",
       "requires": {
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-kms": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-kms": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-secretsmanager": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-0.33.0.tgz",
-      "integrity": "sha512-zmdo3t2WubaKG/KH2hJr9tYqrVVQMYGC2YbX2r6fpzjRD2LvC8PCbUlySvK5JL3RYUhS9IY4nA232QrfFD8ZIg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-0.34.0.tgz",
+      "integrity": "sha512-2dUlGx5ulEjGMSBfJHoBGsI9NAz1kDfGkolFsJVmkVc9bDXt0Co3D976FTcVWraOYj5BnPPDLTwBnWQGaItp5Q==",
       "requires": {
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-kms": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-kms": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-servicediscovery": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-0.33.0.tgz",
-      "integrity": "sha512-jSDucjj5OX+n7HEsAwnH3wldo3iGaymLv0BSC1UreWpGHyAwntABtvvFy1EZP6PGhbgqvrlbGg7f/HutogHfyQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-0.34.0.tgz",
+      "integrity": "sha512-qOdkH3w94ZEqvdHh7t8plJrHa2ei4brZJOMWWVhJMjhnRJtdc8YTxXfxm0SSp5Y7oA6UvtmiFXV3oT1/yTynEg==",
       "requires": {
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "^0.33.0",
-        "@aws-cdk/aws-route53": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.34.0",
+        "@aws-cdk/aws-route53": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-sns": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-0.33.0.tgz",
-      "integrity": "sha512-Y4d3hMyakoVDP2SI30tavf1YFT43g35rCSjUxaNKueBeYMVeGpRgFKnprO/W1xkrz/KzFbg0/ZKzqO3P3wgQwg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-0.34.0.tgz",
+      "integrity": "sha512-p+Gk2Qa20irXlvP4k9xWrJslIcJsylD6IBPioLDJk17ZfOvMWqUEqUwAhM7Wvlk86JQ7tkwu2QVMohnbb9kCvA==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-sqs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-sqs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-sqs": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-0.33.0.tgz",
-      "integrity": "sha512-Rq53Vk0qdd74Vik9RWwuQY4Q11ZNgMYJaxT2pa2wJctnZRNIrwFB4vqeLxf7vvHEyI67ZskLptGt6rVvnkmF8Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-0.34.0.tgz",
+      "integrity": "sha512-hvBRlKIo6tIhSXhL9yR4O3OcocvkTB4cgCncIgmBo7SktUz6l8t9CpskOyIZP7ARP4jybk+uleHQ+RLjHtPJnA==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-kms": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-kms": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/cdk": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cdk/-/cdk-0.33.0.tgz",
-      "integrity": "sha512-ARfTC6ZTg1r2FOWntYo4kZ3S/Fju2vAagQavll56BJ3EPCxfYbPnIAWu3oFiSzg/4XQ345tbAZP1GSVZsF4RJw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cdk/-/cdk-0.34.0.tgz",
+      "integrity": "sha512-zir7bamhQcsJB2c1kBUHa3KhIAiHRpwv6UCPWXTCyzrc85M8JMXl2UQgcayq4dwJk5Tmeh4BMwQyYmz7Bf35wQ==",
       "requires": {
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/cx-api": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-0.33.0.tgz",
-      "integrity": "sha512-PvPO1quhrezUyYtyi3kEq4CHjmg5TccWQrU4khmTrP9bmb7sNKCmR7ish1VHcA2FBaNjtAj0PgdA+2/+Q+Pzrw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-0.34.0.tgz",
+      "integrity": "sha512-0k+CHsAs5zIOin80r95iKG87moa7PuP8eWlBkjNS4r1CjMc5G45MOWbq/iOk+p+155y7fPqTbl3lPCwgek1doA==",
       "requires": {
-        "semver": "^6.0.0"
+        "semver": "^6.1.1"
       },
       "dependencies": {
         "semver": {
-          "version": "6.1.0",
+          "version": "6.1.1",
           "bundled": true
         }
       }
     },
     "@aws-cdk/region-info": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-0.33.0.tgz",
-      "integrity": "sha512-Sy0gXDqzGNuOYAF7edd5rlY3iChVSfjaaZ+bONyClF7gulkYv4jehYkQ1ShATl8XsVRedtCOwSU+mDo/tu8npA=="
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-0.34.0.tgz",
+      "integrity": "sha512-XIm/Mh5LZpsknmrBU6U27Ov/+t7UL+d9GntY7A+lr5DIPOmrFZYlXGsL2C3fLMQAlvUciLFvTrfp2GBbytnnrg=="
     },
     "@types/node": {
       "version": "8.10.49",

--- a/typescript/ecs/ecs-service-with-task-networking/index.ts
+++ b/typescript/ecs/ecs-service-with-task-networking/index.ts
@@ -47,4 +47,4 @@ new ecs.Ec2Service(stack, 'awsvpc-ecs-demo-service', {
   securityGroup,
 });
 
-app.run();
+app.synth();

--- a/typescript/ecs/ecs-service-with-task-placement/index.ts
+++ b/typescript/ecs/ecs-service-with-task-placement/index.ts
@@ -40,4 +40,4 @@ const service = new ecs.Ec2Service(stack, "Service", {
 service.placePackedBy(ecs.BinPackResource.Memory);
 service.placeSpreadAcross(ecs.BuiltInAttributes.AvailabilityZone);
 
-app.run();
+app.synth();

--- a/typescript/ecs/fargate-load-balanced-service/index.ts
+++ b/typescript/ecs/fargate-load-balanced-service/index.ts
@@ -27,4 +27,4 @@ const app = new cdk.App();
 
 new BonjourFargate(app, 'Bonjour');
 
-app.run();
+app.synth();

--- a/typescript/ecs/fargate-service-with-auto-scaling/index.ts
+++ b/typescript/ecs/fargate-service-with-auto-scaling/index.ts
@@ -33,4 +33,4 @@ const app = new cdk.App();
 
 new AutoScalingFargateService(app, 'aws-fargate-application-autoscaling');
 
-app.run();
+app.synth();

--- a/typescript/ecs/fargate-service-with-auto-scaling/package-lock.json
+++ b/typescript/ecs/fargate-service-with-auto-scaling/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "@aws-cdk/assets": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-0.33.0.tgz",
-      "integrity": "sha512-igv2d1Yl5II2lGAQdgBMVG9GDtN713QKpCc4GIvGoi+Ucz+pZ70AbUOCZhIQC3dZf1Thh4YFtVzBHmTIgl5M1A==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-0.34.0.tgz",
+      "integrity": "sha512-nXAAFb6EKhdVcNseZQnjiYYrpzbJu8tVCfSJiIbi6WjYw+7jygexj7YkrZY1jRnCHUIqWcGD2LeCUx/k8yY4aQ==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0",
         "minimatch": "^3.0.4"
       },
       "dependencies": {
@@ -42,94 +42,94 @@
       }
     },
     "@aws-cdk/assets-docker": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets-docker/-/assets-docker-0.33.0.tgz",
-      "integrity": "sha512-cwbKyAGXzYBWMToDZ8TBWOkK0lTtaCDsSnhJUXMrtNg7vleQz/Zl0CPEase2SOfNRax9EZheKThE/OdMFJLSyg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets-docker/-/assets-docker-0.34.0.tgz",
+      "integrity": "sha512-SMuDqZtr8eirZsUXG8gskteXRXLJ5Jsb1us5pg8NtVPzF1drgu2iW/E8YlSP1QBZF20nqLfjMm7C1cEy/NxPHg==",
       "requires": {
-        "@aws-cdk/assets": "^0.33.0",
-        "@aws-cdk/aws-cloudformation": "^0.33.0",
-        "@aws-cdk/aws-ecr": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/assets": "^0.34.0",
+        "@aws-cdk/aws-cloudformation": "^0.34.0",
+        "@aws-cdk/aws-ecr": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-applicationautoscaling": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-0.33.0.tgz",
-      "integrity": "sha512-zzmKvL2XFdjqp1ZYE/2KGPtKApId0LltZHSZKzVlUWJYQA4qCxqoMX8bh1sSJ7wzZRX58FGwsecK74rTNZndmQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-0.34.0.tgz",
+      "integrity": "sha512-XjZJHGDEW77l6kFAPuId8unr6FYX0E0d/qUq7BmjQEbdW/3ljSlZeDQb5sObvHjR7eTpyhaNzLEfePM6A3x2fw==",
       "requires": {
-        "@aws-cdk/aws-autoscaling-common": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-autoscaling-common": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-autoscaling": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling/-/aws-autoscaling-0.33.0.tgz",
-      "integrity": "sha512-ZgclpQvAj4mYo+7Sj/IAGMVvADXuJyV1JP1sjiXMhGWqibtrBYetgpD0yUEOVM9f6MiEGU+/D2PpaPkt7+1ubg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling/-/aws-autoscaling-0.34.0.tgz",
+      "integrity": "sha512-B+JXGjBm9hwbm4GAe0nmGvrrNGkjNdF9UvMqk1O4cXYr7gabIOcbemWGU3i7sLYUEvcjEgQYA8s9KsxIhlp99w==",
       "requires": {
-        "@aws-cdk/aws-autoscaling-common": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancing": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-sns": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-autoscaling-common": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancing": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-sns": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-autoscaling-common": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-0.33.0.tgz",
-      "integrity": "sha512-fdY3JcG7kLo6qNltQZWwBoyZF3pKDhLILuJQ94V86pHWTfntiucM4jgJBbU+gEzYDtmCUkYEIeorFIxYIBq/6A==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-0.34.0.tgz",
+      "integrity": "sha512-HmYDOACF1o3vR01IHgkY0BfXnZIFUCY8epBUUowYD5zbtqG2Cne/6TGaw9m7hBXJnuQmyGhvlPmtV+nW/aGnLQ==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-autoscaling-hooktargets": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-0.33.0.tgz",
-      "integrity": "sha512-mlUQsNt0zV9F2EepqQl9jJdren5ZV3ackpb9BCTvpvbD9PLNSMcDQ8s063M94E77xV+g40bsWPTWlYh9wA4fGQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-0.34.0.tgz",
+      "integrity": "sha512-JSnA4Fk+9olF2Gx6JgKqfjwevt6q2Xku01c1k7zI9Z53Jru2RZ/sG56jAYZarbB0YH9mJy6sOqzWOu9s5EPnwA==",
       "requires": {
-        "@aws-cdk/aws-autoscaling": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-sns": "^0.33.0",
-        "@aws-cdk/aws-sqs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-autoscaling": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-sns": "^0.34.0",
+        "@aws-cdk/aws-sqs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-certificatemanager": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-0.33.0.tgz",
-      "integrity": "sha512-KfKTHAX3o1wbmDsGLw23WBYv/cjtF8pbiQnISK1kDdVrfzM2LJUqzw09RtjBN56CFQ4Dpxn+3Yf9UJWvoAKGxA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-0.34.0.tgz",
+      "integrity": "sha512-tp0w0ifzlUPkaAYR9dJJZ8iwxgqucrRHXK5HoG5PY8WcBH1xSAIm6MtfP5R7Dh9s5hUwg1hz8wygEerN90SrzA==",
       "requires": {
-        "@aws-cdk/aws-cloudformation": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-route53": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudformation": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-route53": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-cloudformation": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-0.33.0.tgz",
-      "integrity": "sha512-x43Ynmz6s/7GnWpmdUZAsg0uK2bQVJxDezVeP6fTPmnXabC0ZB38/tiB7BCafOwRcKAZTeKVWQLX0+nEKmXaBw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-0.34.0.tgz",
+      "integrity": "sha512-F9W53h4Ho//2YrdEgBj7JIXbYo/LT7V2FL33SK9guBHAxYVWWNipFcu/rvuZtKm/8te7F102b9RZGE42yfjKIg==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-sns": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-sns": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
         "aws-sdk": "^2.409.0"
       },
       "dependencies": {
         "aws-sdk": {
-          "version": "2.409.0",
+          "version": "2.469.0",
           "bundled": true,
           "requires": {
             "buffer": "4.9.1",
@@ -211,346 +211,347 @@
       }
     },
     "@aws-cdk/aws-cloudfront": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-0.33.0.tgz",
-      "integrity": "sha512-xlwQzuNl3iWt3v0ChgvcRsZd0qfs3I05pqIYC4raQ0TeYVEF4YZhZnmsnU0Wy2IsFVajXC13HHYAaQYiunUP7A==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-0.34.0.tgz",
+      "integrity": "sha512-3zRJlKYAl0Z2C5ayyG5QjCPVOyDjf2/cf5NBRI1jznSu5Q+Rloal6NPj9t55MywY/54IeuTEQSy/UbtLSnLeiw==",
       "requires": {
-        "@aws-cdk/aws-certificatemanager": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-kms": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-certificatemanager": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-kms": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-cloudwatch": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-0.33.0.tgz",
-      "integrity": "sha512-TvQCLdBaBoPtmPKSDdkjpKriN2a89P5R2M2ZLHW7nED8BX0pe2rTy4pBdLVHMxRkCf1txwXlLa8IAEhQNq6Ixw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-0.34.0.tgz",
+      "integrity": "sha512-w8xWg4wA11g7MS/Cn5CFKv3R9egtsQbGSruoROLpLzI2HY5/MpZ0Is8Nnv2acTKY2unoCIexVo9Ee666NgTVdg==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-codebuild": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codebuild/-/aws-codebuild-0.33.0.tgz",
-      "integrity": "sha512-R5qvLklGcfLU+XYNeyJDrgILtSkwI2/mlE1Y0O+m5lwC4rNEUl35G8maIlhCOhny6wAZ8FHZ6L8KauGHp7H+oA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codebuild/-/aws-codebuild-0.34.0.tgz",
+      "integrity": "sha512-uTwF0EllR5sCD5jTWx8m/tnbNxKlJzkHoCrKT0posRqqoC5Z/m1TCmV2/g+LJGQrxWnGdRhSRdASf7ZR41/eww==",
       "requires": {
-        "@aws-cdk/assets": "^0.33.0",
-        "@aws-cdk/assets-docker": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-codecommit": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-ecr": "^0.33.0",
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-kms": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/assets": "^0.34.0",
+        "@aws-cdk/assets-docker": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-codecommit": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-ecr": "^0.34.0",
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-kms": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-codecommit": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codecommit/-/aws-codecommit-0.33.0.tgz",
-      "integrity": "sha512-o+EsvwNQIHwId6oeRaTHOEN6IK79GuJExUWYiUH4EkJRgX/a/9OhkPuMXECHEZwEZAeHibYG6TntObk6c6hIag==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codecommit/-/aws-codecommit-0.34.0.tgz",
+      "integrity": "sha512-jJwZrnDKhXbNAZd0tvMVw6b2lpxkj3e7d9kJetvKEjfiJwg/+37MYFkR1bAbg8Mb8N1j2f1D4N4nD3ej8RTxEw==",
       "requires": {
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-codepipeline": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline/-/aws-codepipeline-0.33.0.tgz",
-      "integrity": "sha512-+FK4RUKtV8oDdJwMyxdquwSkUbcxEM+EMxgvRKx5ZfUdudIWEQvkUiY7+dxYbC2jDKGqZZu1RgpLOmWj6S0/mw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline/-/aws-codepipeline-0.34.0.tgz",
+      "integrity": "sha512-/vmuKSGjv1ObqTlAet9Y6bl4Ykmt9oukeEvjLT6itbjqCMlULKDis1xAJ0sFnReC6GWaYnjsjo8K24Ejms4SHg==",
       "requires": {
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-kms": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-kms": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-ec2": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-0.33.0.tgz",
-      "integrity": "sha512-JNbYU9WGwgW+J+bEH8LOk5wdN95j/bqhoPuktM6cd9cNs9J7uI+a2dXYLoelA+axYXgXMYRfmK0rjGNOUo1WDg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-0.34.0.tgz",
+      "integrity": "sha512-7LU3V8b00k8TXNT4j/WnC0qpAGk9LVvoRd0UgKJzrGTN6Cah0lnM5MpMirwfr0KwKeFL83NwgsCZwMJdV2hHNw==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-ecr": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-0.33.0.tgz",
-      "integrity": "sha512-gz51Ysvn6C0jDw0ZbvFAiX4HTqBRR+VjX+HbBG4kTMd8fOysW4ELQk+iCYrRBqsBjfHKgCEG9Kw/C/vyUdidVw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-0.34.0.tgz",
+      "integrity": "sha512-Q70M7NmqUuw9O3s3aO4nHwCkYJ0KWaxzKfz3Ng5AKgd1G9kDmH8kNrGSuQRefdXIkF2St00Zuq2HpnqEMR8l1g==",
       "requires": {
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-ecs": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs/-/aws-ecs-0.33.0.tgz",
-      "integrity": "sha512-tLa5IuNgbvzxvLsW9x7M50U9FTGDN1XEfG6UtOTGHEJvuDi8aHJqTGZp64EGvJF78+8Dsr6oil6cWK8TR+sO6Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs/-/aws-ecs-0.34.0.tgz",
+      "integrity": "sha512-UR8O509P4zjwrVA6IS4eednmUcbUVwvpTnyG2T76pHQ28StVXcGr9zBDO+l1iHSP83hrklAM+1uwaw9GgEj4gA==",
       "requires": {
-        "@aws-cdk/assets-docker": "^0.33.0",
-        "@aws-cdk/aws-applicationautoscaling": "^0.33.0",
-        "@aws-cdk/aws-autoscaling": "^0.33.0",
-        "@aws-cdk/aws-autoscaling-hooktargets": "^0.33.0",
-        "@aws-cdk/aws-certificatemanager": "^0.33.0",
-        "@aws-cdk/aws-cloudformation": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-ecr": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancing": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-logs": "^0.33.0",
-        "@aws-cdk/aws-route53": "^0.33.0",
-        "@aws-cdk/aws-route53-targets": "^0.33.0",
-        "@aws-cdk/aws-secretsmanager": "^0.33.0",
-        "@aws-cdk/aws-servicediscovery": "^0.33.0",
-        "@aws-cdk/aws-sns": "^0.33.0",
-        "@aws-cdk/aws-sqs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/assets-docker": "^0.34.0",
+        "@aws-cdk/aws-applicationautoscaling": "^0.34.0",
+        "@aws-cdk/aws-autoscaling": "^0.34.0",
+        "@aws-cdk/aws-autoscaling-hooktargets": "^0.34.0",
+        "@aws-cdk/aws-certificatemanager": "^0.34.0",
+        "@aws-cdk/aws-cloudformation": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-ecr": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancing": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-logs": "^0.34.0",
+        "@aws-cdk/aws-route53": "^0.34.0",
+        "@aws-cdk/aws-route53-targets": "^0.34.0",
+        "@aws-cdk/aws-secretsmanager": "^0.34.0",
+        "@aws-cdk/aws-servicediscovery": "^0.34.0",
+        "@aws-cdk/aws-sns": "^0.34.0",
+        "@aws-cdk/aws-sqs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-ecs-patterns": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs-patterns/-/aws-ecs-patterns-0.33.0.tgz",
-      "integrity": "sha512-w44avkLsor7YZUS8hkhtJ1Wb5Zw3hhkBdCzUWNo75hl3yj5yCoUMPBXI2V++E85qfBiPbs7hgVl+6T1pzaE7lg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs-patterns/-/aws-ecs-patterns-0.34.0.tgz",
+      "integrity": "sha512-g5wkQBN65zyxenpuuAEmtIb4AjLSZxIxPR2kyWYqKhzRccRsIc9yNi6EJ0wwaZO66d7rUFNwWfWLgUfCfLqZnw==",
       "requires": {
-        "@aws-cdk/aws-applicationautoscaling": "^0.33.0",
-        "@aws-cdk/aws-certificatemanager": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-ecs": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "^0.33.0",
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-events-targets": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-route53": "^0.33.0",
-        "@aws-cdk/aws-route53-targets": "^0.33.0",
-        "@aws-cdk/aws-sqs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-applicationautoscaling": "^0.34.0",
+        "@aws-cdk/aws-certificatemanager": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-ecs": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.34.0",
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-events-targets": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-route53": "^0.34.0",
+        "@aws-cdk/aws-route53-targets": "^0.34.0",
+        "@aws-cdk/aws-sqs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-elasticloadbalancing": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-0.33.0.tgz",
-      "integrity": "sha512-07KB62CtvgrOpoKJdy51CMiwQHp+BQ1gsXmbomM1lDwPDn0ysNo/J3RjKpaAAAREpb9+GGlYGmbDiDA2xVFEuw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-0.34.0.tgz",
+      "integrity": "sha512-gUwOSuoHU4VR8DDIY+X+nRLVvZGGE9vJQH/f9iU5GuIoJGGLuYBpSGum8BP9wrjVfDjf9qHzadxINAaz4CoEKg==",
       "requires": {
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-elasticloadbalancingv2": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-0.33.0.tgz",
-      "integrity": "sha512-LNH8nppUxAcY+Mj0AF3uLn0ZhGql868RYr2BjxdsNpijFBN2sMzpKRxJUvQ1YBlPgrbn2U6Y5Ye1LAr8PchfRg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-0.34.0.tgz",
+      "integrity": "sha512-ImYrubUmxcxpAqChmxjJx4K8QQ3rWyhQrwnzMHQLSt9zQGoLV4SIiDC8LGpIJ/fYI7xKIj0cFUs2MLpxcTifvQ==",
       "requires": {
-        "@aws-cdk/aws-certificatemanager": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-certificatemanager": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-events": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-0.33.0.tgz",
-      "integrity": "sha512-mOoMqhw6YzR5Ly0+SdXqJOlTvlAB/+eTmJkhh/DRBOrDVdwVidDytUTCkmcKJcfzir9OqGUvuANdj8zPD4glQA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-0.34.0.tgz",
+      "integrity": "sha512-UeR9J/VeMN42LSfZvgwjGgl+JsPYl7ah3JLYBKBfxFf7Cee3oWPooJdjtzzmHIBsNkUybK8UJ5rFOxIP+o1sGg==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-events-targets": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events-targets/-/aws-events-targets-0.33.0.tgz",
-      "integrity": "sha512-17bu+DnXneOA2v0TbPC37kpkV3SQh7tQCWs7uKjHyCL9XRl+sniZIai6k5SKIuNehGOpocfxQkpIBynED2d7NA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events-targets/-/aws-events-targets-0.34.0.tgz",
+      "integrity": "sha512-3EZjRT81WgTaMHjxQOcoqKFHZML0uBD2lIEG9K4XTr1Q2UAnjFxZlEvlfYvDRz261T/FK+YQbGjrJmXrTuYhYA==",
       "requires": {
-        "@aws-cdk/aws-codebuild": "^0.33.0",
-        "@aws-cdk/aws-codepipeline": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-ecs": "^0.33.0",
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-sns": "^0.33.0",
-        "@aws-cdk/aws-stepfunctions": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudformation": "^0.34.0",
+        "@aws-cdk/aws-codebuild": "^0.34.0",
+        "@aws-cdk/aws-codepipeline": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-ecs": "^0.34.0",
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-sns": "^0.34.0",
+        "@aws-cdk/aws-stepfunctions": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-iam": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-0.33.0.tgz",
-      "integrity": "sha512-d6HVkScJlG3a0rwWO0LgmZCTndze1c2cpoIezJINZ+sXPyMQiWWyFQDVTDC3LxPPUalG9t42gr2139d2zbfX6w==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-0.34.0.tgz",
+      "integrity": "sha512-C/cCuh7O+UdFUtClzqFRkiO+Tb/8xHRMMM1f6trQJf2BqbJY2TYHBAc47CwJTjhA+1zb1hTW6axNDTFkv+NoZg==",
       "requires": {
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/region-info": "^0.33.0"
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/region-info": "^0.34.0"
       }
     },
     "@aws-cdk/aws-kms": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-0.33.0.tgz",
-      "integrity": "sha512-Yj1i/kqcpLu4LMIfIrk8F1Znereh7kL05+j7Ho0gy+HjwMbODIxB0BcyTiJ/5CjHkJPsR8Tl2GPyerZ6OGk/Dw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-0.34.0.tgz",
+      "integrity": "sha512-p4UMsql0IbGgtbNkrYHlqoq6ne7dqKjIt4Xf3qGCWDAGiXWSlYntFHh6UBzKR0RzW6r0GODttSmypFolLkNUFw==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-lambda": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-0.33.0.tgz",
-      "integrity": "sha512-79q1ZGyNc6hWbZGJkzPs2lxK3/M8o6j7R5m3XZsKE/5KYTEdjM9oJdbWU32PaZ7QXaYDaMOdAR1arzekIG86bw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-0.34.0.tgz",
+      "integrity": "sha512-llndnoPan/uDAoamQzxC5FCzV7nLIkKeBiVHMCo+aokiJsIaDvxmaLpY6PxVvqo+bw5mP/fQeivDOenvAOYlcA==",
       "requires": {
-        "@aws-cdk/assets": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-logs": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/aws-sqs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/assets": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-logs": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/aws-sqs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-logs": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-0.33.0.tgz",
-      "integrity": "sha512-/VPZeb2eyB5uJbKteaM8QFy21Y2s7hsglAJFdWOWtEvQA5snOeJu8kVcsWm+UaYKG6Y+Ix3F5N+KRiyDlrqZFw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-0.34.0.tgz",
+      "integrity": "sha512-A2SPBYBYgLv7BacCxHmFMwFuCxZKe4TRE+M7mDplng6S6Fmq803neyCTPrOgznSGzJYFtfDoacFULuAXJ2hanQ==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-route53": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-0.33.0.tgz",
-      "integrity": "sha512-A+CJL0WSXPkftOWiryjXqumL4ZrqVC5Mc1lIxG8Ks4e/0G/sutlCbsoj2FaDq/reJvO/tQ99PeRgjFoN/FIPBg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-0.34.0.tgz",
+      "integrity": "sha512-jf8SF4wppJsRPCoVmvd6/votGxlbibDqlGP26IGLztIurAZ3ddxdXLHobDIaj1Y+/+8O6FnpFclmO2LNtGXL2g==",
       "requires": {
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-logs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-logs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-route53-targets": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-0.33.0.tgz",
-      "integrity": "sha512-rgCMpEBMoIG6ITo7pz/E0ZSft4NAbt3JunO88b5x/wEpSskQoweUNDN4MyFLxOGUbssyw1ZWZzHODqbhxuGB6g==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-0.34.0.tgz",
+      "integrity": "sha512-ORDUa13KnbkBW1w+SGogZ1IvtitiBaoZX7gvwfkgDIfGwvuFi8cojVqd2CuOVfcjbXcUHe+Ul67ezC0A7NjznA==",
       "requires": {
-        "@aws-cdk/aws-cloudfront": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-route53": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudfront": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-route53": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-s3": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-0.33.0.tgz",
-      "integrity": "sha512-9HWVrlzup8o9GbpjPxX9YKtiRj034pVf+MteVWkiRccVy07BGL8i4d/dpCJDiNsOxaFH4qXCrgdbpUzq/tIcyw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-0.34.0.tgz",
+      "integrity": "sha512-TT1eQFI7cenFHphMtouPVlKTyEQk8bigHL5r6ljLewWWMSp+ai6PS0RECjfJZ9rDwKj0IwGmqq+1H6xjPnbJUQ==",
       "requires": {
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-kms": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-kms": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-secretsmanager": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-0.33.0.tgz",
-      "integrity": "sha512-zmdo3t2WubaKG/KH2hJr9tYqrVVQMYGC2YbX2r6fpzjRD2LvC8PCbUlySvK5JL3RYUhS9IY4nA232QrfFD8ZIg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-0.34.0.tgz",
+      "integrity": "sha512-2dUlGx5ulEjGMSBfJHoBGsI9NAz1kDfGkolFsJVmkVc9bDXt0Co3D976FTcVWraOYj5BnPPDLTwBnWQGaItp5Q==",
       "requires": {
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-kms": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-kms": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-servicediscovery": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-0.33.0.tgz",
-      "integrity": "sha512-jSDucjj5OX+n7HEsAwnH3wldo3iGaymLv0BSC1UreWpGHyAwntABtvvFy1EZP6PGhbgqvrlbGg7f/HutogHfyQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-0.34.0.tgz",
+      "integrity": "sha512-qOdkH3w94ZEqvdHh7t8plJrHa2ei4brZJOMWWVhJMjhnRJtdc8YTxXfxm0SSp5Y7oA6UvtmiFXV3oT1/yTynEg==",
       "requires": {
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "^0.33.0",
-        "@aws-cdk/aws-route53": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.34.0",
+        "@aws-cdk/aws-route53": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-sns": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-0.33.0.tgz",
-      "integrity": "sha512-Y4d3hMyakoVDP2SI30tavf1YFT43g35rCSjUxaNKueBeYMVeGpRgFKnprO/W1xkrz/KzFbg0/ZKzqO3P3wgQwg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-0.34.0.tgz",
+      "integrity": "sha512-p+Gk2Qa20irXlvP4k9xWrJslIcJsylD6IBPioLDJk17ZfOvMWqUEqUwAhM7Wvlk86JQ7tkwu2QVMohnbb9kCvA==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-sqs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-sqs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-sqs": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-0.33.0.tgz",
-      "integrity": "sha512-Rq53Vk0qdd74Vik9RWwuQY4Q11ZNgMYJaxT2pa2wJctnZRNIrwFB4vqeLxf7vvHEyI67ZskLptGt6rVvnkmF8Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-0.34.0.tgz",
+      "integrity": "sha512-hvBRlKIo6tIhSXhL9yR4O3OcocvkTB4cgCncIgmBo7SktUz6l8t9CpskOyIZP7ARP4jybk+uleHQ+RLjHtPJnA==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-kms": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-kms": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-stepfunctions": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-0.33.0.tgz",
-      "integrity": "sha512-FeMcSmm0SCV+hnWOfti3D356HvppUv6wYPL3Q+17VWJGxSJS8VJeBITV7ZZ3YFLENErshQmUIvG37003wDZJbA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-0.34.0.tgz",
+      "integrity": "sha512-3cBf8vI3OkZZV+7dOLOom7whj1/nfb6zqEHSc6eISKM0k7u2NNSlZ4qUb5a6MMViiavMxOK4ojko6V6oq4RDEw==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/cdk": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cdk/-/cdk-0.33.0.tgz",
-      "integrity": "sha512-ARfTC6ZTg1r2FOWntYo4kZ3S/Fju2vAagQavll56BJ3EPCxfYbPnIAWu3oFiSzg/4XQ345tbAZP1GSVZsF4RJw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cdk/-/cdk-0.34.0.tgz",
+      "integrity": "sha512-zir7bamhQcsJB2c1kBUHa3KhIAiHRpwv6UCPWXTCyzrc85M8JMXl2UQgcayq4dwJk5Tmeh4BMwQyYmz7Bf35wQ==",
       "requires": {
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/cx-api": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-0.33.0.tgz",
-      "integrity": "sha512-PvPO1quhrezUyYtyi3kEq4CHjmg5TccWQrU4khmTrP9bmb7sNKCmR7ish1VHcA2FBaNjtAj0PgdA+2/+Q+Pzrw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-0.34.0.tgz",
+      "integrity": "sha512-0k+CHsAs5zIOin80r95iKG87moa7PuP8eWlBkjNS4r1CjMc5G45MOWbq/iOk+p+155y7fPqTbl3lPCwgek1doA==",
       "requires": {
-        "semver": "^6.0.0"
+        "semver": "^6.1.1"
       },
       "dependencies": {
         "semver": {
-          "version": "6.1.0",
+          "version": "6.1.1",
           "bundled": true
         }
       }
     },
     "@aws-cdk/region-info": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-0.33.0.tgz",
-      "integrity": "sha512-Sy0gXDqzGNuOYAF7edd5rlY3iChVSfjaaZ+bONyClF7gulkYv4jehYkQ1ShATl8XsVRedtCOwSU+mDo/tu8npA=="
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-0.34.0.tgz",
+      "integrity": "sha512-XIm/Mh5LZpsknmrBU6U27Ov/+t7UL+d9GntY7A+lr5DIPOmrFZYlXGsL2C3fLMQAlvUciLFvTrfp2GBbytnnrg=="
     },
     "@types/node": {
       "version": "8.10.49",

--- a/typescript/ecs/fargate-service-with-local-image/index.ts
+++ b/typescript/ecs/fargate-service-with-local-image/index.ts
@@ -23,4 +23,4 @@ new ecs_patterns.LoadBalancedFargateService(stack, "FargateService", {
   })
 });
 
-app.run();
+app.synth();

--- a/typescript/ecs/fargate-service-with-local-image/local-image/app.py
+++ b/typescript/ecs/fargate-service-with-local-image/local-image/app.py
@@ -11,5 +11,5 @@ def hello():
     return html.format(name=os.getenv("NAME", "world"), hostname=socket.gethostname())
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0', port=80)
+    app.synth()(host='0.0.0.0', port=80)
 

--- a/typescript/ecs/fargate-service-with-logging/index.ts
+++ b/typescript/ecs/fargate-service-with-logging/index.ts
@@ -35,4 +35,4 @@ const app = new cdk.App();
 
 new WillkommenFargate(app, 'Willkommen');
 
-app.run();
+app.synth();

--- a/typescript/ecs/fargate-service-with-logging/package-lock.json
+++ b/typescript/ecs/fargate-service-with-logging/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "@aws-cdk/assets": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-0.33.0.tgz",
-      "integrity": "sha512-igv2d1Yl5II2lGAQdgBMVG9GDtN713QKpCc4GIvGoi+Ucz+pZ70AbUOCZhIQC3dZf1Thh4YFtVzBHmTIgl5M1A==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-0.34.0.tgz",
+      "integrity": "sha512-nXAAFb6EKhdVcNseZQnjiYYrpzbJu8tVCfSJiIbi6WjYw+7jygexj7YkrZY1jRnCHUIqWcGD2LeCUx/k8yY4aQ==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0",
         "minimatch": "^3.0.4"
       },
       "dependencies": {
@@ -42,94 +42,94 @@
       }
     },
     "@aws-cdk/assets-docker": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/assets-docker/-/assets-docker-0.33.0.tgz",
-      "integrity": "sha512-cwbKyAGXzYBWMToDZ8TBWOkK0lTtaCDsSnhJUXMrtNg7vleQz/Zl0CPEase2SOfNRax9EZheKThE/OdMFJLSyg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets-docker/-/assets-docker-0.34.0.tgz",
+      "integrity": "sha512-SMuDqZtr8eirZsUXG8gskteXRXLJ5Jsb1us5pg8NtVPzF1drgu2iW/E8YlSP1QBZF20nqLfjMm7C1cEy/NxPHg==",
       "requires": {
-        "@aws-cdk/assets": "^0.33.0",
-        "@aws-cdk/aws-cloudformation": "^0.33.0",
-        "@aws-cdk/aws-ecr": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/assets": "^0.34.0",
+        "@aws-cdk/aws-cloudformation": "^0.34.0",
+        "@aws-cdk/aws-ecr": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-applicationautoscaling": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-0.33.0.tgz",
-      "integrity": "sha512-zzmKvL2XFdjqp1ZYE/2KGPtKApId0LltZHSZKzVlUWJYQA4qCxqoMX8bh1sSJ7wzZRX58FGwsecK74rTNZndmQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-0.34.0.tgz",
+      "integrity": "sha512-XjZJHGDEW77l6kFAPuId8unr6FYX0E0d/qUq7BmjQEbdW/3ljSlZeDQb5sObvHjR7eTpyhaNzLEfePM6A3x2fw==",
       "requires": {
-        "@aws-cdk/aws-autoscaling-common": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-autoscaling-common": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-autoscaling": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling/-/aws-autoscaling-0.33.0.tgz",
-      "integrity": "sha512-ZgclpQvAj4mYo+7Sj/IAGMVvADXuJyV1JP1sjiXMhGWqibtrBYetgpD0yUEOVM9f6MiEGU+/D2PpaPkt7+1ubg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling/-/aws-autoscaling-0.34.0.tgz",
+      "integrity": "sha512-B+JXGjBm9hwbm4GAe0nmGvrrNGkjNdF9UvMqk1O4cXYr7gabIOcbemWGU3i7sLYUEvcjEgQYA8s9KsxIhlp99w==",
       "requires": {
-        "@aws-cdk/aws-autoscaling-common": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancing": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-sns": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-autoscaling-common": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancing": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-sns": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-autoscaling-common": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-0.33.0.tgz",
-      "integrity": "sha512-fdY3JcG7kLo6qNltQZWwBoyZF3pKDhLILuJQ94V86pHWTfntiucM4jgJBbU+gEzYDtmCUkYEIeorFIxYIBq/6A==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-0.34.0.tgz",
+      "integrity": "sha512-HmYDOACF1o3vR01IHgkY0BfXnZIFUCY8epBUUowYD5zbtqG2Cne/6TGaw9m7hBXJnuQmyGhvlPmtV+nW/aGnLQ==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-autoscaling-hooktargets": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-0.33.0.tgz",
-      "integrity": "sha512-mlUQsNt0zV9F2EepqQl9jJdren5ZV3ackpb9BCTvpvbD9PLNSMcDQ8s063M94E77xV+g40bsWPTWlYh9wA4fGQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-0.34.0.tgz",
+      "integrity": "sha512-JSnA4Fk+9olF2Gx6JgKqfjwevt6q2Xku01c1k7zI9Z53Jru2RZ/sG56jAYZarbB0YH9mJy6sOqzWOu9s5EPnwA==",
       "requires": {
-        "@aws-cdk/aws-autoscaling": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-sns": "^0.33.0",
-        "@aws-cdk/aws-sqs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-autoscaling": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-sns": "^0.34.0",
+        "@aws-cdk/aws-sqs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-certificatemanager": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-0.33.0.tgz",
-      "integrity": "sha512-KfKTHAX3o1wbmDsGLw23WBYv/cjtF8pbiQnISK1kDdVrfzM2LJUqzw09RtjBN56CFQ4Dpxn+3Yf9UJWvoAKGxA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-0.34.0.tgz",
+      "integrity": "sha512-tp0w0ifzlUPkaAYR9dJJZ8iwxgqucrRHXK5HoG5PY8WcBH1xSAIm6MtfP5R7Dh9s5hUwg1hz8wygEerN90SrzA==",
       "requires": {
-        "@aws-cdk/aws-cloudformation": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-route53": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudformation": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-route53": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-cloudformation": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-0.33.0.tgz",
-      "integrity": "sha512-x43Ynmz6s/7GnWpmdUZAsg0uK2bQVJxDezVeP6fTPmnXabC0ZB38/tiB7BCafOwRcKAZTeKVWQLX0+nEKmXaBw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-0.34.0.tgz",
+      "integrity": "sha512-F9W53h4Ho//2YrdEgBj7JIXbYo/LT7V2FL33SK9guBHAxYVWWNipFcu/rvuZtKm/8te7F102b9RZGE42yfjKIg==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-sns": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-sns": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
         "aws-sdk": "^2.409.0"
       },
       "dependencies": {
         "aws-sdk": {
-          "version": "2.409.0",
+          "version": "2.469.0",
           "bundled": true,
           "requires": {
             "buffer": "4.9.1",
@@ -211,259 +211,259 @@
       }
     },
     "@aws-cdk/aws-cloudfront": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-0.33.0.tgz",
-      "integrity": "sha512-xlwQzuNl3iWt3v0ChgvcRsZd0qfs3I05pqIYC4raQ0TeYVEF4YZhZnmsnU0Wy2IsFVajXC13HHYAaQYiunUP7A==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-0.34.0.tgz",
+      "integrity": "sha512-3zRJlKYAl0Z2C5ayyG5QjCPVOyDjf2/cf5NBRI1jznSu5Q+Rloal6NPj9t55MywY/54IeuTEQSy/UbtLSnLeiw==",
       "requires": {
-        "@aws-cdk/aws-certificatemanager": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-kms": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-certificatemanager": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-kms": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-cloudwatch": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-0.33.0.tgz",
-      "integrity": "sha512-TvQCLdBaBoPtmPKSDdkjpKriN2a89P5R2M2ZLHW7nED8BX0pe2rTy4pBdLVHMxRkCf1txwXlLa8IAEhQNq6Ixw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-0.34.0.tgz",
+      "integrity": "sha512-w8xWg4wA11g7MS/Cn5CFKv3R9egtsQbGSruoROLpLzI2HY5/MpZ0Is8Nnv2acTKY2unoCIexVo9Ee666NgTVdg==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-ec2": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-0.33.0.tgz",
-      "integrity": "sha512-JNbYU9WGwgW+J+bEH8LOk5wdN95j/bqhoPuktM6cd9cNs9J7uI+a2dXYLoelA+axYXgXMYRfmK0rjGNOUo1WDg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-0.34.0.tgz",
+      "integrity": "sha512-7LU3V8b00k8TXNT4j/WnC0qpAGk9LVvoRd0UgKJzrGTN6Cah0lnM5MpMirwfr0KwKeFL83NwgsCZwMJdV2hHNw==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-ecr": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-0.33.0.tgz",
-      "integrity": "sha512-gz51Ysvn6C0jDw0ZbvFAiX4HTqBRR+VjX+HbBG4kTMd8fOysW4ELQk+iCYrRBqsBjfHKgCEG9Kw/C/vyUdidVw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-0.34.0.tgz",
+      "integrity": "sha512-Q70M7NmqUuw9O3s3aO4nHwCkYJ0KWaxzKfz3Ng5AKgd1G9kDmH8kNrGSuQRefdXIkF2St00Zuq2HpnqEMR8l1g==",
       "requires": {
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-ecs": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs/-/aws-ecs-0.33.0.tgz",
-      "integrity": "sha512-tLa5IuNgbvzxvLsW9x7M50U9FTGDN1XEfG6UtOTGHEJvuDi8aHJqTGZp64EGvJF78+8Dsr6oil6cWK8TR+sO6Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs/-/aws-ecs-0.34.0.tgz",
+      "integrity": "sha512-UR8O509P4zjwrVA6IS4eednmUcbUVwvpTnyG2T76pHQ28StVXcGr9zBDO+l1iHSP83hrklAM+1uwaw9GgEj4gA==",
       "requires": {
-        "@aws-cdk/assets-docker": "^0.33.0",
-        "@aws-cdk/aws-applicationautoscaling": "^0.33.0",
-        "@aws-cdk/aws-autoscaling": "^0.33.0",
-        "@aws-cdk/aws-autoscaling-hooktargets": "^0.33.0",
-        "@aws-cdk/aws-certificatemanager": "^0.33.0",
-        "@aws-cdk/aws-cloudformation": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-ecr": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancing": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-logs": "^0.33.0",
-        "@aws-cdk/aws-route53": "^0.33.0",
-        "@aws-cdk/aws-route53-targets": "^0.33.0",
-        "@aws-cdk/aws-secretsmanager": "^0.33.0",
-        "@aws-cdk/aws-servicediscovery": "^0.33.0",
-        "@aws-cdk/aws-sns": "^0.33.0",
-        "@aws-cdk/aws-sqs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/assets-docker": "^0.34.0",
+        "@aws-cdk/aws-applicationautoscaling": "^0.34.0",
+        "@aws-cdk/aws-autoscaling": "^0.34.0",
+        "@aws-cdk/aws-autoscaling-hooktargets": "^0.34.0",
+        "@aws-cdk/aws-certificatemanager": "^0.34.0",
+        "@aws-cdk/aws-cloudformation": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-ecr": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancing": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-logs": "^0.34.0",
+        "@aws-cdk/aws-route53": "^0.34.0",
+        "@aws-cdk/aws-route53-targets": "^0.34.0",
+        "@aws-cdk/aws-secretsmanager": "^0.34.0",
+        "@aws-cdk/aws-servicediscovery": "^0.34.0",
+        "@aws-cdk/aws-sns": "^0.34.0",
+        "@aws-cdk/aws-sqs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-elasticloadbalancing": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-0.33.0.tgz",
-      "integrity": "sha512-07KB62CtvgrOpoKJdy51CMiwQHp+BQ1gsXmbomM1lDwPDn0ysNo/J3RjKpaAAAREpb9+GGlYGmbDiDA2xVFEuw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-0.34.0.tgz",
+      "integrity": "sha512-gUwOSuoHU4VR8DDIY+X+nRLVvZGGE9vJQH/f9iU5GuIoJGGLuYBpSGum8BP9wrjVfDjf9qHzadxINAaz4CoEKg==",
       "requires": {
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-elasticloadbalancingv2": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-0.33.0.tgz",
-      "integrity": "sha512-LNH8nppUxAcY+Mj0AF3uLn0ZhGql868RYr2BjxdsNpijFBN2sMzpKRxJUvQ1YBlPgrbn2U6Y5Ye1LAr8PchfRg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-0.34.0.tgz",
+      "integrity": "sha512-ImYrubUmxcxpAqChmxjJx4K8QQ3rWyhQrwnzMHQLSt9zQGoLV4SIiDC8LGpIJ/fYI7xKIj0cFUs2MLpxcTifvQ==",
       "requires": {
-        "@aws-cdk/aws-certificatemanager": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-certificatemanager": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-events": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-0.33.0.tgz",
-      "integrity": "sha512-mOoMqhw6YzR5Ly0+SdXqJOlTvlAB/+eTmJkhh/DRBOrDVdwVidDytUTCkmcKJcfzir9OqGUvuANdj8zPD4glQA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-0.34.0.tgz",
+      "integrity": "sha512-UeR9J/VeMN42LSfZvgwjGgl+JsPYl7ah3JLYBKBfxFf7Cee3oWPooJdjtzzmHIBsNkUybK8UJ5rFOxIP+o1sGg==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-iam": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-0.33.0.tgz",
-      "integrity": "sha512-d6HVkScJlG3a0rwWO0LgmZCTndze1c2cpoIezJINZ+sXPyMQiWWyFQDVTDC3LxPPUalG9t42gr2139d2zbfX6w==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-0.34.0.tgz",
+      "integrity": "sha512-C/cCuh7O+UdFUtClzqFRkiO+Tb/8xHRMMM1f6trQJf2BqbJY2TYHBAc47CwJTjhA+1zb1hTW6axNDTFkv+NoZg==",
       "requires": {
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/region-info": "^0.33.0"
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/region-info": "^0.34.0"
       }
     },
     "@aws-cdk/aws-kms": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-0.33.0.tgz",
-      "integrity": "sha512-Yj1i/kqcpLu4LMIfIrk8F1Znereh7kL05+j7Ho0gy+HjwMbODIxB0BcyTiJ/5CjHkJPsR8Tl2GPyerZ6OGk/Dw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-0.34.0.tgz",
+      "integrity": "sha512-p4UMsql0IbGgtbNkrYHlqoq6ne7dqKjIt4Xf3qGCWDAGiXWSlYntFHh6UBzKR0RzW6r0GODttSmypFolLkNUFw==",
       "requires": {
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-lambda": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-0.33.0.tgz",
-      "integrity": "sha512-79q1ZGyNc6hWbZGJkzPs2lxK3/M8o6j7R5m3XZsKE/5KYTEdjM9oJdbWU32PaZ7QXaYDaMOdAR1arzekIG86bw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-0.34.0.tgz",
+      "integrity": "sha512-llndnoPan/uDAoamQzxC5FCzV7nLIkKeBiVHMCo+aokiJsIaDvxmaLpY6PxVvqo+bw5mP/fQeivDOenvAOYlcA==",
       "requires": {
-        "@aws-cdk/assets": "^0.33.0",
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-logs": "^0.33.0",
-        "@aws-cdk/aws-s3": "^0.33.0",
-        "@aws-cdk/aws-sqs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/assets": "^0.34.0",
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-logs": "^0.34.0",
+        "@aws-cdk/aws-s3": "^0.34.0",
+        "@aws-cdk/aws-sqs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-logs": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-0.33.0.tgz",
-      "integrity": "sha512-/VPZeb2eyB5uJbKteaM8QFy21Y2s7hsglAJFdWOWtEvQA5snOeJu8kVcsWm+UaYKG6Y+Ix3F5N+KRiyDlrqZFw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-0.34.0.tgz",
+      "integrity": "sha512-A2SPBYBYgLv7BacCxHmFMwFuCxZKe4TRE+M7mDplng6S6Fmq803neyCTPrOgznSGzJYFtfDoacFULuAXJ2hanQ==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-route53": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-0.33.0.tgz",
-      "integrity": "sha512-A+CJL0WSXPkftOWiryjXqumL4ZrqVC5Mc1lIxG8Ks4e/0G/sutlCbsoj2FaDq/reJvO/tQ99PeRgjFoN/FIPBg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-0.34.0.tgz",
+      "integrity": "sha512-jf8SF4wppJsRPCoVmvd6/votGxlbibDqlGP26IGLztIurAZ3ddxdXLHobDIaj1Y+/+8O6FnpFclmO2LNtGXL2g==",
       "requires": {
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-logs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0",
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-logs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0",
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/aws-route53-targets": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-0.33.0.tgz",
-      "integrity": "sha512-rgCMpEBMoIG6ITo7pz/E0ZSft4NAbt3JunO88b5x/wEpSskQoweUNDN4MyFLxOGUbssyw1ZWZzHODqbhxuGB6g==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-0.34.0.tgz",
+      "integrity": "sha512-ORDUa13KnbkBW1w+SGogZ1IvtitiBaoZX7gvwfkgDIfGwvuFi8cojVqd2CuOVfcjbXcUHe+Ul67ezC0A7NjznA==",
       "requires": {
-        "@aws-cdk/aws-cloudfront": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-route53": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudfront": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-route53": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-s3": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-0.33.0.tgz",
-      "integrity": "sha512-9HWVrlzup8o9GbpjPxX9YKtiRj034pVf+MteVWkiRccVy07BGL8i4d/dpCJDiNsOxaFH4qXCrgdbpUzq/tIcyw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-0.34.0.tgz",
+      "integrity": "sha512-TT1eQFI7cenFHphMtouPVlKTyEQk8bigHL5r6ljLewWWMSp+ai6PS0RECjfJZ9rDwKj0IwGmqq+1H6xjPnbJUQ==",
       "requires": {
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-kms": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-kms": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-secretsmanager": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-0.33.0.tgz",
-      "integrity": "sha512-zmdo3t2WubaKG/KH2hJr9tYqrVVQMYGC2YbX2r6fpzjRD2LvC8PCbUlySvK5JL3RYUhS9IY4nA232QrfFD8ZIg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-0.34.0.tgz",
+      "integrity": "sha512-2dUlGx5ulEjGMSBfJHoBGsI9NAz1kDfGkolFsJVmkVc9bDXt0Co3D976FTcVWraOYj5BnPPDLTwBnWQGaItp5Q==",
       "requires": {
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-kms": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-kms": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-servicediscovery": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-0.33.0.tgz",
-      "integrity": "sha512-jSDucjj5OX+n7HEsAwnH3wldo3iGaymLv0BSC1UreWpGHyAwntABtvvFy1EZP6PGhbgqvrlbGg7f/HutogHfyQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-0.34.0.tgz",
+      "integrity": "sha512-qOdkH3w94ZEqvdHh7t8plJrHa2ei4brZJOMWWVhJMjhnRJtdc8YTxXfxm0SSp5Y7oA6UvtmiFXV3oT1/yTynEg==",
       "requires": {
-        "@aws-cdk/aws-ec2": "^0.33.0",
-        "@aws-cdk/aws-elasticloadbalancingv2": "^0.33.0",
-        "@aws-cdk/aws-route53": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-ec2": "^0.34.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^0.34.0",
+        "@aws-cdk/aws-route53": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-sns": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-0.33.0.tgz",
-      "integrity": "sha512-Y4d3hMyakoVDP2SI30tavf1YFT43g35rCSjUxaNKueBeYMVeGpRgFKnprO/W1xkrz/KzFbg0/ZKzqO3P3wgQwg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-0.34.0.tgz",
+      "integrity": "sha512-p+Gk2Qa20irXlvP4k9xWrJslIcJsylD6IBPioLDJk17ZfOvMWqUEqUwAhM7Wvlk86JQ7tkwu2QVMohnbb9kCvA==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-events": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-lambda": "^0.33.0",
-        "@aws-cdk/aws-sqs": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-events": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-lambda": "^0.34.0",
+        "@aws-cdk/aws-sqs": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/aws-sqs": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-0.33.0.tgz",
-      "integrity": "sha512-Rq53Vk0qdd74Vik9RWwuQY4Q11ZNgMYJaxT2pa2wJctnZRNIrwFB4vqeLxf7vvHEyI67ZskLptGt6rVvnkmF8Q==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-0.34.0.tgz",
+      "integrity": "sha512-hvBRlKIo6tIhSXhL9yR4O3OcocvkTB4cgCncIgmBo7SktUz6l8t9CpskOyIZP7ARP4jybk+uleHQ+RLjHtPJnA==",
       "requires": {
-        "@aws-cdk/aws-cloudwatch": "^0.33.0",
-        "@aws-cdk/aws-iam": "^0.33.0",
-        "@aws-cdk/aws-kms": "^0.33.0",
-        "@aws-cdk/cdk": "^0.33.0"
+        "@aws-cdk/aws-cloudwatch": "^0.34.0",
+        "@aws-cdk/aws-iam": "^0.34.0",
+        "@aws-cdk/aws-kms": "^0.34.0",
+        "@aws-cdk/cdk": "^0.34.0"
       }
     },
     "@aws-cdk/cdk": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cdk/-/cdk-0.33.0.tgz",
-      "integrity": "sha512-ARfTC6ZTg1r2FOWntYo4kZ3S/Fju2vAagQavll56BJ3EPCxfYbPnIAWu3oFiSzg/4XQ345tbAZP1GSVZsF4RJw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cdk/-/cdk-0.34.0.tgz",
+      "integrity": "sha512-zir7bamhQcsJB2c1kBUHa3KhIAiHRpwv6UCPWXTCyzrc85M8JMXl2UQgcayq4dwJk5Tmeh4BMwQyYmz7Bf35wQ==",
       "requires": {
-        "@aws-cdk/cx-api": "^0.33.0"
+        "@aws-cdk/cx-api": "^0.34.0"
       }
     },
     "@aws-cdk/cx-api": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-0.33.0.tgz",
-      "integrity": "sha512-PvPO1quhrezUyYtyi3kEq4CHjmg5TccWQrU4khmTrP9bmb7sNKCmR7ish1VHcA2FBaNjtAj0PgdA+2/+Q+Pzrw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-0.34.0.tgz",
+      "integrity": "sha512-0k+CHsAs5zIOin80r95iKG87moa7PuP8eWlBkjNS4r1CjMc5G45MOWbq/iOk+p+155y7fPqTbl3lPCwgek1doA==",
       "requires": {
-        "semver": "^6.0.0"
+        "semver": "^6.1.1"
       },
       "dependencies": {
         "semver": {
-          "version": "6.1.0",
+          "version": "6.1.1",
           "bundled": true
         }
       }
     },
     "@aws-cdk/region-info": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-0.33.0.tgz",
-      "integrity": "sha512-Sy0gXDqzGNuOYAF7edd5rlY3iChVSfjaaZ+bONyClF7gulkYv4jehYkQ1ShATl8XsVRedtCOwSU+mDo/tu8npA=="
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-0.34.0.tgz",
+      "integrity": "sha512-XIm/Mh5LZpsknmrBU6U27Ov/+t7UL+d9GntY7A+lr5DIPOmrFZYlXGsL2C3fLMQAlvUciLFvTrfp2GBbytnnrg=="
     },
     "@types/node": {
       "version": "8.10.49",

--- a/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
@@ -12,9 +12,9 @@ export class CdkStack extends cdk.Stack {
     //objects for access parameters
     const node = this.node;
 
-    const blue_env = node.getContext("blue_env");
-    const green_env = node.getContext("green_env");
-    const app_name = node.getContext("app_name");
+    const blue_env = node.tryGetContext("blue_env");
+    const green_env = node.tryGetContext("green_env");
+    const app_name = node.tryGetContext("app_name");
 
     const bucket = new s3.Bucket(this, 'BlueGreenBucket');
 

--- a/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
@@ -76,4 +76,4 @@ const app = new cdk.App();
 
 new CdkStack(app, 'ElasticBeanstalkBG');
 
-app.run();
+app.synth();

--- a/typescript/elasticbeanstalk/elasticbeanstalk-environment/index.ts
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-environment/index.ts
@@ -29,4 +29,4 @@ const app = new cdk.App();
 
 new CdkStack(app, 'ElasticBeanstalk');
 
-app.run();
+app.synth();

--- a/typescript/elasticbeanstalk/elasticbeanstalk-environment/index.ts
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-environment/index.ts
@@ -10,7 +10,7 @@ export class CdkStack extends cdk.Stack {
     //objects for access parameters
     const node = this.node;
 
-    const platform = node.getContext("platform");
+    const platform = node.tryGetContext("platform");
 
 
     const app = new elasticbeanstalk.CfnApplication(this, 'Application', {

--- a/typescript/lambda-cron/index.ts
+++ b/typescript/lambda-cron/index.ts
@@ -28,4 +28,4 @@ export class LambdaCronStack extends cdk.Stack {
 
 const app = new cdk.App();
 new LambdaCronStack(app, 'LambdaCronExample');
-app.run();
+app.synth();

--- a/typescript/my-widget-service/index.ts
+++ b/typescript/my-widget-service/index.ts
@@ -12,4 +12,4 @@ export class MyWidgetServiceStack extends cdk.Stack {
 
 const app = new cdk.App();
 new MyWidgetServiceStack(app, 'MyWidgetServiceStack');
-app.run();
+app.synth();

--- a/typescript/resource-overrides/index.ts
+++ b/typescript/resource-overrides/index.ts
@@ -106,4 +106,4 @@ class ResourceOverridesExample extends cdk.Stack {
 
 const app = new cdk.App();
 new ResourceOverridesExample(app, 'resource-overrides');
-app.run();
+app.synth();

--- a/typescript/static-site/index.ts
+++ b/typescript/static-site/index.ts
@@ -18,8 +18,8 @@ class MyStaticSiteStack extends cdk.Stack {
         super(parent, name, props);
 
         new StaticSite(this, 'StaticSite', {
-            domainName: this.node.getContext('domain'),
-            siteSubDomain: this.node.getContext('subdomain'),
+            domainName: this.node.tryGetContext('domain'),
+            siteSubDomain: this.node.tryGetContext('subdomain'),
         });
    }
 }

--- a/typescript/static-site/index.ts
+++ b/typescript/static-site/index.ts
@@ -28,4 +28,4 @@ const app = new cdk.App();
 
 new MyStaticSiteStack(app, 'MyStaticSite', { env: { region: 'us-east-1' } });
 
-app.run();
+app.synth();

--- a/typescript/static-site/package.json
+++ b/typescript/static-site/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@aws-cdk/aws-cloudfront": "*",
     "@aws-cdk/aws-route53": "*",
+    "@aws-cdk/aws-route53-targets": "^0.34.0",
     "@aws-cdk/aws-s3": "*",
     "@aws-cdk/aws-ssm": "*",
     "@aws-cdk/cdk": "*"

--- a/typescript/static-site/static-site.ts
+++ b/typescript/static-site/static-site.ts
@@ -4,6 +4,7 @@ import route53 = require('@aws-cdk/aws-route53');
 import s3 = require('@aws-cdk/aws-s3');
 import ssm = require('@aws-cdk/aws-ssm');
 import cdk = require('@aws-cdk/cdk');
+import targets = require('@aws-cdk/aws-route53-targets/lib');
 
 export interface StaticSiteProps {
     domainName: string;
@@ -60,9 +61,9 @@ export class StaticSite extends cdk.Construct {
 
         // Route53 alias record for the CloudFront distribution
         const zone = new route53.HostedZoneProvider(this, { domainName: props.domainName }).findAndImport(this, 'Zone');
-        new route53.AliasRecord(this, 'SiteAliasRecord', {
+        new route53.ARecord(this, 'SiteAliasRecord', {
             recordName: siteDomain,
-            target: distribution,
+            target: route53.AddressRecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
             zone
         });
     }

--- a/typescript/stepfunctions-job-poller/index.ts
+++ b/typescript/stepfunctions-job-poller/index.ts
@@ -47,4 +47,4 @@ class JobPollerStack extends cdk.Stack {
 
 const app = new cdk.App();
 new JobPollerStack(app, 'aws-stepfunctions-integ');
-app.run();
+app.synth();


### PR DESCRIPTION
*Issue #, if available:* #49

*Description of changes:*
Updated typescript examples to account for breaking changes
- Replaced "app.run()" with "app.synth()"
- Replaced "node.getContext()" with "node.tryGetContext()"
- Replaced "route53.AliasRecord()" with "route53.ARecord()"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
