### PR TITLE
fix: Lambda runtime has been changed from PYTHON_2_7 to PYTHON_3_6

### DIFF
--- a/typescript/custom-resource/my-custom-resource.ts
+++ b/typescript/custom-resource/my-custom-resource.ts
@@ -23,7 +23,7 @@ export class MyCustomResource extends cdk.Construct {
         code: new lambda.InlineCode(fs.readFileSync('custom-resource-handler.py', { encoding: 'utf-8' })),
         handler: 'index.main',
         timeout: cdk.Duration.seconds(300),
-        runtime: lambda.Runtime.PYTHON_2_7,
+        runtime: lambda.Runtime.PYTHON_3_6,
       })),
       properties: props
     });

--- a/typescript/lambda-cron/index.ts
+++ b/typescript/lambda-cron/index.ts
@@ -13,7 +13,7 @@ export class LambdaCronStack extends cdk.Stack {
       code: new lambda.InlineCode(fs.readFileSync('lambda-handler.py', { encoding: 'utf-8' })),
       handler: 'index.main',
       timeout: cdk.Duration.seconds(300),
-      runtime: lambda.Runtime.PYTHON_2_7,
+      runtime: lambda.Runtime.PYTHON_3_6,
     });
 
     // Run every day at 6PM UTC


### PR DESCRIPTION
The Python version specified in the Lambda runtime has been changed from PYTHON_2_7 to PYTHON_3_6.

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
