### PR TITLE
sets removal policy on S3 and DynamoDB to DESTROY

### DIFF
--- a/typescript/api-cors-lambda-crud-dynamodb/index.ts
+++ b/typescript/api-cors-lambda-crud-dynamodb/index.ts
@@ -12,7 +12,12 @@ export class ApiLambdaCrudDynamoDBStack extends cdk.Stack {
         name: 'itemId',
         type: dynamodb.AttributeType.STRING
       },
-      tableName: 'items'
+      tableName: 'items',
+
+      // The default removal policy is RETAIN, which means that cdk destroy will not attempt to delete
+      // the new table, and it will remain in your account until manually deleted. By setting the policy to 
+      // DESTROY, cdk destroy will delete the table (even if it has data in it)
+      removalPolicy: cdk.RemovalPolicy.DESTROY, // NOT recommended for production code
     });
 
     const getOneLambda = new lambda.Function(this, 'getOneItemFunction', {

--- a/typescript/appsync-graphql-dynamodb/index.ts
+++ b/typescript/appsync-graphql-dynamodb/index.ts
@@ -51,7 +51,12 @@ export class AppSyncCdkStack extends cdk.Stack {
         type: AttributeType.STRING
       },
       billingMode: BillingMode.PAY_PER_REQUEST,
-      stream: StreamViewType.NEW_IMAGE
+      stream: StreamViewType.NEW_IMAGE,
+
+      // The default removal policy is RETAIN, which means that cdk destroy will not attempt to delete
+      // the new table, and it will remain in your account until manually deleted. By setting the policy to 
+      // DESTROY, cdk destroy will delete the table (even if it has data in it)
+      removalPolicy: cdk.RemovalPolicy.DESTROY, // NOT recommended for production code
     });
 
     const itemsTableRole = new Role(this, 'ItemsDynamoDBRole', {

--- a/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
@@ -16,7 +16,12 @@ export class CdkStack extends cdk.Stack {
     const green_env = node.tryGetContext("green_env");
     const app_name = node.tryGetContext("app_name");
 
-    const bucket = new s3.Bucket(this, 'BlueGreenBucket');
+    const bucket = new s3.Bucket(this, 'BlueGreenBucket', {
+      // The default removal policy is RETAIN, which means that cdk destroy will not attempt to delete
+      // the new bucket, and it will remain in your account until manually deleted. By setting the policy to 
+      // DESTROY, cdk destroy will attempt to delete the bucket, but will error if the bucket is not empty.
+      removalPolicy: cdk.RemovalPolicy.DESTROY, // NOT recommended for production code
+    });
 
     const handler = new lambda.Function(this, 'BlueGreenLambda', {
       runtime: lambda.Runtime.PYTHON_3_6,

--- a/typescript/my-widget-service/widget_service.ts
+++ b/typescript/my-widget-service/widget_service.ts
@@ -36,7 +36,12 @@ export class WidgetService extends cdk.Construct {
   constructor(scope: cdk.Construct, id: string) {
     super(scope, id);
 
-    const bucket = new s3.Bucket(this, "WidgetStore");
+    const bucket = new s3.Bucket(this, "WidgetStore", {
+      // The default removal policy is RETAIN, which means that cdk destroy will not attempt to delete
+      // the new bucket, and it will remain in your account until manually deleted. By setting the policy to 
+      // DESTROY, cdk destroy will attempt to delete the bucket, but will error if the bucket is not empty.
+      removalPolicy: cdk.RemovalPolicy.DESTROY, // NOT recommended for production code
+    });
 
     const handler = new lambda.Function(this, "WidgetHandler", {
       runtime: lambda.Runtime.NODEJS_8_10, // So we can use async in widget.js

--- a/typescript/static-site/static-site.ts
+++ b/typescript/static-site/static-site.ts
@@ -32,7 +32,12 @@ export class StaticSite extends Construct {
             bucketName: siteDomain,
             websiteIndexDocument: 'index.html',
             websiteErrorDocument: 'error.html',
-            publicReadAccess: true
+            publicReadAccess: true,
+
+            // The default removal policy is RETAIN, which means that cdk destroy will not attempt to delete
+            // the new bucket, and it will remain in your account until manually deleted. By setting the policy to 
+            // DESTROY, cdk destroy will attempt to delete the bucket, but will error if the bucket is not empty.
+            removalPolicy: cdk.RemovalPolicy.DESTROY, // NOT recommended for production code
         });
         new cdk.CfnOutput(this, 'Bucket', { value: siteBucket.bucketName });
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-cdk-examples/issues/99

*Description of changes:*
Changes the behaviour of examples that create S3 Buckets and DynamoDB Tables such that these resources are deleted by cdk destroy. Explains the behaviour in comments

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
