### PR TITLE
fix: `kubeCtlEnabled` is no longer necessary

### DIFF
--- a/typescript/eks/cluster/index.ts
+++ b/typescript/eks/cluster/index.ts
@@ -17,7 +17,6 @@ class EKSCluster extends cdk.Stack {
 
     const eksCluster = new eks.Cluster(this, 'Cluster', {
       vpc: vpc,
-      kubectlEnabled: true,  // we want to be able to manage k8s resources using CDK
       defaultCapacity: 0,  // we want to manage capacity our selves
       version: eks.KubernetesVersion.V1_16,
     });


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
