### PR TITLE
refactor: replace deprecated method

### DIFF
--- a/typescript/static-site/static-site.ts
+++ b/typescript/static-site/static-site.ts
@@ -70,7 +70,7 @@ export class StaticSite extends Construct {
         // Route53 alias record for the CloudFront distribution
         new route53.ARecord(this, 'SiteAliasRecord', {
             recordName: siteDomain,
-            target: route53.AddressRecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
+            target: route53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
             zone
         });
 


### PR DESCRIPTION
<refactor>

Update deprecated method `AddressRecordTarget `
[Use RecordTarget](https://docs.aws.amazon.com/cdk/api/latest/python/aws_cdk.aws_route53/AddressRecordTarget.html)

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
