### PR TITLE
Add java assertions examples to Lambda-Cron

### DIFF
--- a/java/lambda-cron/README.md
+++ b/java/lambda-cron/README.md
@@ -10,6 +10,14 @@ dependencies to compile the Java code.
 You can use your IDE to write code and unit tests, but you will need to use the
 CDK toolkit if you wish to synthesize/deploy stacks.
 
+## Testing
+
+To test this app after building, run `mvn test`. This will run two testing files, each with 5 tests. Tests in `OldLambdaCronStackTest.java` are legacy tests that require an additional file,
+`TestUtils.java`, to run. `LambdaCronStackTest.java` is the newest version that depends on the CDK
+[Assertions](https://docs.aws.amazon.com/cdk/api/latest/java/index.html) module. The API in the
+Assertions module replaces the need to write a `TestUtils` class and allows you to focus on writing
+robust tests for your CDK app. 
+
 ## CDK Toolkit
 
 The [`cdk.json`](./cdk.json) file in the root of this repository includes

--- a/java/lambda-cron/pom.xml
+++ b/java/lambda-cron/pom.xml
@@ -55,19 +55,25 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>core</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.125.0, 2)</version>
         </dependency>
 
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>lambda</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.125.0, 2)</version>
         </dependency>
 
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>events-targets</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.125.0, 2)</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>cdk-assertions</artifactId>
+            <version>[1.125.0, 2)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/lambda-cron/src/test/java/software/amazon/awscdk/examples/OldLambdaCronStackTest.java
+++ b/java/lambda-cron/src/test/java/software/amazon/awscdk/examples/OldLambdaCronStackTest.java
@@ -1,0 +1,86 @@
+package software.amazon.awscdk.examples;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static software.amazon.awscdk.examples.TestUtils.toCloudFormationJson;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.awscdk.core.App;
+import software.amazon.awscdk.core.Stack;
+
+
+public class OldLambdaCronStackTest {
+  private JsonNode actualStack;
+  private JsonNode expectedStack;
+
+  @Before
+  public void setUp() throws IOException {
+    App app = new App();
+    Stack stack = new LambdaCronStack(app, "lambdaResource-cdk-lambda-cron");
+    actualStack = toCloudFormationJson(stack).path("Resources");
+    expectedStack =
+        TestUtils.fromFileResource(getClass().getResource("testCronLambdaExpected.json"))
+            .path("Resources");
+  }
+
+  @Test
+  public void testTypes() {
+    List<String> actual =
+        actualStack.findValues("Type").stream()
+            .map(JsonNode::textValue)
+            .collect(Collectors.toList());
+    String[] expected =
+        expectedStack.findValues("Type").stream().map(JsonNode::textValue).toArray(String[]::new);
+    assertThat(actual, containsInAnyOrder(expected));
+  }
+
+  @Test
+  public void testPermission() {
+    final String type = "AWS::Lambda::Permission";
+    JsonNode actual = TestUtils.getJsonNode(actualStack, type);
+    JsonNode expected = TestUtils.getJsonNode(expectedStack, type);
+    String[] keys = {"ManagedPolicyArns", "AssumeRolePolicyDocument"};
+    for (String key : keys) {
+      assertThat(actual.get(key), equalTo(expected.get(key)));
+    }
+  }
+
+  @Test
+  public void testRole() {
+    final String type = "AWS::IAM::Role";
+    JsonNode actual = TestUtils.getJsonNode(actualStack, type);
+    JsonNode expected = TestUtils.getJsonNode(expectedStack, type);
+    String[] keys = {"ManagedPolicyArns", "AssumeRolePolicyDocument"};
+    for (String key : keys) {
+      assertThat(actual.get(key), equalTo(expected.get(key)));
+    }
+  }
+
+  @Test
+  public void testLambda() {
+    final String type = "AWS::Lambda::Function";
+    JsonNode actual = TestUtils.getJsonNode(actualStack, type);
+    JsonNode expected = TestUtils.getJsonNode(expectedStack, type);
+    String[] keys = {"Runtime", "Description", "Timeout", "Handler", "Code", "FunctionName"};
+    for (String key : keys) {
+      assertThat(actual.get(key), equalTo(expected.get(key)));
+    }
+  }
+
+  @Test
+  public void testRule() {
+    final String type = "AWS::Events::Rule";
+    JsonNode actual = TestUtils.getJsonNode(actualStack, type);
+    JsonNode expected = TestUtils.getJsonNode(expectedStack, type);
+    String[] keys = {"ScheduleExpression", "Description", "State"};
+    for (String key : keys) {
+      assertThat(actual.get(key), equalTo(expected.get(key)));
+    }
+  }
+}

--- a/typescript/eks/cluster/index.ts
+++ b/typescript/eks/cluster/index.ts
@@ -18,7 +18,7 @@ class EKSCluster extends cdk.Stack {
     const eksCluster = new eks.Cluster(this, 'Cluster', {
       vpc: vpc,
       defaultCapacity: 0,  // we want to manage capacity our selves
-      version: eks.KubernetesVersion.V1_16,
+      version: eks.KubernetesVersion.V1_21,
     });
 
     const onDemandASG = new autoscaling.AutoScalingGroup(this, 'OnDemandASG', {
@@ -28,11 +28,11 @@ class EKSCluster extends cdk.Stack {
       maxCapacity: 10,
       instanceType: new ec2.InstanceType('t3.medium'),
       machineImage: new eks.EksOptimizedImage({
-        kubernetesVersion: '1.14',
+        kubernetesVersion: '1.21',
         nodeType: eks.NodeType.STANDARD  // without this, incorrect SSM parameter for AMI is resolved
       }),
-      updateType: autoscaling.UpdateType.ROLLING_UPDATE
-    });
+      updatePolicy: autoscaling.UpdatePolicy.rollingUpdate()
+      });
 
     eksCluster.connectAutoScalingGroupCapacity(onDemandASG, {});
   }

--- a/typescript/lambda-cron/jest.config.js
+++ b/typescript/lambda-cron/jest.config.js
@@ -1,0 +1,5 @@
+const config = {
+  moduleFileExtensions: ["js"]
+};
+
+module.exports = config;

--- a/typescript/lambda-cron/lambda-cron.test.ts
+++ b/typescript/lambda-cron/lambda-cron.test.ts
@@ -1,0 +1,68 @@
+import { Capture, Match, Template } from '@aws-cdk/assertions';
+import { LambdaCronStack } from './index';
+import * as cdk from '@aws-cdk/core';
+
+const app = new cdk.App();
+const stack = new LambdaCronStack(app, 'testStack');
+const assert = Template.fromStack(stack);
+
+describe('lambda tests', () => {
+  test('specified resources created', () => {
+    assert.resourceCountIs('AWS::Lambda::Function', 1);
+    assert.resourceCountIs('AWS::Events::Rule', 1);
+  });
+
+  test('lambda function has correct properties', () => {
+    const dependencyCapture = new Capture();
+    assert.hasResource('AWS::Lambda::Function', {
+      Properties: {
+        Code: {
+          ZipFile: `def main(event, context):\n    print(\"I'm running!\")`,
+        },
+        Handler: 'index.main',
+        Runtime: 'python3.6',
+        Timeout: 300,
+      },
+      DependsOn: [ dependencyCapture ],
+    });
+
+    expect(dependencyCapture.asString().match(/SingletonServiceRole/)).toBeDefined();
+  });
+
+  test('lambda has correct iam permissions', () => {
+    const roleCapture = new Capture();
+    assert.hasResourceProperties('AWS::IAM::Role', {
+      AssumeRolePolicyDocument: Match.objectLike({
+        Statement: [{
+          Action: 'sts:AssumeRole',
+          Effect: 'Allow',
+          Principal: {
+            Service: 'lambda.amazonaws.com'
+          },
+        }],
+      }),
+      ManagedPolicyArns: [{
+        'Fn::Join': Match.arrayWith([
+          [ 'arn:', { 'Ref': 'AWS::Partition' }, roleCapture ],
+        ]),
+      }],
+    });
+
+    expect(roleCapture.asString().match(/AWSLambdaBasicExecutionRole/)).toBeDefined();
+  });
+
+  test('lambda not running in vpc', () => {
+    assert.hasResource('AWS::Lambda::Function', {
+      Vpc: Match.absentProperty(),
+    });
+  });
+
+  test('event has correct rule', () => {
+    assert.hasResourceProperties('AWS::Events::Rule', {
+      ScheduleExpression: 'cron(0 18 ? * MON-FRI *)',
+      State: 'ENABLED',
+      Targets: Match.anyValue(),
+      Id: Match.anyValue(),
+    });
+  });
+});

--- a/typescript/lambda-cron/package.json
+++ b/typescript/lambda-cron/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "cdk": "cdk"
+    "cdk": "cdk",
+    "test": "jest --config=jest.config.js"
   },
   "author": {
     "name": "Amazon Web Services",
@@ -16,9 +17,12 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/node": "^10.17.0",
-    "typescript": "~3.7.2"
+    "@types/jest": "^26.0.24",
+    "jest": "^26.6.3",
+    "typescript": "~3.9.7"
   },
   "dependencies": {
+    "@aws-cdk/assertions": "*",
     "@aws-cdk/aws-events": "*",
     "@aws-cdk/aws-events-targets": "*",
     "@aws-cdk/aws-lambda": "*",


### PR DESCRIPTION
This PR adds a suite of tests leveraging the `Assertions` library to the Lambda-Cron example. I also added a `Testing` section in the README.

There happens to already be a test file with 5 tests in this example that utilizes a `TestUtils.java` file to test the app. Instead of deleting it, I figured that, with correct execution, this would be an opportunity to show how the new Assertions library removes a pain point of having to maintain your own `TestUtils` class.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
