### PR TITLE
fix: Replace deprectated role

### DIFF
--- a/python/ec2/instance/app.py
+++ b/python/ec2/instance/app.py
@@ -33,7 +33,7 @@ class EC2InstanceStack(core.Stack):
         # Instance Role and SSM Managed Policy
         role = iam.Role(self, "InstanceSSM", assumed_by=iam.ServicePrincipal("ec2.amazonaws.com"))
 
-        role.add_managed_policy(iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AmazonEC2RoleforSSM"))
+        role.add_managed_policy(iam.ManagedPolicy.from_aws_managed_policy_name("AmazonSSMManagedInstanceCore"))
 
         # Instance
         instance = ec2.Instance(self, "Instance",

--- a/python/ec2/instance/app.py
+++ b/python/ec2/instance/app.py
@@ -32,7 +32,6 @@ class EC2InstanceStack(core.Stack):
 
         # Instance Role and SSM Managed Policy
         role = iam.Role(self, "InstanceSSM", assumed_by=iam.ServicePrincipal("ec2.amazonaws.com"))
-
         role.add_managed_policy(iam.ManagedPolicy.from_aws_managed_policy_name("AmazonSSMManagedInstanceCore"))
 
         # Instance

--- a/python/ec2/instance/app.py
+++ b/python/ec2/instance/app.py
@@ -32,6 +32,7 @@ class EC2InstanceStack(core.Stack):
 
         # Instance Role and SSM Managed Policy
         role = iam.Role(self, "InstanceSSM", assumed_by=iam.ServicePrincipal("ec2.amazonaws.com"))
+
         role.add_managed_policy(iam.ManagedPolicy.from_aws_managed_policy_name("AmazonSSMManagedInstanceCore"))
 
         # Instance


### PR DESCRIPTION
The policy AmazonEC2RoleforSSM should be replaced by AmazonSSMManagedInstanceCore and will be deprecated soon.

Old role:
arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM

New role:
arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore

(the new role arn drops the /service-role path) 

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Fixes #428

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
