### PR TITLE
fix: update ecs-patterns examples to use the latest version of the cdk

### DIFF
--- a/typescript/ecs/fargate-service-with-local-image/index.ts
+++ b/typescript/ecs/fargate-service-with-local-image/index.ts
@@ -20,7 +20,11 @@ new ecs_patterns.NetworkLoadBalancedFargateService(stack, "FargateService", {
   cluster,
   taskImageOptions: {
     image: ecs.ContainerImage.fromAsset(path.resolve(__dirname, 'local-image'))
+<<<<<<< HEAD
   }
+=======
+  },
+>>>>>>> Fix ecs-patterns examples to use the latest version of the cdk
 });
 
 app.synth();

--- a/typescript/ecs/fargate-service-with-local-image/index.ts
+++ b/typescript/ecs/fargate-service-with-local-image/index.ts
@@ -20,11 +20,7 @@ new ecs_patterns.NetworkLoadBalancedFargateService(stack, "FargateService", {
   cluster,
   taskImageOptions: {
     image: ecs.ContainerImage.fromAsset(path.resolve(__dirname, 'local-image'))
-<<<<<<< HEAD
-  }
-=======
   },
->>>>>>> Fix ecs-patterns examples to use the latest version of the cdk
 });
 
 app.synth();


### PR DESCRIPTION
Updated the ecs examples to use the latest version of the cdk.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
