### PR TITLE
chore(ecs): add the usage of "loadBalancerTarget()" when creating target group

### DIFF
--- a/typescript/ecs/ecs-service-with-advanced-alb-config/index.ts
+++ b/typescript/ecs/ecs-service-with-advanced-alb-config/index.ts
@@ -43,7 +43,10 @@ const listener = lb.addListener('PublicListener', { port: 80, open: true });
 // Attach ALB to ECS Service
 listener.addTargets('ECS', {
   port: 80,
-  targets: [service],
+  targets: [service.loadBalancerTarget({
+    containerName: 'web',
+    containerPort: 80
+  })],
   // include health check (default is none)
   healthCheck: {
     interval: cdk.Duration.seconds(60),


### PR DESCRIPTION
<!--
Add the usage of `service.loadBalancerTarget()` to ECS ALB example, so as to make it clear about how to have more control over containers and ports when registering ECS targets.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
