### PR TITLE
Fixed function name so it fits the expected Lambda pattern

### DIFF
--- a/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
+++ b/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
@@ -23,7 +23,7 @@ class LambdaCronStack extends Stack {
 
         SingletonFunction lambdaFunction = new SingletonFunction(this, "cdk-lambda-cron",
                 SingletonFunctionProps.builder()
-                        .withFunctionName("CDK Lambda Cron Example")
+                        .withFunctionName("CDKLambdaCronExample")
                         .withDescription("Lambda which prints \"I'm running\"")
                         .withCode(Code.inline(
                                 "def main(event, context):\n" +


### PR DESCRIPTION
Running the Java example for "Lambda cron" fails with the current code. This is due to the name of the function containing spaces which is not allowed in the Lambda function name pattern. The error reported by `cdk deploy` looks like this:

```
 3/6 | 12:46:46 | CREATE_FAILED        | AWS::Lambda::Function   | SingletonLambda025f335dd48e4342a0a584783a9dca46 (SingletonLambda025f335dd48e4342a0a584783a9dca46146E2993) 1 validation error detected: Value 'CDK Lambda Cron Example' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_\.]+)(:(\$LATEST|[a-zA-Z0-9-_]+))? (Service: AWSLambdaInternal; Status Code: 400; Error Code: ValidationException; Request ID: 52b6e8cc-d7ce-45e4-8823-fac0c800d660)
```

This update changes the name from `CDK Lambda Cron Example` to `CDKLambdaCronExample`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
