### PR TITLE
chore: update version of checkout action in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Runs docker build with JSII superchain
       run: docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain /bin/bash -c "scripts/build.sh"
       


### PR DESCRIPTION
Proposing updating the `checkout` action used in the Actions workflow to the latest - `v2`. Details - https://github.com/actions/checkout#checkout-v2

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
