### PR TITLE
fix: replace deprecated aws-lambda.Code.asset with fromAsset

### DIFF
--- a/python/api-cors-lambda/app.py
+++ b/python/api-cors-lambda/app.py
@@ -13,9 +13,9 @@ class ApiCorsLambdaStack(core.Stack):
         base_lambda = _lambda.Function(self,'ApiCorsLambda',
         handler='lambda-handler.handler',
         runtime=_lambda.Runtime.PYTHON_3_7,
-        code=_lambda.Code.asset('lambda'),
+        code=_lambda.Code.fromAsset('lambda'),
         )
-        
+
         base_api = _apigw.RestApi(self, 'ApiGatewayWithCors',
         rest_api_name='ApiGatewayWithCors')
 

--- a/python/dynamodb-lambda/dynamodb_lambda/dynamodb_lambda_stack.py
+++ b/python/dynamodb-lambda/dynamodb_lambda/dynamodb_lambda_stack.py
@@ -25,7 +25,7 @@ class DynamodbLambdaStack(core.Stack):
         producer_lambda = aws_lambda.Function(self, "producer_lambda_function",
                                               runtime=aws_lambda.Runtime.PYTHON_3_6,
                                               handler="lambda_function.lambda_handler",
-                                              code=aws_lambda.Code.asset("./lambda/producer"))
+                                              code=aws_lambda.Code.fromAsset("./lambda/producer"))
 
         producer_lambda.add_environment("TABLE_NAME", demo_table.table_name)
 
@@ -36,7 +36,7 @@ class DynamodbLambdaStack(core.Stack):
         consumer_lambda = aws_lambda.Function(self, "consumer_lambda_function",
                                               runtime=aws_lambda.Runtime.PYTHON_3_6,
                                               handler="lambda_function.lambda_handler",
-                                              code=aws_lambda.Code.asset("./lambda/consumer"))
+                                              code=aws_lambda.Code.fromAsset("./lambda/consumer"))
 
         consumer_lambda.add_environment("TABLE_NAME", demo_table.table_name)
 

--- a/python/lambda-s3-trigger/s3trigger/s3trigger_stack.py
+++ b/python/lambda-s3-trigger/s3trigger/s3trigger_stack.py
@@ -15,7 +15,7 @@ class S3TriggerStack(core.Stack):
         function = _lambda.Function(self, "lambda_function",
                                     runtime=_lambda.Runtime.PYTHON_3_7,
                                     handler="lambda-handler.main",
-                                    code=_lambda.Code.asset("./lambda"))
+                                    code=_lambda.Code.fromAsset("./lambda"))
         # create s3 bucket
         s3 = _s3.Bucket(self, "s3bucket")
 

--- a/python/url-shortener/app.py
+++ b/python/url-shortener/app.py
@@ -22,7 +22,7 @@ class UrlShortenerStack(WaltersCoStack):
 
         # define the API gateway request handler. all API requests will go to the same function.
         handler = aws_lambda.Function(self, "UrlShortenerFunction",
-                                      code=aws_lambda.Code.asset("./lambda"),
+                                      code=aws_lambda.Code.fromAsset("./lambda"),
                                       handler="handler.main",
                                       timeout=Duration.minutes(5),
                                       runtime=aws_lambda.Runtime.PYTHON_3_7)

--- a/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
@@ -25,7 +25,7 @@ export class CdkStack extends cdk.Stack {
 
     const handler = new lambda.Function(this, 'BlueGreenLambda', {
       runtime: lambda.Runtime.PYTHON_3_6,
-      code: lambda.Code.asset('resources'),
+      code: lambda.Code.fromAsset('resources'),
       handler: 'blue_green.lambda_handler',
       environment: {
         BUCKET: bucket.bucketName

--- a/typescript/my-widget-service/widget_service.ts
+++ b/typescript/my-widget-service/widget_service.ts
@@ -45,7 +45,7 @@ export class WidgetService extends cdk.Construct {
 
     const handler = new lambda.Function(this, "WidgetHandler", {
       runtime: lambda.Runtime.NODEJS_10_X, // So we can use async in widget.js
-      code: lambda.AssetCode.asset("resources"),
+      code: lambda.AssetCode.fromAsset("resources"),
       handler: "widgets.main",
       environment: {
         BUCKET: bucket.bucketName


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Fixes use of deprecated `aws-lambda.Code.asset` method

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
