### PR TITLE
fix(java/resource-overrides): example uses method toPrettyString() which doesn't exist

### DIFF
--- a/java/resource-overrides/src/test/java/software/amazon/awscdk/examples/ResourceOverridesStackTest.java
+++ b/java/resource-overrides/src/test/java/software/amazon/awscdk/examples/ResourceOverridesStackTest.java
@@ -20,8 +20,8 @@ public class ResourceOverridesStackTest {
     App app = new App();
     Stack stack = new ResourceOverridesStack(app, "resource-overrides");
 
-    String actual = getStackTemplateJson(stack).toPrettyString();
-    String expected = readJsonFromResource("testResourceOverrides.expected.json").toPrettyString();
+    String actual = getStackTemplateJson(stack).toString();
+    String expected = readJsonFromResource("testResourceOverrides.expected.json").toString();
 
     JSONAssert.assertEquals(expected, actual, JSONCompareMode.LENIENT);
   }


### PR DESCRIPTION
Change to just a regular `toString()`, which works the same in this case.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
