### PR TITLE
fix(typescript/eks/cluster): fix BC

### DIFF
--- a/typescript/eks/cluster/index.ts
+++ b/typescript/eks/cluster/index.ts
@@ -18,7 +18,7 @@ class EKSCluster extends cdk.Stack {
     const eksCluster = new eks.Cluster(this, 'Cluster', {
       vpc: vpc,
       defaultCapacity: 0,  // we want to manage capacity our selves
-      version: eks.KubernetesVersion.V1_16,
+      version: eks.KubernetesVersion.V1_21,
     });
 
     const onDemandASG = new autoscaling.AutoScalingGroup(this, 'OnDemandASG', {
@@ -28,11 +28,11 @@ class EKSCluster extends cdk.Stack {
       maxCapacity: 10,
       instanceType: new ec2.InstanceType('t3.medium'),
       machineImage: new eks.EksOptimizedImage({
-        kubernetesVersion: '1.14',
+        kubernetesVersion: '1.21',
         nodeType: eks.NodeType.STANDARD  // without this, incorrect SSM parameter for AMI is resolved
       }),
-      updateType: autoscaling.UpdateType.ROLLING_UPDATE
-    });
+      updatePolicy: autoscaling.UpdatePolicy.rollingUpdate()
+      });
 
     eksCluster.connectAutoScalingGroupCapacity(onDemandASG, {});
   }


### PR DESCRIPTION
fix: update the props of AutoScalingGroup `updateType: autoscaling.UpdateType.ROLLING_UPDATE` to `updatePolicy: autoscaling.UpdatePolicy.rollingUpdate()`

fix: update eks cluster and dataplane node version to 1.21.
EKS 1.16 will `End of support` at September 27, 2021. 
see: [source](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)
| Kubernetes version | Upstream release | Amazon EKS release | Amazon EKS end of support | 
| --- | --- | --- | --- | 
| 1\.16 | September 8, 2019 | April 30, 2020 | September 27, 2021 | 
| 1\.17 | December 9, 2019 | July 10, 2020 | November 2, 2021 | 
| 1\.18 | March 23, 2020 | October 13, 2020 | February 18, 2022 | 
| 1\.19 | August 26, 2020 | February 16, 2021 | April, 2022 | 
| 1\.20 | December 8, 2020 | May 18, 2021 | July, 2022 | 
| 1\.21 | April 8, 2021 | July 19, 2021 | September, 2022 | 

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
