### PR TITLE
feat: Typescript EC2 instance example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ $ cdk destroy
 | [classic-load-balancer](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/classic-load-balancer/) | Using an AutoScalingGroup with a Classic Load Balancer |
 | [custom-resource](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/custom-resource/) | Shows adding a Custom Resource to your CDK app |
 | [elasticbeanstalk](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/elasticbeanstalk/) | Elastic Beanstalk example using L1 with a Blue/Green pipeline (community contributed) |
+| [ec2-instance](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ec2/instance) |Basic Ec2 instance with VPC (community contributed) |
 | [ecs-cluster](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ecs/cluster/) | Provision an ECS Cluster with custom Autoscaling Group configuration |
 | [ecs-network-load-balanced-service](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ecs/ecs-network-load-balanced-service/) | Starting a container fronted by a network load balancer on ECS |
 | [ecs-service-with-task-placement](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ecs/ecs-service-with-task-placement/) | Starting a container ECS with task placement specifications |

--- a/typescript/ec2/instance/cdk.json
+++ b/typescript/ec2/instance/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "node index"
+}

--- a/typescript/ec2/instance/index.ts
+++ b/typescript/ec2/instance/index.ts
@@ -1,0 +1,34 @@
+import * as ec2 from "@aws-cdk/aws-ec2"
+import * as cdk from "@aws-cdk/core"
+
+export class EC2InstanceStack extends cdk.Stack {
+    constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps ){
+        super(scope, id, props);
+        
+        // VPC
+        let vpc = new ec2.Vpc(this, "VPC", 
+        {
+            cidr: "10.0.0.0/16"
+        });
+
+        // AMI
+        let amiLinux = ec2.MachineImage.latestAmazonLinux(
+            {
+                generation : ec2.AmazonLinuxGeneration.AMAZON_LINUX_2,
+                edition :  ec2.AmazonLinuxEdition.STANDARD,
+                virtualization : ec2.AmazonLinuxVirt.HVM,
+                storage : ec2.AmazonLinuxStorage.GENERAL_PURPOSE,
+            }
+        );
+        
+        // Ec2 instance with vpc and amiLinux AMI
+        let instance = new ec2.Instance(this, id, 
+            {
+               instanceType : new ec2.InstanceType("t3.nano"),
+                machineImage : amiLinux,
+                vpc         : vpc
+            });
+
+    }
+}
+

--- a/typescript/ec2/instance/index.ts
+++ b/typescript/ec2/instance/index.ts
@@ -10,15 +10,13 @@ export class EC2InstanceStack extends cdk.Stack {
           cidr: "10.0.0.0/16"
         });
 
-        // AMI
-        let amiLinux = ec2.MachineImage.latestAmazonLinux(
-            {
-                generation : ec2.AmazonLinuxGeneration.AMAZON_LINUX_2,
-                edition :  ec2.AmazonLinuxEdition.STANDARD,
-                virtualization : ec2.AmazonLinuxVirt.HVM,
-                storage : ec2.AmazonLinuxStorage.GENERAL_PURPOSE,
-            }
-        );
+        // Latest Amazon Linux AMI
+        const machineImage = ec2.MachineImage.latestAmazonLinux({
+          generation : ec2.AmazonLinuxGeneration.AMAZON_LINUX_2,
+          edition :  ec2.AmazonLinuxEdition.STANDARD,
+          virtualization : ec2.AmazonLinuxVirt.HVM,
+          storage : ec2.AmazonLinuxStorage.GENERAL_PURPOSE,
+        });
         
         // Ec2 instance with vpc and amiLinux AMI
         let instance = new ec2.Instance(this, id, 

--- a/typescript/ec2/instance/index.ts
+++ b/typescript/ec2/instance/index.ts
@@ -6,9 +6,8 @@ export class EC2InstanceStack extends cdk.Stack {
         super(scope, id, props);
         
         // VPC
-        let vpc = new ec2.Vpc(this, "VPC", 
-        {
-            cidr: "10.0.0.0/16"
+        new ec2.Vpc(this, 'VPC', {
+          cidr: "10.0.0.0/16"
         });
 
         // AMI
@@ -31,4 +30,3 @@ export class EC2InstanceStack extends cdk.Stack {
 
     }
 }
-

--- a/typescript/ec2/instance/index.ts
+++ b/typescript/ec2/instance/index.ts
@@ -18,13 +18,11 @@ export class EC2InstanceStack extends cdk.Stack {
           storage : ec2.AmazonLinuxStorage.GENERAL_PURPOSE,
         });
         
-        // Ec2 instance with vpc and amiLinux AMI
-        let instance = new ec2.Instance(this, id, 
-            {
-               instanceType : new ec2.InstanceType("t3.nano"),
-                machineImage : amiLinux,
-                vpc         : vpc
-            });
+        new ec2.Instance(this, id, {
+          instanceType : new ec2.InstanceType('t3.nano'),
+          machineImage,
+          vpc,
+        });
 
     }
 }

--- a/typescript/ec2/instance/package.json
+++ b/typescript/ec2/instance/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ec2-instance",
+  "version": "1.0.0",
+  "description": "Basic Ec2 instance with VPC",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "cdk": "cdk"
+  },
+  "author": {
+    "name": "Lachlan Vass",
+    "url": "https://aws.amazon.com",
+    "organization": true
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/node": "^10.17.0",
+    "typescript": "~3.7.2"
+  },
+  "dependencies": {
+    "@aws-cdk/aws-ec2": "*",
+    "@aws-cdk/core": "*",
+    "aws-cdk": "^1.61.1"
+  }
+}

--- a/typescript/ec2/instance/tsconfig.json
+++ b/typescript/ec2/instance/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "target":"ES2018",
+        "module": "commonjs",
+        "lib": ["es2016", "es2017.object", "es2017.string"],
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization":false
+    }
+}


### PR DESCRIPTION
Created an Ec2 instance example for Typescript. This is largely cloned from the related Python Ec2 instance example.

This is important to add because created an Ec2 instance can be seen as essential knowledge for any AWS IAC configuration language. The Python example really helped me figure it out for Typescript, being experienced with Python but newer to Typescript.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
