### PR TITLE
fix: update expected tag order in Java ECS example

### DIFF
--- a/java/ecs/fargate-load-balanced-service/src/test/resources/com/amazonaws/cdk/examples/expected.cfn.json
+++ b/java/ecs/fargate-load-balanced-service/src/test/resources/com/amazonaws/cdk/examples/expected.cfn.json
@@ -33,16 +33,16 @@
                 "MapPublicIpOnLaunch": true,
                 "Tags": [
                     {
-                        "Key": "Name",
-                        "Value": "test/MyVpc/PublicSubnet1"
-                    },
-                    {
                         "Key": "aws-cdk:subnet-name",
                         "Value": "Public"
                     },
                     {
                         "Key": "aws-cdk:subnet-type",
                         "Value": "Public"
+                    },
+                    {
+                        "Key": "Name",
+                        "Value": "test/MyVpc/PublicSubnet1"
                     }
                 ]
             }
@@ -137,16 +137,16 @@
                 "MapPublicIpOnLaunch": true,
                 "Tags": [
                     {
-                        "Key": "Name",
-                        "Value": "test/MyVpc/PublicSubnet2"
-                    },
-                    {
                         "Key": "aws-cdk:subnet-name",
                         "Value": "Public"
                     },
                     {
                         "Key": "aws-cdk:subnet-type",
                         "Value": "Public"
+                    },
+                    {
+                        "Key": "Name",
+                        "Value": "test/MyVpc/PublicSubnet2"
                     }
                 ]
             }
@@ -241,16 +241,16 @@
                 "MapPublicIpOnLaunch": false,
                 "Tags": [
                     {
-                        "Key": "Name",
-                        "Value": "test/MyVpc/PrivateSubnet1"
-                    },
-                    {
                         "Key": "aws-cdk:subnet-name",
                         "Value": "Private"
                     },
                     {
                         "Key": "aws-cdk:subnet-type",
                         "Value": "Private"
+                    },
+                    {
+                        "Key": "Name",
+                        "Value": "test/MyVpc/PrivateSubnet1"
                     }
                 ]
             }
@@ -310,16 +310,16 @@
                 "MapPublicIpOnLaunch": false,
                 "Tags": [
                     {
-                        "Key": "Name",
-                        "Value": "test/MyVpc/PrivateSubnet2"
-                    },
-                    {
                         "Key": "aws-cdk:subnet-name",
                         "Value": "Private"
                     },
                     {
                         "Key": "aws-cdk:subnet-type",
                         "Value": "Private"
+                    },
+                    {
+                        "Key": "Name",
+                        "Value": "test/MyVpc/PrivateSubnet2"
                     }
                 ]
             }


### PR DESCRIPTION
The ordering of tags in the CDK was changed to be alphabetical in
https://github.com/aws/aws-cdk/pull/7913. This change updates the
expected result in the Java ECS example to match.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
