### PR TITLE
fix: StaticSiteStack does not extend Stack

### DIFF
--- a/java/static-site/src/main/java/software/amazon/awscdk/examples/StaticSiteStack.java
+++ b/java/static-site/src/main/java/software/amazon/awscdk/examples/StaticSiteStack.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import software.amazon.awscdk.core.CfnOutput;
 import software.amazon.awscdk.core.Construct;
 import software.amazon.awscdk.core.RemovalPolicy;
+import software.amazon.awscdk.core.Stack;
 import software.amazon.awscdk.services.certificatemanager.DnsValidatedCertificate;
 import software.amazon.awscdk.services.cloudfront.AliasConfiguration;
 import software.amazon.awscdk.services.cloudfront.Behavior;
@@ -25,7 +26,7 @@ import software.amazon.awscdk.services.s3.deployment.BucketDeployment;
 import software.amazon.awscdk.services.s3.deployment.ISource;
 import software.amazon.awscdk.services.s3.deployment.Source;
 
-public class StaticSiteStack extends Construct {
+public class StaticSiteStack extends Stack {
 
   /**
    * Static site infrastructure, which deploys site content to an S3 bucket.


### PR DESCRIPTION
Fixes #284:  the constructs are unable to find the stack they are defined in.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
