### PR TITLE
chore: update lambda.Runtime to NODEJS_10_X

### DIFF
--- a/typescript/api-cors-lambda-crud-dynamodb/index.ts
+++ b/typescript/api-cors-lambda-crud-dynamodb/index.ts
@@ -23,7 +23,7 @@ export class ApiLambdaCrudDynamoDBStack extends cdk.Stack {
     const getOneLambda = new lambda.Function(this, 'getOneItemFunction', {
       code: new lambda.AssetCode('src'),
       handler: 'get-one.handler',
-      runtime: lambda.Runtime.NODEJS_8_10,
+      runtime: lambda.Runtime.NODEJS_10_X,
       environment: {
         TABLE_NAME: dynamoTable.tableName,
         PRIMARY_KEY: 'itemId'
@@ -33,7 +33,7 @@ export class ApiLambdaCrudDynamoDBStack extends cdk.Stack {
     const getAllLambda = new lambda.Function(this, 'getAllItemsFunction', {
       code: new lambda.AssetCode('src'),
       handler: 'get-all.handler',
-      runtime: lambda.Runtime.NODEJS_8_10,
+      runtime: lambda.Runtime.NODEJS_10_X,
       environment: {
         TABLE_NAME: dynamoTable.tableName,
         PRIMARY_KEY: 'itemId'
@@ -43,7 +43,7 @@ export class ApiLambdaCrudDynamoDBStack extends cdk.Stack {
     const createOne = new lambda.Function(this, 'createItemFunction', {
       code: new lambda.AssetCode('src'),
       handler: 'create.handler',
-      runtime: lambda.Runtime.NODEJS_8_10,
+      runtime: lambda.Runtime.NODEJS_10_X,
       environment: {
         TABLE_NAME: dynamoTable.tableName,
         PRIMARY_KEY: 'itemId'
@@ -53,7 +53,7 @@ export class ApiLambdaCrudDynamoDBStack extends cdk.Stack {
     const updateOne = new lambda.Function(this, 'updateItemFunction', {
       code: new lambda.AssetCode('src'),
       handler: 'update-one.handler',
-      runtime: lambda.Runtime.NODEJS_8_10,
+      runtime: lambda.Runtime.NODEJS_10_X,
       environment: {
         TABLE_NAME: dynamoTable.tableName,
         PRIMARY_KEY: 'itemId'
@@ -63,7 +63,7 @@ export class ApiLambdaCrudDynamoDBStack extends cdk.Stack {
     const deleteOne = new lambda.Function(this, 'deleteItemFunction', {
       code: new lambda.AssetCode('src'),
       handler: 'delete-one.handler',
-      runtime: lambda.Runtime.NODEJS_8_10,
+      runtime: lambda.Runtime.NODEJS_10_X,
       environment: {
         TABLE_NAME: dynamoTable.tableName,
         PRIMARY_KEY: 'itemId'

--- a/typescript/api-cors-lambda-crud-dynamodb/package.json
+++ b/typescript/api-cors-lambda-crud-dynamodb/package.json
@@ -14,8 +14,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^10.14.19",
-    "typescript": "^3.2.4"
+    "@types/node": "^10.17.0",
+    "typescript": "~3.6.4"
   },
   "dependencies": {
     "@aws-cdk/aws-apigateway": "*",

--- a/typescript/api-cors-lambda-crud-dynamodb/package.json
+++ b/typescript/api-cors-lambda-crud-dynamodb/package.json
@@ -14,7 +14,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^8.10.38",
+    "@types/node": "^10.14.19",
     "typescript": "^3.2.4"
   },
   "dependencies": {

--- a/typescript/application-load-balancer/package.json
+++ b/typescript/application-load-balancer/package.json
@@ -15,8 +15,8 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "typescript": "^3.2.4"
+    "@types/node": "^10.17.0",
+    "typescript": "~3.6.4"
   },
   "dependencies": {
     "@aws-cdk/aws-autoscaling": "*",

--- a/typescript/appsync-graphql-dynamodb/package.json
+++ b/typescript/appsync-graphql-dynamodb/package.json
@@ -14,8 +14,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "typescript": "^3.2.4"
+    "@types/node": "^10.17.0",
+    "typescript": "~3.6.4"
   },
   "dependencies": {
     "@aws-cdk/aws-appsync": "*",

--- a/typescript/classic-load-balancer/package.json
+++ b/typescript/classic-load-balancer/package.json
@@ -15,8 +15,8 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "typescript": "^3.2.4"
+    "@types/node": "^10.17.0",
+    "typescript": "~3.6.4"
   },
   "dependencies": {
     "@aws-cdk/aws-autoscaling": "*",

--- a/typescript/custom-resource/package.json
+++ b/typescript/custom-resource/package.json
@@ -15,8 +15,8 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "typescript": "^3.2.4"
+    "@types/node": "^10.17.0",
+    "typescript": "~3.6.4"
   },
   "dependencies": {
     "@aws-cdk/aws-cloudformation": "*",

--- a/typescript/lambda-cron/package.json
+++ b/typescript/lambda-cron/package.json
@@ -15,8 +15,8 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "typescript": "^3.2.4"
+    "@types/node": "^10.17.0",
+    "typescript": "~3.6.4"
   },
   "dependencies": {
     "@aws-cdk/aws-events": "*",

--- a/typescript/my-widget-service/package.json
+++ b/typescript/my-widget-service/package.json
@@ -15,7 +15,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.9.4",
+    "@types/node": "^10.14.19",
     "typescript": "^3.1.2",
     "aws-cdk": "*"
   },

--- a/typescript/my-widget-service/package.json
+++ b/typescript/my-widget-service/package.json
@@ -15,9 +15,8 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^10.14.19",
-    "typescript": "^3.1.2",
-    "aws-cdk": "*"
+    "@types/node": "^10.17.0",
+    "typescript": "~3.6.4"
   },
   "dependencies": {
     "@aws-cdk/aws-apigateway": "*",

--- a/typescript/my-widget-service/widget_service.ts
+++ b/typescript/my-widget-service/widget_service.ts
@@ -44,7 +44,7 @@ export class WidgetService extends cdk.Construct {
     });
 
     const handler = new lambda.Function(this, "WidgetHandler", {
-      runtime: lambda.Runtime.NODEJS_8_10, // So we can use async in widget.js
+      runtime: lambda.Runtime.NODEJS_10_X, // So we can use async in widget.js
       code: lambda.AssetCode.asset("resources"),
       handler: "widgets.main",
       environment: {

--- a/typescript/resource-overrides/package.json
+++ b/typescript/resource-overrides/package.json
@@ -15,8 +15,8 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "typescript": "^3.2.4"
+    "@types/node": "^10.17.0",
+    "typescript": "~3.6.4"
   },
   "dependencies": {
     "@aws-cdk/aws-autoscaling": "*",

--- a/typescript/static-site/package.json
+++ b/typescript/static-site/package.json
@@ -14,8 +14,8 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^10.9.4",
-    "typescript": "^3.2.4"
+    "@types/node": "^10.17.0",
+    "typescript": "~3.6.4"
   },
   "dependencies": {
     "@aws-cdk/aws-certificatemanager": "*",

--- a/typescript/stepfunctions-job-poller/package.json
+++ b/typescript/stepfunctions-job-poller/package.json
@@ -15,8 +15,8 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "typescript": "^3.2.4"
+    "@types/node": "^10.17.0",
+    "typescript": "~3.6.4"
   },
   "dependencies": {
     "@aws-cdk/aws-stepfunctions": "*",


### PR DESCRIPTION
Node.js 8.x EoL is on 31 Dec 2019 https://endoflife.date/nodejs

Fixes #132

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
