### PR TITLE
fix(typescript/eks): compile fails for missing property 'version'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -377,5 +377,6 @@ $RECYCLE.BIN/
 *.swp
 cdk.context.json
 package-lock.json
+yarn.lock
 .cdk.staging
 cdk.out

--- a/typescript/eks/cluster/index.ts
+++ b/typescript/eks/cluster/index.ts
@@ -18,7 +18,8 @@ class EKSCluster extends cdk.Stack {
     const eksCluster = new eks.Cluster(this, 'Cluster', {
       vpc: vpc,
       kubectlEnabled: true,  // we want to be able to manage k8s resources using CDK
-      defaultCapacity: 0  // we want to manage capacity our selves
+      defaultCapacity: 0,  // we want to manage capacity our selves
+      version: eks.KubernetesVersion.V1_16,
     });
 
     const onDemandASG = new autoscaling.AutoScalingGroup(this, 'OnDemandASG', {


### PR DESCRIPTION
This is due to the breaking change in the eks module introduced in
version 1.50.0.
https://github.com/aws/aws-cdk/blob/master/CHANGELOG.md#1500-2020-07-07

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
