### PR TITLE
chore: fix examples that are affected by breaking changes in 1.65.0

### DIFF
--- a/python/docker-app-with-asg-alb/dockerized_app_cdk/rds_stack.py
+++ b/python/docker-app-with-asg-alb/dockerized_app_cdk/rds_stack.py
@@ -25,11 +25,10 @@ class RDSStack(core.Stack):
             connection=ec2.Port.tcp(3306)
         )
 
-        # Master data base word is automatically generated and
-        # stored in "AWS Secrets Manager"
+        # Master username is 'admin' and database password is automatically
+        # generated and stored in AWS Secrets Manager
         my_sql = rds.DatabaseInstance(
                 self, "RDS",
-                master_username="test",
                 engine=rds.DatabaseInstanceEngine.mysql(
                     version=rds.MysqlEngineVersion.VER_8_0_16
                 ),

--- a/python/new-vpc-alb-asg-mysql/cdk_vpc_ec2/cdk_rds_stack.py
+++ b/python/new-vpc-alb-asg-mysql/cdk_vpc_ec2/cdk_rds_stack.py
@@ -15,7 +15,6 @@ class CdkRdsStack(core.Stack):
         #                                         engine=rds.DatabaseClusterEngine.arora_mysql(
         #                                             version=rds.AuroraMysqlEngineVersion.VER_5_7_12
         #                                         )
-        #                                         master_user=rds.Login(username="admin"),
         #                                         instance_props=rds.InstanceProps(
         #                                             vpc=vpc,
         #                                             vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.ISOLATED),
@@ -37,7 +36,6 @@ class CdkRdsStack(core.Stack):
                                              ),
                                              instance_type=ec2.InstanceType.of(
                                                  ec2.InstanceClass.BURSTABLE2, ec2.InstanceSize.SMALL),
-                                             master_username="admin",
                                              vpc=vpc,
                                              multi_az=True,
                                              allocated_storage=100,

--- a/python/rds/app.py
+++ b/python/rds/app.py
@@ -15,8 +15,6 @@ class RDSStack(core.Stack):
 
         rds.DatabaseInstance(
             self, "RDS",
-            master_username="master",
-            master_user_password=core.SecretValue.plain_text("password"),
             database_name="db1",
             engine=rds.DatabaseInstanceEngine.mysql(
                 version=rds.MysqlEngineVersion.VER_8_0_16

--- a/typescript/eks/cluster/index.ts
+++ b/typescript/eks/cluster/index.ts
@@ -35,7 +35,7 @@ class EKSCluster extends cdk.Stack {
       updateType: autoscaling.UpdateType.ROLLING_UPDATE
     });
 
-    eksCluster.addAutoScalingGroup(onDemandASG, {});
+    eksCluster.connectAutoScalingGroupCapacity(onDemandASG, {});
   }
 }
 


### PR DESCRIPTION
Updates example to use the breaking changes introduced in CDK v1.65.0

eks: `addAutoScalingGroup` was renamed to `connectAutoScalingGroupCapacity`.

rds: the `master_username` and `master_password` properties were renamed to
`login` and are also now optional. dropped them from the example to simplify.

[Release notes for 1.65.0](https://github.com/aws/aws-cdk/releases/tag/v1.65.0)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
