### PR TITLE
rename flasks app.synth to app.run

### DIFF
--- a/typescript/ecs/fargate-service-with-local-image/local-image/app.py
+++ b/typescript/ecs/fargate-service-with-local-image/local-image/app.py
@@ -11,5 +11,5 @@ def hello():
     return html.format(name=os.getenv("NAME", "world"), hostname=socket.gethostname())
 
 if __name__ == "__main__":
-    app.synth()(host='0.0.0.0', port=80)
+    app.run(host='0.0.0.0', port=80)
 


### PR DESCRIPTION
flasks app.run was accidentally renamed to app.synth in global rename

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
