### PR TITLE
chore: remove pinned dependencies for csharp examples

### DIFF
--- a/csharp/capitalize-string/src/CapitalizeString/CapitalizeString.csproj
+++ b/csharp/capitalize-string/src/CapitalizeString/CapitalizeString.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.Lambda" Version="1.18.0" />
+    <PackageReference Include="Amazon.CDK" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.Lambda" Version="*" />
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />
   </ItemGroup>
 

--- a/csharp/classic-load-balancer/src/ClassicLoadBalancer/ClassicLoadBalancer.csproj
+++ b/csharp/classic-load-balancer/src/ClassicLoadBalancer/ClassicLoadBalancer.csproj
@@ -2,15 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.AutoScaling" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.EC2" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.ElasticLoadBalancing" Version="1.18.0" />
+    <PackageReference Include="Amazon.CDK" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.AutoScaling" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.EC2" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.ElasticLoadBalancing" Version="*" />
+    <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/csharp/elasticbeanstalk/elasticbeanstalk-bg-pipeline/src/ElasticbeanstalkBgPipeline/ElasticbeanstalkBgPipeline.csproj
+++ b/csharp/elasticbeanstalk/elasticbeanstalk-bg-pipeline/src/ElasticbeanstalkBgPipeline/ElasticbeanstalkBgPipeline.csproj
@@ -2,17 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.Codepipeline.Actions" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.Codepipeline" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.CodeCommit" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.Lambda" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.S3" Version="1.18.0" />
+    <PackageReference Include="Amazon.CDK" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.Codepipeline.Actions" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.Codepipeline" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.CodeCommit" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.Lambda" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.S3" Version="*" />
+    <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/csharp/elasticbeanstalk/elasticbeanstalk-environment/src/ElasticbeanstalkEnvironment/ElasticbeanstalkEnvironment.csproj
+++ b/csharp/elasticbeanstalk/elasticbeanstalk-environment/src/ElasticbeanstalkEnvironment/ElasticbeanstalkEnvironment.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.ElasticBeanstalk" Version="1.18.0" />
+    <PackageReference Include="Amazon.CDK" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.ElasticBeanstalk" Version="*" />
+    <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/csharp/stepfunctions-job-poller/src/StepfunctionsJobPoller/StepfunctionsJobPoller.csproj
+++ b/csharp/stepfunctions-job-poller/src/StepfunctionsJobPoller/StepfunctionsJobPoller.csproj
@@ -2,18 +2,19 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.IAM" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.StepFunctions" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.StepFunctions.Tasks" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.SNS" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.SNS.Subscriptions" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.SQS" Version="1.18.0" />
+    <PackageReference Include="Amazon.CDK" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.IAM" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.StepFunctions" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.StepFunctions.Tasks" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.SNS" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.SNS.Subscriptions" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.SQS" Version="*" />
+    <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Rationale: these should work with the latest release and also serve as a canary
if they break.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
