### PR TITLE
fix: Update Fargate LoadBalance Service examples

### DIFF
--- a/python/ecs/ecs-load-balanced-service/app.py
+++ b/python/ecs/ecs-load-balanced-service/app.py
@@ -24,7 +24,7 @@ class BonjourECS(core.Stack):
         cluster.add_capacity("DefaultAutoScalingGroup",
                              instance_type=ec2.InstanceType("t2.micro"))
 
-        ecs_service = ecs_patterns.LoadBalancedEc2Service(
+        ecs_service = ecs_patterns.NetworkLoadBalancedEc2Service(
             self, "Ec2Service",
             cluster=cluster,
             memory_limit_mib=512,

--- a/python/ecs/fargate-load-balanced-service/app.py
+++ b/python/ecs/fargate-load-balanced-service/app.py
@@ -23,7 +23,7 @@ class BonjourFargate(core.Stack):
             vpc=vpc
         )
 
-        fargate_service = ecs_patterns.LoadBalancedFargateService(
+        fargate_service = ecs_patterns.NetworkLoadBalancedFargateService(
             self, "FargateService",
             cluster=cluster,
             image=ecs.ContainerImage.from_registry("amazon/amazon-ecs-sample")

--- a/python/ecs/fargate-service-with-autoscaling/app.py
+++ b/python/ecs/fargate-service-with-autoscaling/app.py
@@ -23,7 +23,7 @@ class AutoScalingFargateService(core.Stack):
         )
 
         # Create Fargate Service
-        fargate_service = ecs_patterns.LoadBalancedFargateService(
+        fargate_service = ecs_patterns.NetworkLoadBalancedFargateService(
             self, "sample-app",
             cluster=cluster,
             image=ecs.ContainerImage.from_registry("amazon/amazon-ecs-sample")

--- a/typescript/ecs/ecs-load-balanced-service/index.ts
+++ b/typescript/ecs/ecs-load-balanced-service/index.ts
@@ -18,7 +18,7 @@ class BonjourECS extends cdk.Stack {
     });
 
     // Instantiate ECS Service with just cluster and image
-    const ecsService = new ecs_patterns.LoadBalancedEc2Service(this, "Ec2Service", {
+    const ecsService = new ecs_patterns.NetworkLoadBalancedEc2Service(this, "Ec2Service", {
       cluster,
       memoryLimitMiB: 512,
       image: ecs.ContainerImage.fromRegistry("amazon/amazon-ecs-sample"),

--- a/typescript/ecs/fargate-load-balanced-service/index.ts
+++ b/typescript/ecs/fargate-load-balanced-service/index.ts
@@ -13,7 +13,7 @@ class BonjourFargate extends cdk.Stack {
     const cluster = new ecs.Cluster(this, 'Cluster', { vpc });
 
     // Instantiate Fargate Service with just cluster and image
-    const fargateService = new ecs_patterns.LoadBalancedFargateService(this, "FargateService", {
+    const fargateService = new ecs_patterns.NetworkLoadBalancedFargateService(this, "FargateService", {
       cluster,
       image: ecs.ContainerImage.fromRegistry("amazon/amazon-ecs-sample"),
     });

--- a/typescript/ecs/fargate-service-with-auto-scaling/index.ts
+++ b/typescript/ecs/fargate-service-with-auto-scaling/index.ts
@@ -12,7 +12,7 @@ class AutoScalingFargateService extends cdk.Stack {
     const cluster = new ecs.Cluster(this, 'fargate-service-autoscaling', { vpc });
 
     // Create Fargate Service
-    const fargateService = new ecs_patterns.LoadBalancedFargateService(this, 'sample-app', {
+    const fargateService = new ecs_patterns.NetworkLoadBalancedFargateService(this, 'sample-app', {
       cluster,
       image: ecs.ContainerImage.fromRegistry("amazon/amazon-ecs-sample")
     });

--- a/typescript/ecs/fargate-service-with-local-image/index.ts
+++ b/typescript/ecs/fargate-service-with-local-image/index.ts
@@ -16,7 +16,7 @@ const cluster = new ecs.Cluster(stack, 'Cluster', { vpc });
 // uploaded to an S3 staging bucket prior to being uploaded to ECR.
 // A new repository is created in ECR and the Fargate service is created
 // with the image from ECR.
-new ecs_patterns.LoadBalancedFargateService(stack, "FargateService", {
+new ecs_patterns.NetworkLoadBalancedFargateService(stack, "FargateService", {
   cluster,
   image: ecs.ContainerImage.fromAsset(path.resolve(__dirname, 'local-image'))
 });


### PR DESCRIPTION
Updating several Fargate examples for TypeScript and Python based on breaking change in https://github.com/aws/aws-cdk/pull/3719.

Fixes #125

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0