### PR TITLE
feat: Added Python example - API GW with lambda integration and CORS enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ $ cdk destroy
 
 | Example | Description |
 |---------|-------------|
+| [api-cors-lambda](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/api-cors-lambda/) | Shows creation of Rest API (GW) with an /example GET endpoint, with CORS enabled |
 | [application-load-balancer](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/application-load-balancer/) | Using an AutoScalingGroup with an Application Load Balancer |
 | [classic-load-balancer](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/classic-load-balancer/) | Using an AutoScalingGroup with a Classic Load Balancer |
 | [custom-resource](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/custom-resource/) | Shows adding a Custom Resource to your CDK app |

--- a/python/api-cors-lambda/app.py
+++ b/python/api-cors-lambda/app.py
@@ -1,0 +1,72 @@
+from aws_cdk import (
+    core,
+    aws_lambda as _lambda,
+    aws_apigateway as _apigw
+)
+
+
+class ApiCorsLambdaStack(core.Stack):
+
+    def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        base_lambda = _lambda.Function(self,'ApiCorsLambda',
+        handler='lambda-handler.handler',
+        runtime=_lambda.Runtime.PYTHON_3_7,
+        code=_lambda.Code.asset('lambda'),
+        )
+        
+        base_api = _apigw.RestApi(self, 'ApiGatewayWithCors',
+        rest_api_name='ApiGatewayWithCors')
+
+        example_entity = base_api.root.add_resource('example')
+        example_entity_lambda_integration = _apigw.LambdaIntegration(base_lambda,proxy=False, integration_responses=[
+            {
+                'statusCode': '200',
+                'responseParameters': {
+                'method.response.header.Access-Control-Allow-Origin': "'*'",
+                }
+            }
+                ]
+            )
+        example_entity.add_method('GET', example_entity_lambda_integration, 
+                method_responses=[{
+                    'statusCode': '200',
+                    'responseParameters': {
+                        'method.response.header.Access-Control-Allow-Origin': True,
+                }
+            }
+        ]
+            )
+
+        self.add_cors_options(example_entity)
+
+
+    def add_cors_options(self, apigw_resource):
+        apigw_resource.add_method('OPTIONS', _apigw.MockIntegration(
+            integration_responses=[{
+                'statusCode': '200',
+                'responseParameters': {
+                    'method.response.header.Access-Control-Allow-Headers': "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+                    'method.response.header.Access-Control-Allow-Origin': "'*'",
+                    'method.response.header.Access-Control-Allow-Methods': "'GET,OPTIONS'"
+                }
+            }
+            ],
+            passthrough_behavior=_apigw.PassthroughBehavior.WHEN_NO_MATCH,
+            request_templates={"application/json":"{\"statusCode\":200}"}
+        ),
+        method_responses=[{
+            'statusCode': '200',
+            'responseParameters': {
+                'method.response.header.Access-Control-Allow-Headers': True,
+                'method.response.header.Access-Control-Allow-Methods': True,
+                'method.response.header.Access-Control-Allow-Origin': True,
+                }
+            }
+        ],
+    )
+
+app = core.App()
+ApiCorsLambdaStack(app, "ApiCorsLambdaStack")
+app.synth()

--- a/python/api-cors-lambda/cdk.json
+++ b/python/api-cors-lambda/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/api-cors-lambda/lambda/lambda-handler.py
+++ b/python/api-cors-lambda/lambda/lambda-handler.py
@@ -1,0 +1,6 @@
+def handler(event, context):
+    return {
+        'statusCode': 200,
+        'body': 'Lambda was invoked successfully.'
+    }
+


### PR DESCRIPTION
This PR will add an example in Python, showing one possible way of creating an API GW Rest API, with an /example endpoint (method: GET), with CORS enabled.
Should be fairly straight forward to modify and expand.
There's a similar example in typescript, although this one is a bit more simplifed, and is in Python (Which lacks examples IMHO).
CORS functionality was Tested locally, as well as by using https://www.test-cors.org/.
