### PR TITLE
Reference to Typescript >Python translation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AWS CDK Examples
 
 This repository contains a set of example projects for the [AWS Cloud Development
-Kit](https://github.com/awslabs/aws-cdk). Some examples are only available in TypeScript, there  is a guide on how to read TypeScript code and translate it to Python [here](https://docs.aws.amazon.com/cdk/latest/guide/multiple_languages.html). This is currently the only other stable programming language that the AWS CDK supports (the AWS CDK supports a developer preview version of Java and C#/.NET)
+Kit](https://github.com/awslabs/aws-cdk). Some examples are only available in TypeScript, there is a guide on how to read TypeScript code and translate it to Python [here](https://docs.aws.amazon.com/cdk/latest/guide/multiple_languages.html).
 
 ## Table of Contents
 1. [TypeScript examples](#TypeScript)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # AWS CDK Examples
 
 This repository contains a set of example projects for the [AWS Cloud Development
-Kit](https://github.com/awslabs/aws-cdk).
+Kit](https://github.com/awslabs/aws-cdk). Some examples are only available in TypeScript, there  is a guide on how to read TypeScript code and translate it to Python [here](https://docs.aws.amazon.com/cdk/latest/guide/multiple_languages.html). This is currently the only other stable programming language that the AWS CDK supports (the AWS CDK supports a developer preview version of Java and C#/.NET)
 
 ## Table of Contents
 1. [TypeScript examples](#TypeScript)


### PR DESCRIPTION
*Description of changes:* Added reference to doc that provides guidance on how to read TypeScript code and translating it to Python.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
