### PR TITLE
fix: broken build

### DIFF
--- a/typescript/cognito-api-lambda/index.ts
+++ b/typescript/cognito-api-lambda/index.ts
@@ -1,7 +1,7 @@
 import { LambdaRestApi, CfnAuthorizer, LambdaIntegration, AuthorizationType } from '@aws-cdk/aws-apigateway';
 import { AssetCode, Function, Runtime } from '@aws-cdk/aws-lambda';
 import { App, Stack } from '@aws-cdk/core';
-import { UserPool, SignInType } from '@aws-cdk/aws-cognito'
+import { UserPool } from '@aws-cdk/aws-cognito'
 
 export class CognitoProtectedApi extends Stack {
   constructor(app: App, id: string) {
@@ -23,7 +23,9 @@ export class CognitoProtectedApi extends Stack {
 
     // Cognito User Pool with Email Sign-in Type.
     const userPool = new UserPool(this, 'userPool', {
-      signInType: SignInType.EMAIL
+      signInAliases: {
+        email: true
+      }
     })
 
     // Authorizer for the Hello World API that uses the

--- a/typescript/eks/cluster/index.ts
+++ b/typescript/eks/cluster/index.ts
@@ -29,7 +29,7 @@ class EKSCluster extends cdk.Stack {
       instanceType: new ec2.InstanceType('t3.medium'),
       machineImage: new eks.EksOptimizedImage({
         kubernetesVersion: '1.14',
-        nodeType: eks.NodeType.STANDARD  // wihtout this, incorrect SSM parameter for AMI is resolved
+        nodeType: eks.NodeType.STANDARD  // without this, incorrect SSM parameter for AMI is resolved
       }),
       updateType: autoscaling.UpdateType.ROLLING_UPDATE
     });

--- a/typescript/eks/cluster/tsconfig.json
+++ b/typescript/eks/cluster/tsconfig.json
@@ -16,5 +16,9 @@
       "inlineSources": true,
       "experimentalDecorators": true,
       "strictPropertyInitialization":false
-  }
+  },
+  "include": [ "**/*.ts" ],
+  "exclude": [
+    "**/*.d.ts"
+  ]
 }


### PR DESCRIPTION
* update Cognito example to incorporate the recent breaking change.
* eks/cluster typescript project to exclude re-compiling dependencies in
  `node_modules/`.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
