### PR TITLE
fix: Lambda runtime has been changed from PYTHON_2_7 to PYTHON_3_6 - Java

### DIFF
--- a/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
+++ b/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
@@ -29,7 +29,7 @@ class LambdaCronStack extends Stack {
                                         "    print(\"I'm running!\")\n"))
                         .withHandler("index.main")
                         .withTimeout(Duration.seconds(300))
-                        .withRuntime(Runtime.PYTHON_2_7)
+                        .withRuntime(Runtime.PYTHON_3_6)
                         .withUuid(UUID.randomUUID().toString())
                         .build()
         );


### PR DESCRIPTION
The Python version specified in the Lambda runtime has been changed from PYTHON_2_7 to PYTHON_3_6.


By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
