### PR TITLE
fix: example appsync-graphql-dynamodb fails due to incorrect policy name

### DIFF
--- a/python/appsync-graphql-dynamodb/app_sync_cdk/app_sync_cdk_stack.py
+++ b/python/appsync-graphql-dynamodb/app_sync_cdk/app_sync_cdk_stack.py
@@ -89,7 +89,7 @@ class AppSyncCdkStack(core.Stack):
 
         items_table_role.add_managed_policy(
             ManagedPolicy.from_aws_managed_policy_name(
-                'arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess'
+                'AmazonDynamoDBFullAccess'
             )
         )
 


### PR DESCRIPTION
see the issue for details

Closes #335

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
