### PR TITLE
feat: update rekognition_lambda_s3_trigger_stack.py

### DIFF
--- a/python/rekognition-lambda-s3-trigger/rekognition_lambda_s3_trigger/rekognition_lambda_s3_trigger_stack.py
+++ b/python/rekognition-lambda-s3-trigger/rekognition_lambda_s3_trigger/rekognition_lambda_s3_trigger_stack.py
@@ -58,7 +58,9 @@ class RekognitionLambdaS3TriggerStack(core.Stack):
         # create trigger for Lambda function
         notification = s3_notifications.LambdaDestination(lambda_function)
         notification.bind(self, bucket)
-        bucket.add_object_created_notification(notification)
+        bucket.add_object_created_notification(notification, s3.NotificationKeyFilter(suffix='.jpg'))
+        bucket.add_object_created_notification(notification, s3.NotificationKeyFilter(suffix='.jpeg'))
+        bucket.add_object_created_notification(notification, s3.NotificationKeyFilter(suffix='.png'))
 
         # grant permissions for lambda to read/write to DynamoDB table and bucket
         table.grant_read_write_data(lambda_function)

--- a/python/rekognition-lambda-s3-trigger/rekognition_lambda_s3_trigger/rekognition_lambda_s3_trigger_stack.py
+++ b/python/rekognition-lambda-s3-trigger/rekognition_lambda_s3_trigger/rekognition_lambda_s3_trigger_stack.py
@@ -55,7 +55,7 @@ class RekognitionLambdaS3TriggerStack(core.Stack):
         statement.add_resources("*")
         lambda_function.add_to_role_policy(statement)
 
-        # create trigger for Lambda function
+        # create trigger for Lambda function with image type suffixes
         notification = s3_notifications.LambdaDestination(lambda_function)
         notification.bind(self, bucket)
         bucket.add_object_created_notification(notification, s3.NotificationKeyFilter(suffix='.jpg'))


### PR DESCRIPTION
feat: Add specific suffixes for image types supported by Amazon Rekognition

<!--
Explain what changed and why.

Add specific suffixes for image types supported by Amazon Rekognition
This will ensure the Lambda function is triggered only for files that are in a valid image format

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
