### PR TITLE
feat: add `dependsOn` for beanstalk environment

### DIFF
--- a/typescript/elasticbeanstalk/elasticbeanstalk-environment/index.ts
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-environment/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import cdk = require('@aws-cdk/core');
-import elasticbeanstalk = require('@aws-cdk/aws-elasticbeanstalk');
+import * as cdk from '@aws-cdk/core';
+import * as elasticbeanstalk from '@aws-cdk/aws-elasticbeanstalk';
 
 
 export class CdkStack extends cdk.Stack {
@@ -18,11 +18,14 @@ export class CdkStack extends cdk.Stack {
       applicationName: appName
     });
 
-    new elasticbeanstalk.CfnEnvironment(this, 'Environment', {
+    const env = new elasticbeanstalk.CfnEnvironment(this, 'Environment', {
       environmentName: 'MySampleEnvironment',
       applicationName: app.applicationName || appName,
       platformArn: platform
     });
+
+    // to ensure the application is created before the environment
+    env.addDependsOn(app);
   }
 }
 


### PR DESCRIPTION
Fixes # 

- Fix the beanstalk dependency so that app creation happens before the environment creation.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
