### PR TITLE
chore: remove Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: generic
-dist: bionic
-
-services:
-  - docker
-
-script:
-  - docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain /bin/bash -c "scripts/build.sh"


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->
Remove the Travis configuration file so Github Actions is the only CI for repo.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
