### PR TITLE
chore(repo): Add stale github action

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,46 @@
+name: "Close Stale Issues"
+
+# Controls when the action will run.
+on:
+  schedule:
+  - cron: "0 * * * *"
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+    - uses: aws-actions/stale-issue-cleanup@v3
+      with:
+        # Setting messages to an empty string will cause the automation to skip
+        # that category
+        ancient-issue-message: This issue has not received any attention in 2 years. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+        stale-issue-message: This issue has not received a response in a while. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+        stale-pr-message: This PR has not received a response in a while. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+        
+        # These labels are required
+        stale-issue-label: closing-soon
+        exempt-issue-label: no-autoclose
+        stale-pr-label: closing-soon
+        exempt-pr-label: no-autoclose
+        response-requested-label: response-requested
+
+        # Don't set closed-for-staleness label to skip closing very old issues
+        # regardless of label
+        closed-for-staleness-label: closed-for-staleness
+
+        # Issue timing
+        days-before-stale: 7
+        days-before-close: 4
+        days-before-ancient: 730
+
+        # If you don't want to mark a issue as being ancient based on a
+        # threshold of "upvotes", you can set this here. An "upvote" is
+        # the total number of +1, heart, hooray, and rocket reactions
+        # on an issue.
+        minimum-upvotes-to-exempt: 5
+
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # loglevel: DEBUG
+        # Set dry-run to true to not perform label or close actions.
+        dry-run: false

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -3,7 +3,7 @@ name: "Close Stale Issues"
 # Controls when the action will run.
 on:
   schedule:
-  - cron: "0 * * * *"
+  - cron: "0 6 * * *"
 
 jobs:
   cleanup:


### PR DESCRIPTION
- Sends a warning and then closes issues that haven't gotten a response in 2 years.
- Adds a closing-soon label to issues that have had the response-requested label for a week with no response.
- Sends a warning and then closes issues that have a closing-soon label and haven't had a response in 4 days.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

 <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
