### PR TITLE
chore(mergify): remove commented-reviews-by condition

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,7 +19,6 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - -approved-reviews-by~=author
       - "#changes-requested-reviews-by=0"
-      - "#commented-reviews-by=0"
       - status-success=build
       - status-success=Semantic Pull Request
   - name: remove stale reviews


### PR DESCRIPTION
This condition enforces that PRs have no comments before it can be
merged. It's not clear why this is needed. As long as the build succeeds
and there is one approval from a core member, it's fine to merge

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
