### PR TITLE
fix: resource-overrides build broken due to changes to CDK autoscaling module

### DIFF
--- a/java/resource-overrides/src/test/resources/software/amazon/awscdk/examples/testResourceOverrides.expected.json
+++ b/java/resource-overrides/src/test/resources/software/amazon/awscdk/examples/testResourceOverrides.expected.json
@@ -373,7 +373,6 @@
       "Properties": {
         "MaxSize": "1",
         "MinSize": "1",
-        "DesiredCapacity": "1",
         "LaunchConfigurationName": {
           "Ref": "ASGLaunchConfigC00AF12B"
         },

--- a/scripts/build-java.sh
+++ b/scripts/build-java.sh
@@ -10,6 +10,7 @@ npm install
 for pomFile in $(find $scriptdir/../java -name pom.xml); do
     (
         cd $(dirname $pomFile)
+        echo "Building project at $(dirname $pomFile)"
         mvn compile test
 
         $scriptdir/synth.sh

--- a/scripts/build-npm.sh
+++ b/scripts/build-npm.sh
@@ -22,6 +22,7 @@ verify_star_dependencies() {
 # Find and build all NPM projects
 for pkgJson in $(find typescript -name package.json | grep -v node_modules); do
     (
+        echo "Building project at $(dirname $pkgJson)"
         cd $(dirname $pkgJson)
 
         if [[ -f DO_NOT_AUTOTEST ]]; then exit 0; fi

--- a/scripts/build-python.sh
+++ b/scripts/build-python.sh
@@ -16,6 +16,7 @@ for requirements in $(find $scriptdir/../python -name requirements.txt  -not -pa
         echo "=============================="
 
         cd $(dirname $requirements)
+        echo "Building project at $(dirname $requirements)"
         [[ ! -f DO_NOT_AUTOTEST ]] || exit 0
 
         source /tmp/.venv/bin/activate


### PR DESCRIPTION
The resource-overrides code build was broken because desiredCapacity is
not calculated all of the time.

Ref: https://github.com/aws/aws-cdk/commit/0adf6c75c1f0aa4acc131915970a496326dc559f

Also, outputting the current project being built into STDOUT for better
future diagnosis.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
