### PR TITLE
fix(GitHub issue templates): remove requirement from "Acknowledge" section

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -49,6 +49,6 @@ body:
       label: Acknowledge
       options:
         - label: I may be able to implement this feature request
-          required: true
+          required: false
         - label: This feature might incur a breaking change
-          required: true
+          required: false


### PR DESCRIPTION
## Summary

This PR removes the requirement to check the boxes in the "Acknowledge" section of feature-request issues.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
