### PR TITLE
chore: Added notes about broken examples

### DIFF
--- a/csharp/static-site/README.md
+++ b/csharp/static-site/README.md
@@ -18,6 +18,8 @@ This example creates the infrastructure for a static site, which uses an S3 buck
 
 The site redirects from HTTP to HTTPS, using a CloudFront distribution, Route53 alias record, and ACM certificate.
 
+> **Note:** Due to a known issue with the EKS module in CDK version `1.81.0`, the project currently only works with version `1.80.0`. See https://github.com/aws/aws-cdk/issues/12291 for possible workarounds if you require version `1.81.0`.
+
 ## Prep
 
 The domain for the static site (i.e. mystaticsite.com) must be configured as a hosted zone in Route53 prior to deploying this example.  For instructions on configuring Route53 as the DNS service for your domain, see the [Route53 documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring.html).

--- a/csharp/static-site/README.md
+++ b/csharp/static-site/README.md
@@ -18,7 +18,7 @@ This example creates the infrastructure for a static site, which uses an S3 buck
 
 The site redirects from HTTP to HTTPS, using a CloudFront distribution, Route53 alias record, and ACM certificate.
 
-> **Note:** Due to a known issue with the EKS module in CDK version `1.81.0`, the project currently only works with version `1.80.0`. See https://github.com/aws/aws-cdk/issues/12291 for possible workarounds if you require version `1.81.0`.
+> **Note:** Due to a known issue, the example does not currently work with version `1.81.0`. See https://github.com/aws/aws-cdk/issues/12291 for possible workarounds if you require version `1.81.0`.
 
 ## Prep
 

--- a/java/static-site/README.md
+++ b/java/static-site/README.md
@@ -18,6 +18,8 @@ This example creates the infrastructure for a static site, which uses an S3 buck
 
 The site redirects from HTTP to HTTPS, using a CloudFront distribution, Route53 alias record, and ACM certificate.
 
+> **Note:** Due to a known issue with the EKS module in CDK version `1.81.0`, the project currently only works with version `1.80.0`. See https://github.com/aws/aws-cdk/issues/12291 for possible workarounds if you require version `1.81.0`.
+
 ## Prep
 
 The domain for the static site (i.e. mystaticsite.com) must be configured as a hosted zone in Route53 prior to deploying this example.  For instructions on configuring Route53 as the DNS service for your domain, see the [Route53 documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring.html).

--- a/java/static-site/README.md
+++ b/java/static-site/README.md
@@ -18,7 +18,7 @@ This example creates the infrastructure for a static site, which uses an S3 buck
 
 The site redirects from HTTP to HTTPS, using a CloudFront distribution, Route53 alias record, and ACM certificate.
 
-> **Note:** Due to a known issue with the EKS module in CDK version `1.81.0`, the project currently only works with version `1.80.0`. See https://github.com/aws/aws-cdk/issues/12291 for possible workarounds if you require version `1.81.0`.
+> **Note:** Due to a known issue, the example does not currently work with version `1.81.0`. See https://github.com/aws/aws-cdk/issues/12291 for possible workarounds if you require version `1.81.0`.
 
 ## Prep
 

--- a/typescript/eks/cluster/README.md
+++ b/typescript/eks/cluster/README.md
@@ -18,3 +18,4 @@ This example creates the infrastructure for a static site, which uses an S3 buck
 The site redirects from HTTP to HTTPS, using a CloudFront distribution, Route53 alias record, and ACM certificate.
 
 > **Note:** Due to a known issue with the EKS module in CDK version `1.81.0`, the project currently only works with version `1.80.0`. See https://github.com/aws/aws-cdk/issues/12291 for possible workarounds if you require version `1.81.0`.
+

--- a/typescript/eks/cluster/README.md
+++ b/typescript/eks/cluster/README.md
@@ -1,4 +1,4 @@
-# Static site
+# EKS Cluster
 <!--BEGIN STABILITY BANNER-->
 ---
 
@@ -18,16 +18,3 @@ This example creates the infrastructure for a static site, which uses an S3 buck
 The site redirects from HTTP to HTTPS, using a CloudFront distribution, Route53 alias record, and ACM certificate.
 
 > **Note:** Due to a known issue with the EKS module in CDK version `1.81.0`, the project currently only works with version `1.80.0`. See https://github.com/aws/aws-cdk/issues/12291 for possible workarounds if you require version `1.81.0`.
-
-## Prep
-
-The domain for the static site (i.e. mystaticsite.com) must be configured as a hosted zone in Route53 prior to deploying this example.  For instructions on configuring Route53 as the DNS service for your domain, see the [Route53 documentation](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-configuring.html).
-
-## Deploy
-
-```
-$ npm install -g aws-cdk
-$ npm install
-$ npm run build
-$ cdk deploy -c domain=mystaticsite.com -c subdomain=www
-```

--- a/typescript/eks/cluster/README.md
+++ b/typescript/eks/cluster/README.md
@@ -17,5 +17,5 @@ This example creates the infrastructure for a static site, which uses an S3 buck
 
 The site redirects from HTTP to HTTPS, using a CloudFront distribution, Route53 alias record, and ACM certificate.
 
-> **Note:** Due to a known issue with the EKS module in CDK version `1.81.0`, the project currently only works with version `1.80.0`. See https://github.com/aws/aws-cdk/issues/12291 for possible workarounds if you require version `1.81.0`.
+> **Note:** Due to a known issue, the example does not currently work with version `1.81.0`. See https://github.com/aws/aws-cdk/issues/12291 for possible workarounds if you require version `1.81.0`.
 

--- a/typescript/static-site/README.md
+++ b/typescript/static-site/README.md
@@ -17,7 +17,7 @@ This example creates the infrastructure for a static site, which uses an S3 buck
 
 The site redirects from HTTP to HTTPS, using a CloudFront distribution, Route53 alias record, and ACM certificate.
 
-> **Note:** Due to a known issue with the EKS module in CDK version `1.81.0`, the project currently only works with version `1.80.0`. See https://github.com/aws/aws-cdk/issues/12291 for possible workarounds if you require version `1.81.0`.
+> **Note:** Due to a known issue, the example does not currently work with version `1.81.0`. See https://github.com/aws/aws-cdk/issues/12291 for possible workarounds if you require version `1.81.0`.
 
 ## Prep
 


### PR DESCRIPTION
This [issue](https://github.com/aws/aws-cdk/issues/12291) broke several examples. Added a note about this breakage with a link to possible workarounds.

Once we release a patch, the builds should be fixed and we can remove those disclaimers. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
