### PR TITLE
fix(ci): moved condition logic from github "build" workflow to `scripts/build.sh`

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -53,9 +53,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Runs docker builds with JSII superchain
       run: |
-        docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain /bin/bash \
+        docker run --rm --net=host -t -v $PWD:$PWD \
         -e HAS_CSHARP_CHANGES="${{needs.check_file_changes.outputs.has_csharp_changes}}" \
         -e HAS_JAVA_CHANGES="${{needs.check_file_changes.outputs.has_java_changes}}" \
         -e HAS_PYTHON_CHANGES="${{needs.check_file_changes.outputs.has_python_changes}}" \
         -e HAS_TYPESCRIPT_CHANGES="${{needs.check_file_changes.outputs.has_typescript_changes}}" \
-        -c "scripts/build.sh"
+        -w $PWD jsii/superchain /bin/bash -c "scripts/build.sh"

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -53,23 +53,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Runs docker builds with JSII superchain
       run: |
-        HAS_CSHARP_CHANGES="${{needs.check_file_changes.outputs.has_csharp_changes}}"
-        HAS_JAVA_CHANGES="${{needs.check_file_changes.outputs.has_java_changes}}"
-        HAS_PYTHON_CHANGES="${{needs.check_file_changes.outputs.has_python_changes}}"
-        HAS_TYPESCRIPT_CHANGES="${{needs.check_file_changes.outputs.has_typescript_changes}}"
-
-        if [ "${HAS_CSHARP_CHANGES}" == "true" ]; then
-          docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain /bin/bash -c "scripts/build-csharp.sh"
-        fi
-
-        if [ "${HAS_JAVA_CHANGES}" == "true" ]; then
-          docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain /bin/bash -c "scripts/build-java.sh"
-        fi
-
-        if [ "${HAS_PYTHON_CHANGES}" == "true" ]; then
-          docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain /bin/bash -c "scripts/build-python.sh"
-        fi
-
-        if [ "${HAS_TYPESCRIPT_CHANGES}" == "true" ]; then
-          docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain /bin/bash -c "scripts/build-typescript.sh"
-        fi
+        docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain /bin/bash \
+        -e HAS_CSHARP_CHANGES="${{needs.check_file_changes.outputs.has_csharp_changes}}" \
+        -e HAS_JAVA_CHANGES="${{needs.check_file_changes.outputs.has_java_changes}}" \
+        -e HAS_PYTHON_CHANGES="${{needs.check_file_changes.outputs.has_python_changes}}" \
+        -e HAS_TYPESCRIPT_CHANGES="${{needs.check_file_changes.outputs.has_typescript_changes}}" \
+        -c "scripts/build.sh"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+HAS_CSHARP_CHANGES=${HAS_CSHARP_CHANGES}
+HAS_JAVA_CHANGES=${HAS_JAVA_CHANGES}
+HAS_PYTHON_CHANGES=${HAS_PYTHON_CHANGES}
+HAS_TYPESCRIPT_CHANGES=${HAS_TYPESCRIPT_CHANGES}
+
+set -euo pipefail
+scriptdir=$(cd $(dirname $0) && pwd)
+
+if [ "${HAS_CSHARP_CHANGES}" == "true" ]; then
+  $scriptdir/build-csharp.sh
+fi
+
+if [ "${HAS_JAVA_CHANGES}" == "true" ]; then
+  $scriptdir/build-java.sh
+fi
+
+if [ "${HAS_PYTHON_CHANGES}" == "true" ]; then
+  $scriptdir/build-python.sh
+fi
+
+if [ "${HAS_TYPESCRIPT_CHANGES}" == "true" ]; then
+  $scriptdir/build-typescript.sh
+fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,25 +1,20 @@
 #!/bin/bash
 
-HAS_CSHARP_CHANGES=${HAS_CSHARP_CHANGES}
-HAS_JAVA_CHANGES=${HAS_JAVA_CHANGES}
-HAS_PYTHON_CHANGES=${HAS_PYTHON_CHANGES}
-HAS_TYPESCRIPT_CHANGES=${HAS_TYPESCRIPT_CHANGES}
-
 set -euo pipefail
 scriptdir=$(cd $(dirname $0) && pwd)
 
-if [ "${HAS_CSHARP_CHANGES}" == "true" ]; then
+if [[ "${HAS_CSHARP_CHANGES:-}" && "${HAS_CSHARP_CHANGES}" == "true" ]]; then
   $scriptdir/build-csharp.sh
 fi
 
-if [ "${HAS_JAVA_CHANGES}" == "true" ]; then
+if [[ "${HAS_JAVA_CHANGES:-}" && "${HAS_JAVA_CHANGES}" == "true" ]]; then
   $scriptdir/build-java.sh
 fi
 
-if [ "${HAS_PYTHON_CHANGES}" == "true" ]; then
+if [[ "${HAS_PYTHON_CHANGES:-}" && "${HAS_PYTHON_CHANGES}" == "true" ]]; then
   $scriptdir/build-python.sh
 fi
 
-if [ "${HAS_TYPESCRIPT_CHANGES}" == "true" ]; then
+if [[ "${HAS_TYPESCRIPT_CHANGES:-}" && "${HAS_TYPESCRIPT_CHANGES}" == "true" ]]; then
   $scriptdir/build-typescript.sh
 fi


### PR DESCRIPTION
## Summary

This PR fixes an issue thrown in the cdk-ops CI:

```shell
[Container] 2021/07/02 13:07:11 Running command chmod +x scripts/*.sh && scripts/build.sh
/codebuild/output/tmp/script.sh: line 4: scripts/build.sh: No such file or directory
```

This was being thrown because the `scripts/build.sh` file was deleted in a previous commit to the `aws-cdk-examples` repo in an effort to optimize build times.

See:

- https://github.com/aws-samples/aws-cdk-examples/pull/463
- https://github.com/aws-samples/aws-cdk-examples/commit/b690f003b0aaa443920c1e714b4fc230aa5f76fb

To resolve this issue I recreated the `scripts/build.sh` and moved the condition logic implemented in `.github/workflows/build-pull-request.yml` to the `build.sh`.


