### PR TITLE
fix(python/ecs):  Fix AutoScalingFargateService.__init__()

### DIFF
--- a/python/ecs/fargate-service-with-autoscaling/app.py
+++ b/python/ecs/fargate-service-with-autoscaling/app.py
@@ -9,7 +9,7 @@ from aws_cdk import (
 class AutoScalingFargateService(core.Stack):
 
     def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
-        super().__init__(scope, id, *kwargs)
+        super().__init__(scope, id, **kwargs)
 
         # Create a cluster
         vpc = ec2.Vpc(


### PR DESCRIPTION
aws-cdk-examples/python/ecs/fargate-service-with-autoscaling/app.py is throwing following a type error, due to improper function arguments

This PR fixes the invalid  arguments in  AutoScalingFargateService.__init__()

Fixes #332 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
