### PR TITLE
fix: indicate port 80 is http NOT ssh

### DIFF
--- a/python/existing-vpc-new-ec2-ebs-userdata/cdk_vpc_ec2/cdk_vpc_ec2_stack.py
+++ b/python/existing-vpc-new-ec2-ebs-userdata/cdk_vpc_ec2/cdk_vpc_ec2_stack.py
@@ -48,7 +48,7 @@ class CdkVpcEc2Stack(core.Stack):
         host.connections.allow_from_any_ipv4(
             ec2.Port.tcp(22), "Allow ssh from internet")
         host.connections.allow_from_any_ipv4(
-            ec2.Port.tcp(80), "Allow ssh from internet")
+            ec2.Port.tcp(80), "Allow http from internet")
 
         core.CfnOutput(self, "Output",
                        value=host.instance_public_ip)


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
