### PR TITLE
Change @aws-cdk/cdk to @aws-cdk/core

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ Create a directory with a name that is descriptive of the resource type or workf
   },
   "dependencies": {
     ...
-    "@aws-cdk/core": "^0.23.0"
+    "@aws-cdk/core": "^0.36.0"
   }
 }
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ Create a directory with a name that is descriptive of the resource type or workf
   },
   "dependencies": {
     ...
-    "@aws-cdk/cdk": "^0.23.0"
+    "@aws-cdk/core": "^0.23.0"
   }
 }
 ```

--- a/typescript/api-cors-lambda-crud-dynamodb/index.ts
+++ b/typescript/api-cors-lambda-crud-dynamodb/index.ts
@@ -1,7 +1,7 @@
 import apigateway = require('@aws-cdk/aws-apigateway'); 
 import dynamodb = require('@aws-cdk/aws-dynamodb');
 import lambda = require('@aws-cdk/aws-lambda');
-import cdk = require('@aws-cdk/cdk');
+import cdk = require('@aws-cdk/core');
 
 export class ApiLambdaCrudDynamoDBStack extends cdk.Stack {
   constructor(app: cdk.App, id: string) {

--- a/typescript/api-cors-lambda-crud-dynamodb/index.ts
+++ b/typescript/api-cors-lambda-crud-dynamodb/index.ts
@@ -10,7 +10,7 @@ export class ApiLambdaCrudDynamoDBStack extends cdk.Stack {
     const dynamoTable = new dynamodb.Table(this, 'items', {
       partitionKey: {
         name: 'itemId',
-        type: dynamodb.AttributeType.String
+        type: dynamodb.AttributeType.STRING
       },
       tableName: 'items'
     });
@@ -18,7 +18,7 @@ export class ApiLambdaCrudDynamoDBStack extends cdk.Stack {
     const getOneLambda = new lambda.Function(this, 'getOneItemFunction', {
       code: new lambda.AssetCode('src'),
       handler: 'get-one.handler',
-      runtime: lambda.Runtime.NodeJS810,
+      runtime: lambda.Runtime.NODEJS_8_10,
       environment: {
         TABLE_NAME: dynamoTable.tableName,
         PRIMARY_KEY: 'itemId'
@@ -28,7 +28,7 @@ export class ApiLambdaCrudDynamoDBStack extends cdk.Stack {
     const getAllLambda = new lambda.Function(this, 'getAllItemsFunction', {
       code: new lambda.AssetCode('src'),
       handler: 'get-all.handler',
-      runtime: lambda.Runtime.NodeJS810,
+      runtime: lambda.Runtime.NODEJS_8_10,
       environment: {
         TABLE_NAME: dynamoTable.tableName,
         PRIMARY_KEY: 'itemId'
@@ -38,7 +38,7 @@ export class ApiLambdaCrudDynamoDBStack extends cdk.Stack {
     const createOne = new lambda.Function(this, 'createItemFunction', {
       code: new lambda.AssetCode('src'),
       handler: 'create.handler',
-      runtime: lambda.Runtime.NodeJS810,
+      runtime: lambda.Runtime.NODEJS_8_10,
       environment: {
         TABLE_NAME: dynamoTable.tableName,
         PRIMARY_KEY: 'itemId'
@@ -48,7 +48,7 @@ export class ApiLambdaCrudDynamoDBStack extends cdk.Stack {
     const updateOne = new lambda.Function(this, 'updateItemFunction', {
       code: new lambda.AssetCode('src'),
       handler: 'update-one.handler',
-      runtime: lambda.Runtime.NodeJS810,
+      runtime: lambda.Runtime.NODEJS_8_10,
       environment: {
         TABLE_NAME: dynamoTable.tableName,
         PRIMARY_KEY: 'itemId'
@@ -58,7 +58,7 @@ export class ApiLambdaCrudDynamoDBStack extends cdk.Stack {
     const deleteOne = new lambda.Function(this, 'deleteItemFunction', {
       code: new lambda.AssetCode('src'),
       handler: 'delete-one.handler',
-      runtime: lambda.Runtime.NodeJS810,
+      runtime: lambda.Runtime.NODEJS_8_10,
       environment: {
         TABLE_NAME: dynamoTable.tableName,
         PRIMARY_KEY: 'itemId'
@@ -108,7 +108,7 @@ export function addCorsOptions(apiResource: apigateway.IResource) {
         'method.response.header.Access-Control-Allow-Methods': "'OPTIONS,GET,PUT,POST,DELETE'",
       },
     }],
-    passthroughBehavior: apigateway.PassthroughBehavior.Never,
+    passthroughBehavior: apigateway.PassthroughBehavior.NEVER,
     requestTemplates: {
       "application/json": "{\"statusCode\": 200}"
     },

--- a/typescript/api-cors-lambda-crud-dynamodb/package.json
+++ b/typescript/api-cors-lambda-crud-dynamodb/package.json
@@ -21,6 +21,6 @@
     "@aws-cdk/aws-apigateway": "*",
     "@aws-cdk/aws-dynamodb": "*",
     "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/cdk": "*"
+    "@aws-cdk/core": "*"
   }
 }

--- a/typescript/application-load-balancer/index.ts
+++ b/typescript/application-load-balancer/index.ts
@@ -12,7 +12,7 @@ class LoadBalancerStack extends cdk.Stack {
 
     const asg = new autoscaling.AutoScalingGroup(this, 'ASG', {
       vpc,
-      instanceType: new ec2.InstanceType('t2.micro'),
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO),
       machineImage: new ec2.AmazonLinuxImage(),
     });
 

--- a/typescript/application-load-balancer/index.ts
+++ b/typescript/application-load-balancer/index.ts
@@ -2,7 +2,7 @@
 import autoscaling = require('@aws-cdk/aws-autoscaling');
 import ec2 = require('@aws-cdk/aws-ec2');
 import elbv2 = require('@aws-cdk/aws-elasticloadbalancingv2');
-import cdk = require('@aws-cdk/cdk');
+import cdk = require('@aws-cdk/core');
 
 class LoadBalancerStack extends cdk.Stack {
   constructor(app: cdk.App, id: string) {

--- a/typescript/application-load-balancer/index.ts
+++ b/typescript/application-load-balancer/index.ts
@@ -12,7 +12,7 @@ class LoadBalancerStack extends cdk.Stack {
 
     const asg = new autoscaling.AutoScalingGroup(this, 'ASG', {
       vpc,
-      instanceType: new ec2.InstanceType(ec2.InstanceClass.BURSTABLE2),
+      instanceType: new ec2.InstanceType('t2.micro'),
       machineImage: new ec2.AmazonLinuxImage(),
     });
 

--- a/typescript/application-load-balancer/index.ts
+++ b/typescript/application-load-balancer/index.ts
@@ -12,7 +12,7 @@ class LoadBalancerStack extends cdk.Stack {
 
     const asg = new autoscaling.AutoScalingGroup(this, 'ASG', {
       vpc,
-      instanceType: new ec2.InstanceTypePair(ec2.InstanceClass.Burstable2, ec2.InstanceSize.Micro),
+      instanceType: new ec2.InstanceType(ec2.InstanceClass.BURSTABLE2),
       machineImage: new ec2.AmazonLinuxImage(),
     });
 

--- a/typescript/application-load-balancer/package.json
+++ b/typescript/application-load-balancer/package.json
@@ -22,6 +22,6 @@
     "@aws-cdk/aws-autoscaling": "*",
     "@aws-cdk/aws-ec2": "*",
     "@aws-cdk/aws-elasticloadbalancingv2": "*",
-    "@aws-cdk/cdk": "*"
+    "@aws-cdk/core": "*"
   }
 }

--- a/typescript/appsync-graphql-dynamodb/index.ts
+++ b/typescript/appsync-graphql-dynamodb/index.ts
@@ -1,7 +1,7 @@
 import cdk = require('@aws-cdk/core');
 import { CfnGraphQLApi, CfnApiKey, CfnGraphQLSchema, CfnDataSource, CfnResolver } from '@aws-cdk/aws-appsync';
 import { Table, AttributeType, StreamViewType, BillingMode } from '@aws-cdk/aws-dynamodb';
-import { Role, ServicePrincipal } from '@aws-cdk/aws-iam';
+import { Role, ServicePrincipal, ManagedPolicy } from '@aws-cdk/aws-iam';
 
 
 export class AppSyncCdkStack extends cdk.Stack {
@@ -17,11 +17,11 @@ export class AppSyncCdkStack extends cdk.Stack {
     });
 
     new CfnApiKey(this, 'ItemsApiKey', {
-      apiId: itemsGraphQLApi.graphQlApiApiId
+      apiId: itemsGraphQLApi.attrApiId
     });
 
     const apiSchema = new CfnGraphQLSchema(this, 'ItemsSchema', {
-      apiId: itemsGraphQLApi.graphQlApiApiId,
+      apiId: itemsGraphQLApi.attrApiId,
       definition: `type ${tableName} {
         ${tableName}Id: ID!
         name: String
@@ -48,20 +48,20 @@ export class AppSyncCdkStack extends cdk.Stack {
       tableName: tableName,
       partitionKey: {
         name: `${tableName}Id`,
-        type: AttributeType.String
+        type: AttributeType.STRING
       },
-      billingMode: BillingMode.PayPerRequest,
-      streamSpecification: StreamViewType.NewImage
+      billingMode: BillingMode.PAY_PER_REQUEST,
+      stream: StreamViewType.NEW_IMAGE
     });
 
     const itemsTableRole = new Role(this, 'ItemsDynamoDBRole', {
       assumedBy: new ServicePrincipal('appsync.amazonaws.com')
     });
 
-    itemsTableRole.attachManagedPolicy('arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess');
+    itemsTableRole.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName('arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess'));
 
     const dataSource = new CfnDataSource(this, 'ItemsDataSource', {
-      apiId: itemsGraphQLApi.graphQlApiApiId,
+      apiId: itemsGraphQLApi.attrApiId,
       name: 'ItemsDynamoDataSource',
       type: 'AMAZON_DYNAMODB',
       dynamoDbConfig: {
@@ -72,10 +72,10 @@ export class AppSyncCdkStack extends cdk.Stack {
     });
 
     const getOneResolver = new CfnResolver(this, 'GetOneQueryResolver', {
-      apiId: itemsGraphQLApi.graphQlApiApiId,
+      apiId: itemsGraphQLApi.attrApiId,
       typeName: 'Query',
       fieldName: 'getOne',
-      dataSourceName: dataSource.dataSourceName,
+      dataSourceName: dataSource.name,
       requestMappingTemplate: `{
         "version": "2017-02-28",
         "operation": "GetItem",
@@ -88,10 +88,10 @@ export class AppSyncCdkStack extends cdk.Stack {
     getOneResolver.addDependsOn(apiSchema);
 
     const getAllResolver = new CfnResolver(this, 'GetAllQueryResolver', {
-      apiId: itemsGraphQLApi.graphQlApiApiId,
+      apiId: itemsGraphQLApi.attrApiId,
       typeName: 'Query',
       fieldName: 'all',
-      dataSourceName: dataSource.dataSourceName,
+      dataSourceName: dataSource.name,
       requestMappingTemplate: `{
         "version": "2017-02-28",
         "operation": "Scan",
@@ -103,10 +103,10 @@ export class AppSyncCdkStack extends cdk.Stack {
     getAllResolver.addDependsOn(apiSchema);
 
     const saveResolver = new CfnResolver(this, 'SaveMutationResolver', {
-      apiId: itemsGraphQLApi.graphQlApiApiId,
+      apiId: itemsGraphQLApi.attrApiId,
       typeName: 'Mutation',
       fieldName: 'save',
-      dataSourceName: dataSource.dataSourceName,
+      dataSourceName: dataSource.name,
       requestMappingTemplate: `{
         "version": "2017-02-28",
         "operation": "PutItem",
@@ -122,10 +122,10 @@ export class AppSyncCdkStack extends cdk.Stack {
     saveResolver.addDependsOn(apiSchema);
 
     const deleteResolver = new CfnResolver(this, 'DeleteMutationResolver', {
-      apiId: itemsGraphQLApi.graphQlApiApiId,
+      apiId: itemsGraphQLApi.attrApiId,
       typeName: 'Mutation',
       fieldName: 'delete',
-      dataSourceName: dataSource.dataSourceName,
+      dataSourceName: dataSource.name,
       requestMappingTemplate: `{
         "version": "2017-02-28",
         "operation": "DeleteItem",

--- a/typescript/appsync-graphql-dynamodb/index.ts
+++ b/typescript/appsync-graphql-dynamodb/index.ts
@@ -1,4 +1,4 @@
-import cdk = require('@aws-cdk/cdk');
+import cdk = require('@aws-cdk/core');
 import { CfnGraphQLApi, CfnApiKey, CfnGraphQLSchema, CfnDataSource, CfnResolver } from '@aws-cdk/aws-appsync';
 import { Table, AttributeType, StreamViewType, BillingMode } from '@aws-cdk/aws-dynamodb';
 import { Role, ServicePrincipal } from '@aws-cdk/aws-iam';

--- a/typescript/appsync-graphql-dynamodb/package.json
+++ b/typescript/appsync-graphql-dynamodb/package.json
@@ -21,6 +21,6 @@
     "@aws-cdk/aws-appsync": "*",
     "@aws-cdk/aws-dynamodb": "*",
     "@aws-cdk/aws-iam": "*",
-    "@aws-cdk/cdk": "*"
+    "@aws-cdk/core": "*"
   }
 }

--- a/typescript/classic-load-balancer/index.ts
+++ b/typescript/classic-load-balancer/index.ts
@@ -12,7 +12,7 @@ class LoadBalancerStack extends cdk.Stack {
 
     const asg = new autoscaling.AutoScalingGroup(this, 'ASG', {
       vpc,
-      instanceType: new ec2.InstanceType('t2.micro'),
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO),
       machineImage: new ec2.AmazonLinuxImage(),
     });
 

--- a/typescript/classic-load-balancer/index.ts
+++ b/typescript/classic-load-balancer/index.ts
@@ -12,7 +12,7 @@ class LoadBalancerStack extends cdk.Stack {
 
     const asg = new autoscaling.AutoScalingGroup(this, 'ASG', {
       vpc,
-      instanceType: new ec2.InstanceType(ec2.InstanceClass.BURSTABLE2),
+      instanceType: new ec2.InstanceType('t2.micro'),
       machineImage: new ec2.AmazonLinuxImage(),
     });
 

--- a/typescript/classic-load-balancer/index.ts
+++ b/typescript/classic-load-balancer/index.ts
@@ -12,7 +12,7 @@ class LoadBalancerStack extends cdk.Stack {
 
     const asg = new autoscaling.AutoScalingGroup(this, 'ASG', {
       vpc,
-      instanceType: new ec2.InstanceTypePair(ec2.InstanceClass.Burstable2, ec2.InstanceSize.Micro),
+      instanceType: new ec2.InstanceType(ec2.InstanceClass.BURSTABLE2),
       machineImage: new ec2.AmazonLinuxImage(),
     });
 

--- a/typescript/classic-load-balancer/index.ts
+++ b/typescript/classic-load-balancer/index.ts
@@ -2,7 +2,7 @@
 import autoscaling = require('@aws-cdk/aws-autoscaling');
 import ec2 = require('@aws-cdk/aws-ec2');
 import elb = require('@aws-cdk/aws-elasticloadbalancing');
-import cdk = require('@aws-cdk/cdk');
+import cdk = require('@aws-cdk/core');
 
 class LoadBalancerStack extends cdk.Stack {
   constructor(app: cdk.App, id: string) {

--- a/typescript/classic-load-balancer/package.json
+++ b/typescript/classic-load-balancer/package.json
@@ -22,6 +22,6 @@
     "@aws-cdk/aws-autoscaling": "*",
     "@aws-cdk/aws-ec2": "*",
     "@aws-cdk/aws-elasticloadbalancing": "*",
-    "@aws-cdk/cdk": "*"
+    "@aws-cdk/core": "*"
   }
 }

--- a/typescript/custom-resource/index.ts
+++ b/typescript/custom-resource/index.ts
@@ -1,4 +1,4 @@
-import cdk = require('@aws-cdk/cdk');
+import cdk = require('@aws-cdk/core');
 import { MyCustomResource } from './my-custom-resource';
 
 /**

--- a/typescript/custom-resource/my-custom-resource.ts
+++ b/typescript/custom-resource/my-custom-resource.ts
@@ -22,8 +22,7 @@ export class MyCustomResource extends cdk.Construct {
         uuid: 'f7d4f730-4ee1-11e8-9c2d-fa7ae01bbebc',
         code: new lambda.InlineCode(fs.readFileSync('custom-resource-handler.py', { encoding: 'utf-8' })),
         handler: 'index.main',
-        timeout: 300,
-        runtime: lambda.Runtime.Python27,
+        runtime: lambda.Runtime.PYTHON_2_7,
       })),
       properties: props
     });

--- a/typescript/custom-resource/my-custom-resource.ts
+++ b/typescript/custom-resource/my-custom-resource.ts
@@ -1,6 +1,6 @@
 import cfn = require('@aws-cdk/aws-cloudformation');
 import lambda = require('@aws-cdk/aws-lambda');
-import cdk = require('@aws-cdk/cdk');
+import cdk = require('@aws-cdk/core');
 
 import fs = require('fs');
 

--- a/typescript/custom-resource/my-custom-resource.ts
+++ b/typescript/custom-resource/my-custom-resource.ts
@@ -22,6 +22,7 @@ export class MyCustomResource extends cdk.Construct {
         uuid: 'f7d4f730-4ee1-11e8-9c2d-fa7ae01bbebc',
         code: new lambda.InlineCode(fs.readFileSync('custom-resource-handler.py', { encoding: 'utf-8' })),
         handler: 'index.main',
+        timeout: cdk.Duration.seconds(300),
         runtime: lambda.Runtime.PYTHON_2_7,
       })),
       properties: props

--- a/typescript/custom-resource/package.json
+++ b/typescript/custom-resource/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "@aws-cdk/aws-cloudformation": "*",
     "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/cdk": "*"
+    "@aws-cdk/core": "*"
   }
 }

--- a/typescript/ecs/cluster/index.ts
+++ b/typescript/ecs/cluster/index.ts
@@ -10,7 +10,7 @@ class ECSCluster extends cdk.Stack {
     const vpc = new ec2.Vpc(this, 'MyVpc', { maxAZs: 2 });
 
     const asg = new autoscaling.AutoScalingGroup(this, 'MyFleet', {
-      instanceType: new ec2.InstanceType('t2.xlarge'),
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.XLARGE),
       machineImage: new ecs.EcsOptimizedAmi(),
       updateType: autoscaling.UpdateType.REPLACING_UPDATE,
       desiredCapacity: 3,
@@ -26,8 +26,8 @@ class ECSCluster extends cdk.Stack {
      * Hence, commenting out
      */
 
-    // cluster.cap('DefaultAutoScalingGroup', {
-    //   instanceType: new ec2.InstanceType('t2.micro'),
+    // cluster.addCapacity('DefaultAutoScalingGroup', {
+    //   instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO)
     // });
   }
 }

--- a/typescript/ecs/cluster/index.ts
+++ b/typescript/ecs/cluster/index.ts
@@ -10,7 +10,7 @@ class ECSCluster extends cdk.Stack {
     const vpc = new ec2.Vpc(this, 'MyVpc', { maxAZs: 2 });
 
     const asg = new autoscaling.AutoScalingGroup(this, 'MyFleet', {
-      instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO),
+      instanceType: new ec2.InstanceType('t2.xlarge'),
       machineImage: new ecs.EcsOptimizedAmi(),
       updateType: autoscaling.UpdateType.REPLACING_UPDATE,
       desiredCapacity: 3,
@@ -27,7 +27,7 @@ class ECSCluster extends cdk.Stack {
      */
 
     // cluster.cap('DefaultAutoScalingGroup', {
-    //   instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO),
+    //   instanceType: new ec2.InstanceType('t2.micro'),
     // });
   }
 }

--- a/typescript/ecs/cluster/index.ts
+++ b/typescript/ecs/cluster/index.ts
@@ -19,6 +19,16 @@ class ECSCluster extends cdk.Stack {
 
     const cluster = new ecs.Cluster(this, 'EcsCluster', { vpc });
     cluster.addAutoScalingGroup(asg);
+
+    /**
+     * This lines seem to break the synth with the following error:
+     * Error: There is already a Construct with name 'SsmParameterValue:/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter' in ECSCluster [MyFirstEcsCluster]
+     * Hence, commenting out
+     */
+
+    // cluster.cap('DefaultAutoScalingGroup', {
+    //   instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO),
+    // });
   }
 }
 

--- a/typescript/ecs/cluster/index.ts
+++ b/typescript/ecs/cluster/index.ts
@@ -23,12 +23,12 @@ class ECSCluster extends cdk.Stack {
     /**
      * This lines seem to break the synth with the following error:
      * Error: There is already a Construct with name 'SsmParameterValue:/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id:C96584B6-F00A-464E-AD19-53AFF4B05118.Parameter' in ECSCluster [MyFirstEcsCluster]
-     * Hence, commenting out
+     * This will be investigated and code will be left for now. This will break build however. 
      */
 
-    // cluster.addCapacity('DefaultAutoScalingGroup', {
-    //   instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO)
-    // });
+    cluster.addCapacity('DefaultAutoScalingGroup', {
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO)
+    });
   }
 }
 

--- a/typescript/ecs/cluster/index.ts
+++ b/typescript/ecs/cluster/index.ts
@@ -1,6 +1,5 @@
 import autoscaling = require('@aws-cdk/aws-autoscaling');
 import ec2 = require('@aws-cdk/aws-ec2');
-import { InstanceType } from '@aws-cdk/aws-ec2';
 import ecs = require('@aws-cdk/aws-ecs');
 import cdk = require('@aws-cdk/core');
 
@@ -11,20 +10,15 @@ class ECSCluster extends cdk.Stack {
     const vpc = new ec2.Vpc(this, 'MyVpc', { maxAZs: 2 });
 
     const asg = new autoscaling.AutoScalingGroup(this, 'MyFleet', {
-      instanceType: new InstanceType("t2.xlarge"),
+      instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO),
       machineImage: new ecs.EcsOptimizedAmi(),
       updateType: autoscaling.UpdateType.REPLACING_UPDATE,
       desiredCapacity: 3,
-      vpc
+      vpc,
     });
 
     const cluster = new ecs.Cluster(this, 'EcsCluster', { vpc });
     cluster.addAutoScalingGroup(asg);
-
-      cluster.addCapacity('DefaultAutoScalingGroup', {
-        instanceType: new ec2.InstanceType('t2.micro')
-      });
-
   }
 }
 

--- a/typescript/ecs/ecs-load-balanced-service/index.ts
+++ b/typescript/ecs/ecs-load-balanced-service/index.ts
@@ -14,7 +14,7 @@ class BonjourECS extends cdk.Stack {
     const vpc = new ec2.Vpc(this, 'MyVpc', { maxAZs: 2 });
     const cluster = new ecs.Cluster(this, 'Ec2Cluster', { vpc });
     cluster.addCapacity('DefaultAutoScalingGroup', {
-      instanceType: new ec2.InstanceType('t2.micro')
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO)
     });
 
     // Instantiate ECS Service with just cluster and image

--- a/typescript/ecs/ecs-load-balanced-service/index.ts
+++ b/typescript/ecs/ecs-load-balanced-service/index.ts
@@ -14,7 +14,7 @@ class BonjourECS extends cdk.Stack {
     const vpc = new ec2.Vpc(this, 'MyVpc', { maxAZs: 2 });
     const cluster = new ecs.Cluster(this, 'Ec2Cluster', { vpc });
     cluster.addCapacity('DefaultAutoScalingGroup', {
-      instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO)
+      instanceType: new ec2.InstanceType('t2.micro')
     });
 
     // Instantiate ECS Service with just cluster and image

--- a/typescript/ecs/ecs-load-balanced-service/index.ts
+++ b/typescript/ecs/ecs-load-balanced-service/index.ts
@@ -14,7 +14,7 @@ class BonjourECS extends cdk.Stack {
     const vpc = new ec2.Vpc(this, 'MyVpc', { maxAZs: 2 });
     const cluster = new ecs.Cluster(this, 'Ec2Cluster', { vpc });
     cluster.addCapacity('DefaultAutoScalingGroup', {
-      instanceType: new ec2.InstanceType('t2.micro')
+      instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO)
     });
 
     // Instantiate ECS Service with just cluster and image

--- a/typescript/ecs/ecs-service-with-advanced-alb-config/index.ts
+++ b/typescript/ecs/ecs-service-with-advanced-alb-config/index.ts
@@ -11,7 +11,7 @@ const vpc = new ec2.Vpc(stack, 'Vpc', { maxAZs: 2 });
 
 const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
 cluster.addCapacity('DefaultAutoScalingGroup', {
-  instanceType: new ec2.InstanceType('t2.micro')
+  instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO)
 });
 
 // Create Task Definition

--- a/typescript/ecs/ecs-service-with-advanced-alb-config/index.ts
+++ b/typescript/ecs/ecs-service-with-advanced-alb-config/index.ts
@@ -11,7 +11,7 @@ const vpc = new ec2.Vpc(stack, 'Vpc', { maxAZs: 2 });
 
 const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
 cluster.addCapacity('DefaultAutoScalingGroup', {
-  instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO)
+  instanceType: new ec2.InstanceType('t2.micro')
 });
 
 // Create Task Definition

--- a/typescript/ecs/ecs-service-with-advanced-alb-config/index.ts
+++ b/typescript/ecs/ecs-service-with-advanced-alb-config/index.ts
@@ -11,7 +11,7 @@ const vpc = new ec2.Vpc(stack, 'Vpc', { maxAZs: 2 });
 
 const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
 cluster.addCapacity('DefaultAutoScalingGroup', {
-  instanceType: new ec2.InstanceType('t2.micro')
+  instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO)
 });
 
 // Create Task Definition

--- a/typescript/ecs/ecs-service-with-logging/index.ts
+++ b/typescript/ecs/ecs-service-with-logging/index.ts
@@ -9,7 +9,7 @@ class WillkommenECS extends cdk.Stack {
     const vpc = new ec2.Vpc(this, 'MyVpc', { maxAZs: 2 });
     const cluster = new ecs.Cluster(this, 'Ec2Cluster', { vpc });
     cluster.addCapacity('DefaultAutoScalingGroup', {
-      instanceType: new ec2.InstanceType('t2.micro')
+      instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO)
     });
 
     // create a task definition with CloudWatch Logs

--- a/typescript/ecs/ecs-service-with-logging/index.ts
+++ b/typescript/ecs/ecs-service-with-logging/index.ts
@@ -10,7 +10,7 @@ class WillkommenECS extends cdk.Stack {
     
     const cluster = new ecs.Cluster(this, 'Ec2Cluster', { vpc });
     cluster.addCapacity('DefaultAutoScalingGroup', {
-      instanceType: new ec2.InstanceType('t2.micro')
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO)
     });
 
     // create a task definition with CloudWatch Logs

--- a/typescript/ecs/ecs-service-with-logging/index.ts
+++ b/typescript/ecs/ecs-service-with-logging/index.ts
@@ -10,7 +10,7 @@ class WillkommenECS extends cdk.Stack {
     
     const cluster = new ecs.Cluster(this, 'Ec2Cluster', { vpc });
     cluster.addCapacity('DefaultAutoScalingGroup', {
-      instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO)
+      instanceType: new ec2.InstanceType('t2.micro')
     });
 
     // create a task definition with CloudWatch Logs

--- a/typescript/ecs/ecs-service-with-logging/index.ts
+++ b/typescript/ecs/ecs-service-with-logging/index.ts
@@ -7,6 +7,7 @@ class WillkommenECS extends cdk.Stack {
     super(scope, id, props);
 
     const vpc = new ec2.Vpc(this, 'MyVpc', { maxAZs: 2 });
+    
     const cluster = new ecs.Cluster(this, 'Ec2Cluster', { vpc });
     cluster.addCapacity('DefaultAutoScalingGroup', {
       instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO)

--- a/typescript/ecs/ecs-service-with-task-networking/index.ts
+++ b/typescript/ecs/ecs-service-with-task-networking/index.ts
@@ -11,7 +11,7 @@ const vpc = new ec2.Vpc(stack, 'Vpc', { maxAZs: 2 });
 
 const cluster = new ecs.Cluster(stack, 'awsvpc-ecs-demo-cluster', { vpc });
 cluster.addCapacity('DefaultAutoScalingGroup', {
-  instanceType: new ec2.InstanceType('t2.micro')
+  instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO)
 });
 
 // Create a task definition with its own elastic network interface

--- a/typescript/ecs/ecs-service-with-task-networking/index.ts
+++ b/typescript/ecs/ecs-service-with-task-networking/index.ts
@@ -11,7 +11,7 @@ const vpc = new ec2.Vpc(stack, 'Vpc', { maxAZs: 2 });
 
 const cluster = new ecs.Cluster(stack, 'awsvpc-ecs-demo-cluster', { vpc });
 cluster.addCapacity('DefaultAutoScalingGroup', {
-  instanceType: new ec2.InstanceType('t2.micro')
+  instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO)
 });
 
 // Create a task definition with its own elastic network interface

--- a/typescript/ecs/ecs-service-with-task-networking/index.ts
+++ b/typescript/ecs/ecs-service-with-task-networking/index.ts
@@ -11,7 +11,7 @@ const vpc = new ec2.Vpc(stack, 'Vpc', { maxAZs: 2 });
 
 const cluster = new ecs.Cluster(stack, 'awsvpc-ecs-demo-cluster', { vpc });
 cluster.addCapacity('DefaultAutoScalingGroup', {
-  instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO)
+  instanceType: new ec2.InstanceType('t2.micro')
 });
 
 // Create a task definition with its own elastic network interface

--- a/typescript/ecs/ecs-service-with-task-placement/index.ts
+++ b/typescript/ecs/ecs-service-with-task-placement/index.ts
@@ -10,7 +10,7 @@ const vpc = new ec2.Vpc(stack, 'Vpc', { maxAZs: 2 });
 
 const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
 cluster.addCapacity('DefaultAutoScalingGroup', {
-  instanceType: new ec2.InstanceType('t2.micro'),
+  instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO)
 });
 
 // Create Task Definition with placement constraint

--- a/typescript/ecs/ecs-service-with-task-placement/index.ts
+++ b/typescript/ecs/ecs-service-with-task-placement/index.ts
@@ -10,7 +10,7 @@ const vpc = new ec2.Vpc(stack, 'Vpc', { maxAZs: 2 });
 
 const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
 cluster.addCapacity('DefaultAutoScalingGroup', {
-  instanceType: new ec2.InstanceType('t2.micro')
+  instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO)
 });
 
 // Create Task Definition with placement constraint

--- a/typescript/ecs/ecs-service-with-task-placement/index.ts
+++ b/typescript/ecs/ecs-service-with-task-placement/index.ts
@@ -32,7 +32,7 @@ container.addPortMappings({
 // Create Service
 const service = new ecs.Ec2Service(stack, "Service", {
   cluster,
-  taskDefinition,
+  taskDefinition
 });
 
 // Specify binpack by memory and spread across availability zone as placement strategies.

--- a/typescript/ecs/ecs-service-with-task-placement/index.ts
+++ b/typescript/ecs/ecs-service-with-task-placement/index.ts
@@ -10,29 +10,29 @@ const vpc = new ec2.Vpc(stack, 'Vpc', { maxAZs: 2 });
 
 const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
 cluster.addCapacity('DefaultAutoScalingGroup', {
-  instanceType: new ec2.InstanceType('t2.micro')
+  instanceType: new ec2.InstanceType('t2.micro'),
 });
 
 // Create Task Definition with placement constraint
 const taskDefinition = new ecs.Ec2TaskDefinition(stack, 'TaskDef', {
-  placementConstraints: [ ecs.PlacementConstraint.distinctInstances() ]
+  placementConstraints: [ecs.PlacementConstraint.distinctInstances()],
 });
 
 const container = taskDefinition.addContainer('web', {
-  image: ecs.ContainerImage.fromRegistry("amazon/amazon-ecs-sample"),
+  image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
   memoryLimitMiB: 256,
 });
 
 container.addPortMappings({
   containerPort: 80,
   hostPort: 8080,
-  protocol: ecs.Protocol.TCP
+  protocol: ecs.Protocol.TCP,
 });
 
 // Create Service
-const service = new ecs.Ec2Service(stack, "Service", {
+const service = new ecs.Ec2Service(stack, 'Service', {
   cluster,
-  taskDefinition
+  taskDefinition,
 });
 
 // Specify binpack by memory and spread across availability zone as placement strategies.

--- a/typescript/ecs/ecs-service-with-task-placement/index.ts
+++ b/typescript/ecs/ecs-service-with-task-placement/index.ts
@@ -10,7 +10,7 @@ const vpc = new ec2.Vpc(stack, 'Vpc', { maxAZs: 2 });
 
 const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
 cluster.addCapacity('DefaultAutoScalingGroup', {
-  instanceType: new ec2.InstanceType(ec2.InstanceSize.MICRO)
+  instanceType: new ec2.InstanceType('t2.micro')
 });
 
 // Create Task Definition with placement constraint

--- a/typescript/ecs/fargate-service-with-local-image/index.ts
+++ b/typescript/ecs/fargate-service-with-local-image/index.ts
@@ -2,7 +2,6 @@ import ec2 = require('@aws-cdk/aws-ec2');
 import ecs = require('@aws-cdk/aws-ecs');
 import ecs_patterns = require('@aws-cdk/aws-ecs-patterns');
 import cdk = require('@aws-cdk/core');
-import path = require('path');
 
 const app = new cdk.App();
 const stack = new cdk.Stack(app, 'FargateServiceWithLocalImage');
@@ -18,7 +17,7 @@ const cluster = new ecs.Cluster(stack, 'Cluster', { vpc });
 // with the image from ECR.
 new ecs_patterns.LoadBalancedFargateService(stack, "FargateService", {
   cluster,
-  image: ecs.ContainerImage.fromAsset(path.resolve(__dirname, 'local-image'))
+  image: ecs.ContainerImage.fromAsset("local-image")
 });
 
 app.synth();

--- a/typescript/ecs/fargate-service-with-local-image/index.ts
+++ b/typescript/ecs/fargate-service-with-local-image/index.ts
@@ -2,6 +2,7 @@ import ec2 = require('@aws-cdk/aws-ec2');
 import ecs = require('@aws-cdk/aws-ecs');
 import ecs_patterns = require('@aws-cdk/aws-ecs-patterns');
 import cdk = require('@aws-cdk/core');
+import path = require('path');	
 
 const app = new cdk.App();
 const stack = new cdk.Stack(app, 'FargateServiceWithLocalImage');
@@ -17,7 +18,7 @@ const cluster = new ecs.Cluster(stack, 'Cluster', { vpc });
 // with the image from ECR.
 new ecs_patterns.LoadBalancedFargateService(stack, "FargateService", {
   cluster,
-  image: ecs.ContainerImage.fromAsset("local-image")
+  image: ecs.ContainerImage.fromAsset(path.resolve(__dirname, 'local-image'))
 });
 
 app.synth();

--- a/typescript/ecs/fargate-service-with-local-image/index.ts
+++ b/typescript/ecs/fargate-service-with-local-image/index.ts
@@ -2,7 +2,7 @@ import ec2 = require('@aws-cdk/aws-ec2');
 import ecs = require('@aws-cdk/aws-ecs');
 import ecs_patterns = require('@aws-cdk/aws-ecs-patterns');
 import cdk = require('@aws-cdk/core');
-import path = require('path');	
+import path = require('path');
 
 const app = new cdk.App();
 const stack = new cdk.Stack(app, 'FargateServiceWithLocalImage');

--- a/typescript/ecs/fargate-service-with-logging/index.ts
+++ b/typescript/ecs/fargate-service-with-logging/index.ts
@@ -10,12 +10,12 @@ class WillkommenFargate extends cdk.Stack {
     const cluster = new ecs.Cluster(this, 'Ec2Cluster', { vpc });
 
     // create a task definition with CloudWatch Logs
-    const logging = new ecs.AwsLogDriver({ streamPrefix: "myapp" })
-
-    const taskDef = new ecs.FargateTaskDefinition(this, "MyTaskDefinition", {
-      memoryLimitMiB: 512,
-      cpu: 256,
+    const logging = new ecs.AwsLogDriver({
+      streamPrefix: "myapp",
     })
+
+    const taskDef = new ecs.FargateTaskDefinition(this, "MyTaskDefinition")
+    
     taskDef.addContainer("AppContainer", {
       image: ecs.ContainerImage.fromRegistry("amazon/amazon-ecs-sample"),
       logging,

--- a/typescript/ecs/fargate-service-with-logging/index.ts
+++ b/typescript/ecs/fargate-service-with-logging/index.ts
@@ -14,7 +14,10 @@ class WillkommenFargate extends cdk.Stack {
       streamPrefix: "myapp",
     })
 
-    const taskDef = new ecs.FargateTaskDefinition(this, "MyTaskDefinition")
+    const taskDef = new ecs.FargateTaskDefinition(this, "MyTaskDefinition", {
+      memoryLimitMiB: 512,
+      cpu: 256,
+    })
     
     taskDef.addContainer("AppContainer", {
       image: ecs.ContainerImage.fromRegistry("amazon/amazon-ecs-sample"),

--- a/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
@@ -19,8 +19,8 @@ export class CdkStack extends cdk.Stack {
     const bucket = new s3.Bucket(this, 'BlueGreenBucket');
 
     const handler = new lambda.Function(this, 'BlueGreenLambda', {
-      runtime: lambda.Runtime.Python36,
-      code: lambda.Code.directory('resources'),
+      runtime: lambda.Runtime.PYTHON_3_6,
+      code: lambda.AssetCode.asset('resources'),
       handler: 'blue_green.lambda_handler',
       environment: {
         BUCKET: bucket.bucketName
@@ -36,7 +36,7 @@ export class CdkStack extends cdk.Stack {
     const pipeline = new cp.Pipeline(this, 'MyFirstPipeline');
 
     const sourceStage = pipeline.addStage({
-      name: 'Source'
+      stageName: 'Source'
     });
 
     const sourceArtifact = new cp.Artifact('Source');
@@ -51,7 +51,7 @@ export class CdkStack extends cdk.Stack {
 
 
     const deployStage = pipeline.addStage({
-      name: 'Deploy'
+      stageName: 'Deploy'
     });
 
 

--- a/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
@@ -1,4 +1,4 @@
-import cdk = require('@aws-cdk/cdk');
+import cdk = require('@aws-cdk/core');
 import cpactions = require('@aws-cdk/aws-codepipeline-actions');
 import cp = require('@aws-cdk/aws-codepipeline');
 import cc = require('@aws-cdk/aws-codecommit');

--- a/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
@@ -20,7 +20,7 @@ export class CdkStack extends cdk.Stack {
 
     const handler = new lambda.Function(this, 'BlueGreenLambda', {
       runtime: lambda.Runtime.PYTHON_3_6,
-      code: lambda.AssetCode.asset('resources'),
+      code: lambda.Code.asset('resources'),
       handler: 'blue_green.lambda_handler',
       environment: {
         BUCKET: bucket.bucketName

--- a/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/package.json
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/package.json
@@ -21,7 +21,7 @@
     "@aws-cdk/aws-codecommit": "*",
     "@aws-cdk/aws-lambda": "*",
     "@aws-cdk/aws-s3": "*",
-    "@aws-cdk/cdk": "*",
+    "@aws-cdk/core": "*",
     "source-map-support": "^0.5.9"
   }
 }

--- a/typescript/elasticbeanstalk/elasticbeanstalk-environment/index.ts
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-environment/index.ts
@@ -10,16 +10,17 @@ export class CdkStack extends cdk.Stack {
     //objects for access parameters
     const node = this.node;
 
+    const appName = 'MyApp';
+
     const platform = node.tryGetContext("platform");
 
-
     const app = new elasticbeanstalk.CfnApplication(this, 'Application', {
-      applicationName: "MyApp"
+      applicationName: appName
     });
 
     new elasticbeanstalk.CfnEnvironment(this, 'Environment', {
       environmentName: 'MySampleEnvironment',
-      applicationName: app.applicationName,
+      applicationName: app.applicationName || appName,
       platformArn: platform
     });
   }

--- a/typescript/elasticbeanstalk/elasticbeanstalk-environment/index.ts
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-environment/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import cdk = require('@aws-cdk/cdk');
+import cdk = require('@aws-cdk/core');
 import elasticbeanstalk = require('@aws-cdk/aws-elasticbeanstalk');
 
 

--- a/typescript/elasticbeanstalk/elasticbeanstalk-environment/package.json
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-environment/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@aws-cdk/aws-elasticbeanstalk": "*",
-    "@aws-cdk/cdk": "*",
+    "@aws-cdk/core": "*",
     "source-map-support": "^0.5.9"
   }
 }

--- a/typescript/lambda-cron/index.ts
+++ b/typescript/lambda-cron/index.ts
@@ -1,7 +1,7 @@
 import events = require('@aws-cdk/aws-events');
 import targets = require('@aws-cdk/aws-events-targets');
 import lambda = require('@aws-cdk/aws-lambda');
-import cdk = require('@aws-cdk/cdk');
+import cdk = require('@aws-cdk/core');
 
 import fs = require('fs');
 

--- a/typescript/lambda-cron/index.ts
+++ b/typescript/lambda-cron/index.ts
@@ -12,6 +12,7 @@ export class LambdaCronStack extends cdk.Stack {
     const lambdaFn = new lambda.Function(this, 'Singleton', {
       code: new lambda.InlineCode(fs.readFileSync('lambda-handler.py', { encoding: 'utf-8' })),
       handler: 'index.main',
+      timeout: cdk.Duration.seconds(300),
       runtime: lambda.Runtime.PYTHON_2_7,
     });
 

--- a/typescript/lambda-cron/index.ts
+++ b/typescript/lambda-cron/index.ts
@@ -12,14 +12,13 @@ export class LambdaCronStack extends cdk.Stack {
     const lambdaFn = new lambda.Function(this, 'Singleton', {
       code: new lambda.InlineCode(fs.readFileSync('lambda-handler.py', { encoding: 'utf-8' })),
       handler: 'index.main',
-      timeout: 300,
-      runtime: lambda.Runtime.Python27,
+      runtime: lambda.Runtime.PYTHON_2_7,
     });
 
     // Run every day at 6PM UTC
     // See https://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html
     const rule = new events.Rule(this, 'Rule', {
-      scheduleExpression: 'cron(0 18 ? * MON-FRI *)',
+      schedule: events.Schedule.expression('cron(0 18 ? * MON-FRI *)')
     });
 
     rule.addTarget(new targets.LambdaFunction(lambdaFn));

--- a/typescript/lambda-cron/package.json
+++ b/typescript/lambda-cron/package.json
@@ -22,6 +22,6 @@
     "@aws-cdk/aws-events": "*",
     "@aws-cdk/aws-events-targets": "*",
     "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/cdk": "*"
+    "@aws-cdk/core": "*"
   }
 }

--- a/typescript/my-widget-service/index.ts
+++ b/typescript/my-widget-service/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import cdk = require('@aws-cdk/cdk');
+import cdk = require('@aws-cdk/core');
 import widget_service = require('./widget_service');
 
 export class MyWidgetServiceStack extends cdk.Stack {

--- a/typescript/my-widget-service/package.json
+++ b/typescript/my-widget-service/package.json
@@ -16,7 +16,7 @@
     "@aws-cdk/aws-apigateway": "*",
     "@aws-cdk/aws-lambda": "*",
     "@aws-cdk/aws-s3": "*",
-    "@aws-cdk/cdk": "*",
+    "@aws-cdk/core": "*",
     "source-map-support": "*"
   }
 }

--- a/typescript/my-widget-service/widget_service.ts
+++ b/typescript/my-widget-service/widget_service.ts
@@ -39,8 +39,8 @@ export class WidgetService extends cdk.Construct {
     const bucket = new s3.Bucket(this, "WidgetStore");
 
     const handler = new lambda.Function(this, "WidgetHandler", {
-      runtime: lambda.Runtime.NodeJS810, // So we can use async in widget.js
-      code: lambda.Code.directory("resources"),
+      runtime: lambda.Runtime.NODEJS_8_10, // So we can use async in widget.js
+      code: lambda.AssetCode.asset("resources"),
       handler: "widgets.main",
       environment: {
         BUCKET: bucket.bucketName

--- a/typescript/my-widget-service/widget_service.ts
+++ b/typescript/my-widget-service/widget_service.ts
@@ -27,7 +27,7 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.widget_service]
-import cdk = require("@aws-cdk/cdk");
+import cdk = require("@aws-cdk/core");
 import apigateway = require("@aws-cdk/aws-apigateway");
 import lambda = require("@aws-cdk/aws-lambda");
 import s3 = require("@aws-cdk/aws-s3");

--- a/typescript/resource-overrides/index.ts
+++ b/typescript/resource-overrides/index.ts
@@ -12,7 +12,7 @@ class ResourceOverridesExample extends cdk.Stack {
 
         const bucket = new s3.Bucket(this, 'MyBucket', {
             versioned: true,
-            encryption: s3.BucketEncryption.KmsManaged
+            encryption: s3.BucketEncryption.KMS_MANAGED
         });
 
         const bucketResource2 = bucket.node.findChild('Resource') as s3.CfnBucket;
@@ -24,7 +24,7 @@ class ResourceOverridesExample extends cdk.Stack {
         //
 
         const bucketResource = bucket.node.findChild('Resource') as s3.CfnBucket;
-        const anotherWay = bucket.node.children.find(c => (c as cdk.CfnResource).resourceType === 'AWS::S3::Bucket') as s3.CfnBucket;
+        const anotherWay = bucket.node.children.find(c => (c as cdk.CfnResource).cfnResourceType === 'AWS::S3::Bucket') as s3.CfnBucket;
         assert.equal(bucketResource, anotherWay);
 
         //
@@ -32,8 +32,8 @@ class ResourceOverridesExample extends cdk.Stack {
         //
 
         bucketResource.node.addDependency(otherBucket.node.findChild('Resource') as cdk.CfnResource);
-        bucketResource.options.metadata = { MetadataKey: 'MetadataValue' };
-        bucketResource.options.updatePolicy = {
+        bucketResource.cfnOptions.metadata = { MetadataKey: 'MetadataValue' };
+        bucketResource.cfnOptions.updatePolicy = {
             autoScalingRollingUpdate: {
                 pauseTime: '390'
             }
@@ -88,7 +88,7 @@ class ResourceOverridesExample extends cdk.Stack {
 
         const vpc = new ec2.Vpc(this, 'VPC', { maxAZs: 1 });
         const asg = new autoscaling.AutoScalingGroup(this, 'ASG', {
-            instanceType: new ec2.InstanceTypePair(ec2.InstanceClass.M4, ec2.InstanceSize.XLarge),
+            instanceType: new ec2.InstanceType(ec2.InstanceClass.M4),
             machineImage: new ec2.AmazonLinuxImage(),
             vpc
         });

--- a/typescript/resource-overrides/index.ts
+++ b/typescript/resource-overrides/index.ts
@@ -88,7 +88,7 @@ class ResourceOverridesExample extends cdk.Stack {
 
         const vpc = new ec2.Vpc(this, 'VPC', { maxAZs: 1 });
         const asg = new autoscaling.AutoScalingGroup(this, 'ASG', {
-            instanceType: new ec2.InstanceType(ec2.InstanceClass.M4),
+            instanceType: new ec2.InstanceType('m4.xlarge'),
             machineImage: new ec2.AmazonLinuxImage(),
             vpc
         });

--- a/typescript/resource-overrides/index.ts
+++ b/typescript/resource-overrides/index.ts
@@ -88,7 +88,7 @@ class ResourceOverridesExample extends cdk.Stack {
 
         const vpc = new ec2.Vpc(this, 'VPC', { maxAZs: 1 });
         const asg = new autoscaling.AutoScalingGroup(this, 'ASG', {
-            instanceType: new ec2.InstanceType('m4.xlarge'),
+            instanceType: ec2.InstanceType.of(ec2.InstanceClass.M4, ec2.InstanceSize.XLARGE),
             machineImage: new ec2.AmazonLinuxImage(),
             vpc
         });

--- a/typescript/resource-overrides/index.ts
+++ b/typescript/resource-overrides/index.ts
@@ -1,7 +1,7 @@
 import autoscaling = require('@aws-cdk/aws-autoscaling');
 import ec2 = require('@aws-cdk/aws-ec2');
 import s3 = require('@aws-cdk/aws-s3');
-import cdk = require('@aws-cdk/cdk');
+import cdk = require('@aws-cdk/core');
 import assert = require('assert');
 
 class ResourceOverridesExample extends cdk.Stack {

--- a/typescript/resource-overrides/package.json
+++ b/typescript/resource-overrides/package.json
@@ -22,6 +22,6 @@
     "@aws-cdk/aws-autoscaling": "*",
     "@aws-cdk/aws-ec2": "*",
     "@aws-cdk/aws-s3": "*",
-    "@aws-cdk/cdk": "*"
+    "@aws-cdk/core": "*"
   }
 }

--- a/typescript/static-site/index.ts
+++ b/typescript/static-site/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import cdk = require('@aws-cdk/cdk');
+import cdk = require('@aws-cdk/core');
 import { StaticSite } from './static-site';
 
 /**

--- a/typescript/static-site/package.json
+++ b/typescript/static-site/package.json
@@ -23,6 +23,6 @@
     "@aws-cdk/aws-route53-targets": "^0.34.0",
     "@aws-cdk/aws-s3": "*",
     "@aws-cdk/aws-ssm": "*",
-    "@aws-cdk/cdk": "*"
+    "@aws-cdk/core": "*"
   }
 }

--- a/typescript/static-site/package.json
+++ b/typescript/static-site/package.json
@@ -22,7 +22,7 @@
     "@aws-cdk/aws-route53": "*",
     "@aws-cdk/aws-route53-targets": "^0.34.0",
     "@aws-cdk/aws-s3": "*",
-    "@aws-cdk/aws-ssm": "*",
-    "@aws-cdk/core": "*"
+    "@aws-cdk/core": "*",
+    "@aws-cdk/aws-certificatemanager": "*"
   }
 }

--- a/typescript/static-site/static-site.ts
+++ b/typescript/static-site/static-site.ts
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 import cloudfront = require('@aws-cdk/aws-cloudfront');
-import route53 = require('@aws-cdk/aws-route53');
 import s3 = require('@aws-cdk/aws-s3');
-import ssm = require('@aws-cdk/aws-ssm');
+import acm = require('@aws-cdk/aws-certificatemanager');
 import cdk = require('@aws-cdk/core');
-import targets = require('@aws-cdk/aws-route53-targets/lib');
 
 export interface StaticSiteProps {
     domainName: string;
@@ -36,9 +34,9 @@ export class StaticSite extends cdk.Construct {
         new cdk.CfnOutput(this, 'Bucket', { value: siteBucket.bucketName });
 
         // Pre-existing ACM certificate, with the ARN stored in an SSM Parameter
-        const certificateArn = new ssm.ParameterStoreString(this, 'ArnParameter', {
-            parameterName: 'CertificateArn-' + siteDomain
-        }).stringValue;
+        const certificateArn = new acm.Certificate(this, 'ArnParameter', {
+            domainName: props.domainName
+        }).certificateArn;
 
         // CloudFront distribution that provides HTTPS
         const distribution = new cloudfront.CloudFrontWebDistribution(this, 'SiteDistribution', {
@@ -46,7 +44,7 @@ export class StaticSite extends cdk.Construct {
                 acmCertRef: certificateArn,
                 names: [ siteDomain ],
                 sslMethod: cloudfront.SSLMethod.SNI,
-                securityPolicy: cloudfront.SecurityPolicyProtocol.TLSv1_1_2016
+                securityPolicy: cloudfront.SecurityPolicyProtocol.TLS_V1_1_2016,
             },
             originConfigs: [
                 {
@@ -59,12 +57,19 @@ export class StaticSite extends cdk.Construct {
         });
         new cdk.CfnOutput(this, 'DistributionId', { value: distribution.distributionId });
 
+        /**
+         * NOTE: the code below is not transpiling properly to JavaScript
+         * Commenting out until further review
+         */
+
         // Route53 alias record for the CloudFront distribution
-        const zone = new route53.HostedZoneProvider(this, { domainName: props.domainName }).findAndImport(this, 'Zone');
-        new route53.ARecord(this, 'SiteAliasRecord', {
-            recordName: siteDomain,
-            target: route53.AddressRecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
-            zone
-        });
+        // const zone = new route53.HostedZone(this, 'MyHostedZone', {
+        //     zoneName: props.domainName
+        // });
+        // new route53.ARecord(this, 'SiteAliasRecord', {
+        //     recordName: siteDomain,
+        //     target: route53.AddressRecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
+        //     zone
+        // });
     }
 }

--- a/typescript/static-site/static-site.ts
+++ b/typescript/static-site/static-site.ts
@@ -3,7 +3,7 @@ import cloudfront = require('@aws-cdk/aws-cloudfront');
 import route53 = require('@aws-cdk/aws-route53');
 import s3 = require('@aws-cdk/aws-s3');
 import ssm = require('@aws-cdk/aws-ssm');
-import cdk = require('@aws-cdk/cdk');
+import cdk = require('@aws-cdk/core');
 import targets = require('@aws-cdk/aws-route53-targets/lib');
 
 export interface StaticSiteProps {

--- a/typescript/static-site/static-site.ts
+++ b/typescript/static-site/static-site.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 import cloudfront = require('@aws-cdk/aws-cloudfront');
+import route53 = require('@aws-cdk/aws-route53');	
 import s3 = require('@aws-cdk/aws-s3');
 import acm = require('@aws-cdk/aws-certificatemanager');
 import cdk = require('@aws-cdk/core');
+import targets = require('@aws-cdk/aws-route53-targets/lib');	
 
 export interface StaticSiteProps {
     domainName: string;
@@ -59,17 +61,17 @@ export class StaticSite extends cdk.Construct {
 
         /**
          * NOTE: the code below is not transpiling properly to JavaScript
-         * Commenting out until further review
+         * Pending review by AWS team
          */
 
         // Route53 alias record for the CloudFront distribution
-        // const zone = new route53.HostedZone(this, 'MyHostedZone', {
-        //     zoneName: props.domainName
-        // });
-        // new route53.ARecord(this, 'SiteAliasRecord', {
-        //     recordName: siteDomain,
-        //     target: route53.AddressRecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
-        //     zone
-        // });
+        const zone = new route53.HostedZone(this, 'MyHostedZone', {
+            zoneName: props.domainName
+        });
+        new route53.ARecord(this, 'SiteAliasRecord', {
+            recordName: siteDomain,
+            target: route53.AddressRecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
+            zone
+        });
     }
 }

--- a/typescript/stepfunctions-job-poller/index.ts
+++ b/typescript/stepfunctions-job-poller/index.ts
@@ -1,4 +1,4 @@
-import cdk = require('@aws-cdk/cdk');
+import cdk = require('@aws-cdk/core');
 import sfn = require('@aws-cdk/aws-stepfunctions');
 import sfn_tasks = require('@aws-cdk/aws-stepfunctions-tasks');
 

--- a/typescript/stepfunctions-job-poller/index.ts
+++ b/typescript/stepfunctions-job-poller/index.ts
@@ -13,7 +13,9 @@ class JobPollerStack extends cdk.Stack {
             task: new sfn_tasks.InvokeActivity(submitJobActivity),
             resultPath: '$.guid',
         });
-        const waitX = new sfn.Wait(this, 'Wait X Seconds', { duration: sfn.WaitDuration.secondsPath('$.wait_time') });
+        const waitX = new sfn.Wait(this, 'Wait X Seconds', { 
+            time: sfn.WaitTime.secondsPath('$.wait_time') 
+        });
         const getStatus = new sfn.Task(this, 'Get Job Status', {
             task: new sfn_tasks.InvokeActivity(checkJobActivity),
             inputPath: '$.guid',
@@ -40,7 +42,7 @@ class JobPollerStack extends cdk.Stack {
 
         new sfn.StateMachine(this, 'StateMachine', {
             definition: chain,
-            timeoutSec: 30
+            timeout: cdk.Duration.seconds(30)
         });
     }
 }

--- a/typescript/stepfunctions-job-poller/package.json
+++ b/typescript/stepfunctions-job-poller/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "@aws-cdk/aws-stepfunctions": "*",
     "@aws-cdk/aws-stepfunctions-tasks": "*",
-    "@aws-cdk/cdk": "*"
+    "@aws-cdk/core": "*"
   }
 }


### PR DESCRIPTION


`"@aws-cdk/cdk"` is deprecated in the newst version. Changed examples to import from `"@aws-cdk/core"`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
