### PR TITLE
fix: update the Python URL shortener example with the new cdk.context.json used by the VPC provider

### DIFF
--- a/python/ecs/cluster/app.py
+++ b/python/ecs/cluster/app.py
@@ -24,7 +24,7 @@ class ECSCluster(core.Stack):
             update_type=autoscaling.UpdateType.REPLACING_UPDATE,
             desired_capacity=3,
             vpc=vpc,
-            vpc_subnets={'subnetType': ec2.SubnetType.PUBLIC}
+            vpc_subnets={ 'subnet_type': ec2.SubnetType.PUBLIC },
         )
 
         cluster = ecs.Cluster(

--- a/python/url-shortener/cdk.context.json
+++ b/python/url-shortener/cdk.context.json
@@ -1,36 +1,50 @@
 {
-  "vpc-provider:account=111111111111:filter.vpc-id=vpc-11111111111111111:region=us-east-1": {
+  "vpc-provider:account=111111111111:filter.vpc-id=vpc-11111111111111111:region=us-east-1:returnAsymmetricSubnets=true": {
     "vpcId": "vpc-11111111111111111",
-    "availabilityZones": [
-      "us-east-1a",
-      "us-east-1b",
-      "us-east-1c"
-    ],
-    "privateSubnetIds": [
-      "subnet-0096fdd5c93924860",
-      "subnet-0b4f435f11e937151",
-      "subnet-0136992e35ea88fe2"
-    ],
-    "privateSubnetNames": [
-      "Private"
-    ],
-    "privateSubnetRouteTableIds": [
-      "rtb-09d0493b9c095c1fa",
-      "rtb-0dec4782dc826b93b",
-      "rtb-035992729886f3420"
-    ],
-    "publicSubnetIds": [
-      "subnet-0240a38329b9e2841",
-      "subnet-0328da1132e7d38c2",
-      "subnet-0ff88de2b066463c9"
-    ],
-    "publicSubnetNames": [
-      "Public"
-    ],
-    "publicSubnetRouteTableIds": [
-      "rtb-037fe65bfb5728835",
-      "rtb-07ccdcadf111c8e21",
-      "rtb-0232970151c7ef3fd"
+    "availabilityZones": [],
+    "subnetGroups": [
+      {
+        "name": "Public",
+        "type": "Public",
+        "subnets": [
+          {
+            "subnetId": "subnet-0240a38329b9e2841",
+            "availabilityZone": "us-east-1a",
+            "routeTableId": "rtb-037fe65bfb5728835"
+          },
+          {
+            "subnetId": "subnet-0328da1132e7d38c2",
+            "availabilityZone": "us-east-1b",
+            "routeTableId": "rtb-07ccdcadf111c8e21"
+          },
+          {
+            "subnetId": "subnet-0ff88de2b066463c9",
+            "availabilityZone": "us-east-1c",
+            "routeTableId": "rtb-0232970151c7ef3fd"
+          }
+        ]
+      },
+      {
+        "name": "Private",
+        "type": "Private",
+        "subnets": [
+          {
+            "subnetId": "subnet-0096fdd5c93924860",
+            "availabilityZone": "us-east-1a",
+            "routeTableId": "rtb-09d0493b9c095c1fa"
+          },
+          {
+            "subnetId": "subnet-0b4f435f11e937151",
+            "availabilityZone": "us-east-1b",
+            "routeTableId": "rtb-0dec4782dc826b93b"
+          },
+          {
+            "subnetId": "subnet-0136992e35ea88fe2",
+            "availabilityZone": "us-east-1c",
+            "routeTableId": "rtb-035992729886f3420"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Fixes the failing build.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
