### PR TITLE
feat: add python example for lambda with dynamodb trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ $ cdk destroy
 | [fargate-service-with-autoscaling](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/ecs/fargate-service-with-autoscaling/) | Starting an ECS service of FARGATE launch type that auto scales based on average CPU Utilization |
 | [lambda-cron](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/lambda-cron/) | Running a Lambda on a schedule |
 | [lambda-s3-trigger](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/lambda-s3-trigger/) | S3 trigger for Lambda |
+| [lambda-dynamodb-trigger](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/lambda-dynamodb-trigger/) | Lambda triggered by DynamoDB changes |
 | [rds](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/rds/) | Creating a MySQL RDS database inside its dedicated VPC |
 | [stepfunctions](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/stepfunctions/) | A simple StepFunctions workflow |
 | [url-shortner](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/url-shortener) | Demo from the [Infrastructure ***is*** Code with the AWS CDK](https://youtu.be/ZWCvNFUN-sU) AWS Online Tech Talk |

--- a/python/lambda-dynamodb-trigger/README.md
+++ b/python/lambda-dynamodb-trigger/README.md
@@ -1,0 +1,13 @@
+# Create Lambda function triggered by changes in DynamoDB table
+
+This is a project to create a new lambda, which is triggered by changes in a DynamoDB table
+
+A Lambda function and a DynamoDB table are created. Lambda is configured to use the DynamoDB table as an event source.
+
+## Useful commands
+
+ * `cdk ls`          list all stacks in the app
+ * `cdk synth`       emits the synthesized CloudFormation template
+ * `cdk deploy`      deploy this stack to your default AWS account/region
+ * `cdk diff`        compare deployed stack with current state
+ * `cdk docs`        open CDK documentation

--- a/python/lambda-dynamodb-trigger/app.py
+++ b/python/lambda-dynamodb-trigger/app.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+from aws_cdk import core
+
+from dynamodbtrigger.dynamodbtrigger_stack import DynamoDbTriggerStack
+
+app = core.App()
+DynamoDbTriggerStack(app, "DynamoDbTrigger")
+
+app.synth()

--- a/python/lambda-dynamodb-trigger/cdk.json
+++ b/python/lambda-dynamodb-trigger/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "python3 app.py"
+}

--- a/python/lambda-dynamodb-trigger/dynamodbtrigger/dynamodbtrigger_stack.py
+++ b/python/lambda-dynamodb-trigger/dynamodbtrigger/dynamodbtrigger_stack.py
@@ -1,0 +1,46 @@
+from aws_cdk import (
+    aws_lambda as _lambda,
+    aws_dynamodb as dynamodb,
+    aws_lambda_event_sources as lambda_event_sources,
+    core
+)
+
+
+class DynamoDbTriggerStack(core.Stack):
+
+    def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        # Create Lambda function
+        function = _lambda.Function(
+            self, 'LambdaFunction',
+            runtime = _lambda.Runtime.PYTHON_3_7,
+            handler = 'lambda-handler.main',
+            code = _lambda.Code.asset(
+                './lambda'
+            ),
+            timeout = core.Duration.seconds(300),
+        )
+
+        # Create DynamoDB table
+        table = dynamodb.Table(
+            self, 'DynamoDbTable',
+            table_name = 'SampleTable',
+            partition_key = dynamodb.Attribute(
+                name = 'MainKey',
+                type = dynamodb.AttributeType.STRING
+            ),
+            billing_mode = dynamodb.BillingMode.PAY_PER_REQUEST,
+            stream = dynamodb.StreamViewType.NEW_IMAGE,
+            removal_policy = core.RemovalPolicy.DESTROY
+        )
+        
+        # Add table as trigger for Lambda function
+        function.add_event_source(
+            lambda_event_sources.DynamoEventSource(
+                table = table,
+                starting_position = _lambda.StartingPosition.LATEST,
+                retry_attempts = 5,
+                max_record_age = core.Duration.hours(1)
+            )
+        )

--- a/python/lambda-dynamodb-trigger/lambda/lambda-handler.py
+++ b/python/lambda-dynamodb-trigger/lambda/lambda-handler.py
@@ -1,0 +1,8 @@
+def main(event, context):
+    # save event to logs
+    print(event)
+
+    return {
+        'statusCode': 200,
+        'body': event
+    }

--- a/python/lambda-dynamodb-trigger/requirements.txt
+++ b/python/lambda-dynamodb-trigger/requirements.txt
@@ -1,0 +1,5 @@
+aws-cdk.core
+
+aws-cdk.aws-dynamodb
+aws-cdk.aws-lambda
+aws-cdk.aws-lambda-event-sources


### PR DESCRIPTION
Adds a Python example of how to create a Lambda function that is triggered by changes in a DynamoDB table

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
