### PR TITLE
Fixes an invalid function name in the lambda-cron Java example

### DIFF
--- a/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
+++ b/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
@@ -7,12 +7,12 @@ import software.amazon.awscdk.services.events.Rule;
 import software.amazon.awscdk.services.events.RuleProps;
 import software.amazon.awscdk.services.events.Schedule;
 import software.amazon.awscdk.services.events.targets.LambdaFunction;
-
 import software.amazon.awscdk.services.lambda.Code;
-import software.amazon.awscdk.services.lambda.Function;
-import software.amazon.awscdk.services.lambda.FunctionProps;
 import software.amazon.awscdk.services.lambda.Runtime;
+import software.amazon.awscdk.services.lambda.SingletonFunction;
+import software.amazon.awscdk.services.lambda.SingletonFunctionProps;
 
+import java.util.UUID;
 
 /**
  * Lambda Cron CDK example for Java!
@@ -21,8 +21,8 @@ class LambdaCronStack extends Stack {
     public LambdaCronStack(final Construct parent, final String name) {
         super(parent, name);
 
-        Function lambdaFunction = new Function(this, "cdk-lambda-cron",
-                FunctionProps.builder()
+        SingletonFunction lambdaFunction = new SingletonFunction(this, "cdk-lambda-cron",
+                SingletonFunctionProps.builder()
                         .withDescription("Lambda which prints \"I'm running\"")
                         .withCode(Code.inline(
                                 "def main(event, context):\n" +
@@ -30,6 +30,7 @@ class LambdaCronStack extends Stack {
                         .withHandler("index.main")
                         .withTimeout(Duration.seconds(300))
                         .withRuntime(Runtime.PYTHON_2_7)
+                        .withUuid(UUID.randomUUID().toString())
                         .build()
         );
 

--- a/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
+++ b/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
@@ -7,12 +7,9 @@ import software.amazon.awscdk.services.events.Rule;
 import software.amazon.awscdk.services.events.RuleProps;
 import software.amazon.awscdk.services.events.Schedule;
 import software.amazon.awscdk.services.events.targets.LambdaFunction;
-import software.amazon.awscdk.services.lambda.Code;
+import software.amazon.awscdk.services.lambda.*;
 import software.amazon.awscdk.services.lambda.Runtime;
-import software.amazon.awscdk.services.lambda.SingletonFunction;
-import software.amazon.awscdk.services.lambda.SingletonFunctionProps;
 
-import java.util.UUID;
 
 /**
  * Lambda Cron CDK example for Java!
@@ -21,9 +18,9 @@ class LambdaCronStack extends Stack {
     public LambdaCronStack(final Construct parent, final String name) {
         super(parent, name);
 
-        SingletonFunction lambdaFunction = new SingletonFunction(this, "cdk-lambda-cron",
-                SingletonFunctionProps.builder()
-                        .withFunctionName("CDK Lambda Cron Example")
+        Function lambdaFunction = new Function(this, "cdk-lambda-cron",
+                FunctionProps.builder()
+                        .withFunctionName("cdk-lambda")
                         .withDescription("Lambda which prints \"I'm running\"")
                         .withCode(Code.inline(
                                 "def main(event, context):\n" +
@@ -31,7 +28,6 @@ class LambdaCronStack extends Stack {
                         .withHandler("index.main")
                         .withTimeout(Duration.seconds(300))
                         .withRuntime(Runtime.PYTHON_2_7)
-                        .withUuid(UUID.randomUUID().toString())
                         .build()
         );
 

--- a/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
+++ b/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
@@ -23,7 +23,6 @@ class LambdaCronStack extends Stack {
 
         Function lambdaFunction = new Function(this, "cdk-lambda-cron",
                 FunctionProps.builder()
-                        .withFunctionName("cdk-lambda")
                         .withDescription("Lambda which prints \"I'm running\"")
                         .withCode(Code.inline(
                                 "def main(event, context):\n" +

--- a/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
+++ b/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
@@ -7,7 +7,10 @@ import software.amazon.awscdk.services.events.Rule;
 import software.amazon.awscdk.services.events.RuleProps;
 import software.amazon.awscdk.services.events.Schedule;
 import software.amazon.awscdk.services.events.targets.LambdaFunction;
-import software.amazon.awscdk.services.lambda.*;
+
+import software.amazon.awscdk.services.lambda.Code;
+import software.amazon.awscdk.services.lambda.Function;
+import software.amazon.awscdk.services.lambda.FunctionProps;
 import software.amazon.awscdk.services.lambda.Runtime;
 
 

--- a/java/lambda-cron/src/test/java/software/amazon/awscdk/examples/LambdaCronStackTest.java
+++ b/java/lambda-cron/src/test/java/software/amazon/awscdk/examples/LambdaCronStackTest.java
@@ -10,7 +10,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static software.amazon.awscdk.examples.TestUtils.toCloudFormationJson;
 
@@ -26,7 +27,7 @@ public class LambdaCronStackTest {
         expectedStack = TestUtils.fromFileResource(getClass().getResource("testCronLambdaExpected.json")).path("Resources");
     }
 
-    @Test()
+    @Test
     public void testTypes() {
         List<String> actual = actualStack.findValues("Type")
                 .stream().map(JsonNode::textValue).collect(Collectors.toList());

--- a/java/lambda-cron/src/test/java/software/amazon/awscdk/examples/LambdaCronStackTest.java
+++ b/java/lambda-cron/src/test/java/software/amazon/awscdk/examples/LambdaCronStackTest.java
@@ -8,30 +8,31 @@ import software.amazon.awscdk.core.Stack;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
 import static software.amazon.awscdk.examples.TestUtils.toCloudFormationJson;
 
 public class LambdaCronStackTest {
-    private App app;
-    private Stack stack;
     private JsonNode actualStack;
     private JsonNode expectedStack;
 
     @Before
     public void setUp() throws IOException {
-        app = new App();
-        stack = new LambdaCronStack(app, "lambdaResource-cdk-lambda-cron");
+        App app = new App();
+        Stack stack = new LambdaCronStack(app, "lambdaResource-cdk-lambda-cron");
         actualStack = toCloudFormationJson(stack).path("Resources");
         expectedStack = TestUtils.fromFileResource(getClass().getResource("testCronLambdaExpected.json")).path("Resources");
     }
 
     @Test()
     public void testTypes() {
-        List<JsonNode> actual = actualStack.findValues("Type");
-        List<JsonNode> expected = expectedStack.findValues("Type");
-        containsInAnyOrder(actual, expected);
+        List<String> actual = actualStack.findValues("Type")
+                .stream().map(JsonNode::textValue).collect(Collectors.toList());
+        String[] expected = expectedStack.findValues("Type")
+                .stream().map(JsonNode::textValue).toArray(String[]::new);
+        assertThat(actual, containsInAnyOrder(expected));
     }
 
     @Test
@@ -41,7 +42,7 @@ public class LambdaCronStackTest {
         JsonNode expected = TestUtils.getJsonNode(expectedStack, type);
         String[] keys = {"ManagedPolicyArns", "AssumeRolePolicyDocument"};
         for (String key : keys) {
-            assertEquals(actual.get(key), expected.get(key));
+            assertThat(actual.get(key), equalTo(expected.get(key)));
         }
     }
 
@@ -52,7 +53,7 @@ public class LambdaCronStackTest {
         JsonNode expected = TestUtils.getJsonNode(expectedStack, type);
         String[] keys = {"ManagedPolicyArns", "AssumeRolePolicyDocument"};
         for (String key : keys) {
-            assertEquals(actual.get(key), expected.get(key));
+            assertThat(actual.get(key), equalTo(expected.get(key)));
         }
     }
 
@@ -61,9 +62,9 @@ public class LambdaCronStackTest {
         final String type = "AWS::Lambda::Function";
         JsonNode actual = TestUtils.getJsonNode(actualStack, type);
         JsonNode expected = TestUtils.getJsonNode(expectedStack, type);
-        String[] keys = {"Runtime", "Description", "Timeout", "Handler", "Code"};
+        String[] keys = {"Runtime", "Description", "Timeout", "Handler", "Code", "FunctionName"};
         for (String key : keys) {
-            assertEquals(actual.get(key), expected.get(key));
+            assertThat(actual.get(key), equalTo(expected.get(key)));
         }
     }
 
@@ -74,8 +75,7 @@ public class LambdaCronStackTest {
         JsonNode expected = TestUtils.getJsonNode(expectedStack, type);
         String[] keys = {"ScheduleExpression", "Description", "State"};
         for (String key : keys) {
-            assertEquals(actual.get(key), expected.get(key));
+            assertThat(actual.get(key), equalTo(expected.get(key)));
         }
     }
-
 }

--- a/java/lambda-cron/src/test/resources/software/amazon/awscdk/examples/testCronLambdaExpected.json
+++ b/java/lambda-cron/src/test/resources/software/amazon/awscdk/examples/testCronLambdaExpected.json
@@ -9,12 +9,12 @@
         "Targets" : [ {
           "Id" : "cdk-lambda-cron",
           "Arn" : {
-            "Fn::GetAtt" : [ "SingletonLambda0dc9f04c622c4059b399834a2c1ac15f9CB1DC29", "Arn" ]
+            "Fn::GetAtt" : [ "cdklambdacronE8ADB9B0", "Arn" ]
           }
         } ]
       }
     },
-    "SingletonLambda0dc9f04c622c4059b399834a2c1ac15fServiceRoleD59355BD" : {
+    "cdklambdacronServiceRoleD85BC41F" : {
       "Type" : "AWS::IAM::Role",
       "Properties" : {
         "ManagedPolicyArns" : [ {
@@ -38,11 +38,11 @@
         }
       }
     },
-    "SingletonLambda0dc9f04c622c4059b399834a2c1ac15fAllowEventRulelambdaResourcecdklambdacroncdklambdacronruleD22C5DC3B70D87DC" : {
+    "cdklambdacronAllowEventRulelambdaResourcecdklambdacroncdklambdacronruleD22C5DC3BDDE5CCA" : {
       "Type" : "AWS::Lambda::Permission",
       "Properties" : {
         "FunctionName" : {
-          "Ref" : "SingletonLambda0dc9f04c622c4059b399834a2c1ac15f9CB1DC29"
+          "Ref" : "cdklambdacronE8ADB9B0"
         },
         "Action" : "lambda:InvokeFunction",
         "SourceArn" : {
@@ -51,11 +51,11 @@
         "Principal" : "events.amazonaws.com"
       }
     },
-    "SingletonLambda0dc9f04c622c4059b399834a2c1ac15f9CB1DC29" : {
+    "cdklambdacronE8ADB9B0" : {
       "Type" : "AWS::Lambda::Function",
       "Properties" : {
         "Role" : {
-          "Fn::GetAtt" : [ "SingletonLambda0dc9f04c622c4059b399834a2c1ac15fServiceRoleD59355BD", "Arn" ]
+          "Fn::GetAtt" : [ "cdklambdacronServiceRoleD85BC41F", "Arn" ]
         },
         "Runtime" : "python2.7",
         "Description" : "Lambda which prints \"I'm running\"",

--- a/java/lambda-cron/src/test/resources/software/amazon/awscdk/examples/testCronLambdaExpected.json
+++ b/java/lambda-cron/src/test/resources/software/amazon/awscdk/examples/testCronLambdaExpected.json
@@ -9,12 +9,12 @@
         "Targets" : [ {
           "Id" : "cdk-lambda-cron",
           "Arn" : {
-            "Fn::GetAtt" : [ "cdklambdacronE8ADB9B0", "Arn" ]
+            "Fn::GetAtt" : [ "SingletonLambda0dc9f04c622c4059b399834a2c1ac15f9CB1DC29", "Arn" ]
           }
         } ]
       }
     },
-    "cdklambdacronServiceRoleD85BC41F" : {
+    "SingletonLambda0dc9f04c622c4059b399834a2c1ac15fServiceRoleD59355BD" : {
       "Type" : "AWS::IAM::Role",
       "Properties" : {
         "ManagedPolicyArns" : [ {
@@ -38,11 +38,11 @@
         }
       }
     },
-    "cdklambdacronAllowEventRulelambdaResourcecdklambdacroncdklambdacronruleD22C5DC3BDDE5CCA" : {
+    "SingletonLambda0dc9f04c622c4059b399834a2c1ac15fAllowEventRulelambdaResourcecdklambdacroncdklambdacronruleD22C5DC3B70D87DC" : {
       "Type" : "AWS::Lambda::Permission",
       "Properties" : {
         "FunctionName" : {
-          "Ref" : "cdklambdacronE8ADB9B0"
+          "Ref" : "SingletonLambda0dc9f04c622c4059b399834a2c1ac15f9CB1DC29"
         },
         "Action" : "lambda:InvokeFunction",
         "SourceArn" : {
@@ -51,11 +51,11 @@
         "Principal" : "events.amazonaws.com"
       }
     },
-    "cdklambdacronE8ADB9B0" : {
+    "SingletonLambda0dc9f04c622c4059b399834a2c1ac15f9CB1DC29" : {
       "Type" : "AWS::Lambda::Function",
       "Properties" : {
         "Role" : {
-          "Fn::GetAtt" : [ "cdklambdacronServiceRoleD85BC41F", "Arn" ]
+          "Fn::GetAtt" : [ "SingletonLambda0dc9f04c622c4059b399834a2c1ac15fServiceRoleD59355BD", "Arn" ]
         },
         "Runtime" : "python2.7",
         "Description" : "Lambda which prints \"I'm running\"",

--- a/java/lambda-cron/src/test/resources/software/amazon/awscdk/examples/testCronLambdaExpected.json
+++ b/java/lambda-cron/src/test/resources/software/amazon/awscdk/examples/testCronLambdaExpected.json
@@ -57,7 +57,6 @@
         "Role" : {
           "Fn::GetAtt" : [ "SingletonLambda0dc9f04c622c4059b399834a2c1ac15fServiceRoleD59355BD", "Arn" ]
         },
-        "FunctionName" : "cdk-lambda",
         "Runtime" : "python2.7",
         "Description" : "Lambda which prints \"I'm running\"",
         "Timeout" : 300,

--- a/java/lambda-cron/src/test/resources/software/amazon/awscdk/examples/testCronLambdaExpected.json
+++ b/java/lambda-cron/src/test/resources/software/amazon/awscdk/examples/testCronLambdaExpected.json
@@ -57,7 +57,7 @@
         "Role" : {
           "Fn::GetAtt" : [ "SingletonLambda0dc9f04c622c4059b399834a2c1ac15fServiceRoleD59355BD", "Arn" ]
         },
-        "FunctionName" : "CDK Lambda Cron Example",
+        "FunctionName" : "cdk-lambda",
         "Runtime" : "python2.7",
         "Description" : "Lambda which prints \"I'm running\"",
         "Timeout" : 300,


### PR DESCRIPTION
***Description of changes:***

**1. Updated unit tests to make sure the assertions were running.**
As one of them didn't actually assert anything (`testTypes`). Whilst there, I also fixed some of the tests and the `actual` and `expected` were the wrong way around, unless using hamcrest's `assertThat` (which it now is).

**2. Fixed deployment by removing the function name.**

**Before**
The function name was invalid, although it passed CFT validation, it resulted in:
```
 3/6 | 11:14:26 PM | CREATE_FAILED        | AWS::Lambda::Function   | SingletonLambdac4f9439a61bd48c9859d3e91a657e2cb (SingletonLambdac4f9439a61bd48c9859d3e91a657e2cbF7A8D345) 1 validation er
ror detected: Value 'CDK Lambda Cron Example' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(
-iso(b?)))?-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_\.]+)(:(\$LATEST|[a-zA-Z0-9-_]+))? (Service: AWSLambdaInternal; Status Code: 400; Error Code: ValidationException; Request ID: 67
e1126c-2a1e-4586-a7e6-3e810328682b)
```

**After:**
```
3/6 | 12:05:15 AM | CREATE_COMPLETE      | AWS::Lambda::Function   | cdk-lambda-cron (cdklambdacronE8ADB9B0)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.