### PR TITLE
fix: update my-widget-service examples to use the latest version of the cdk and dotnet core and node.js

### DIFF
--- a/csharp/my-widget-service/cdk.json
+++ b/csharp/my-widget-service/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "dotnet src/MyWidgetService/bin/Debug/netcoreapp2.1/MyWidgetService.dll"
+  "app": "dotnet src/MyWidgetService/bin/Debug/netcoreapp3.0/MyWidgetService.dll"
 }

--- a/csharp/my-widget-service/src/MyWidgetService/MyWidgetService.csproj
+++ b/csharp/my-widget-service/src/MyWidgetService/MyWidgetService.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK" Version="1.2.0-devpreview" />
-    <PackageReference Include="Amazon.CDK.AWS.ApiGateway" Version="1.2.0-devpreview" />
-    <PackageReference Include="Amazon.CDK.AWS.Lambda" Version="1.2.0-devpreview" />
-    <PackageReference Include="Amazon.CDK.AWS.S3" Version="1.2.0-devpreview" />
+    <PackageReference Include="Amazon.CDK" Version="1.13.1-devpreview" />
+    <PackageReference Include="Amazon.CDK.AWS.ApiGateway" Version="1.13.1-devpreview" />
+    <PackageReference Include="Amazon.CDK.AWS.Lambda" Version="1.13.1-devpreview" />
+    <PackageReference Include="Amazon.CDK.AWS.S3" Version="1.13.1-devpreview" />
   </ItemGroup>
 
 </Project>

--- a/csharp/my-widget-service/src/MyWidgetService/MyWidgetServiceStack.cs
+++ b/csharp/my-widget-service/src/MyWidgetService/MyWidgetServiceStack.cs
@@ -13,10 +13,10 @@ namespace MyWidgetService
             var bucket = new Bucket(this, "WidgetStore", null);
 
             var handler = new Function(this, "WidgetHandler", new FunctionProps {
-                Runtime = Runtime.NODEJS_8_10,
-                Code = AssetCode.Asset("src/MyWidgetService/resources"),
+                Runtime = Runtime.NODEJS_10_X,
+                Code = AssetCode.FromAsset("src/MyWidgetService/resources"),
                 Handler = "widgets.main",
-                Environment = new Dictionary<string, object>{
+                Environment = new Dictionary<string, string>{
                     { "BUCKET", bucket.BucketName }
                 }
             });


### PR DESCRIPTION
version up list
- dotnetcore: netcoreapp2.1 to netcoreapp3.0
- cdk: 1.2.0-devpreview to 1.13.1-devpreview
- node.js: NODEJS_8_10 to NODEJS_10_X

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
