### PR TITLE
docs: README - add Go examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repo contains examples in each language supported by the CDK. Some language
 | [Python Examples](https://github.com/aws-samples/aws-cdk-examples/tree/master/python) | _Stable_ |
 | [.NET Examples](https://github.com/aws-samples/aws-cdk-examples/tree/master/csharp) | _Stable_ |
 | [Java Examples](https://github.com/aws-samples/aws-cdk-examples/tree/master/java) | _Stable_ |
-| [Go Examples](https://github.com/aws-samples/aws-cdk-examples/tree/master/go) | _None_ |
+| [Go Examples](https://github.com/aws-samples/aws-cdk-examples/tree/master/go) | _Stable_ |
 
 
 ## Learning Resources <a name="Learning"></a>

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repo contains examples in each language supported by the CDK. Some language
 | [Python Examples](https://github.com/aws-samples/aws-cdk-examples/tree/master/python) | _Stable_ |
 | [.NET Examples](https://github.com/aws-samples/aws-cdk-examples/tree/master/csharp) | _Stable_ |
 | [Java Examples](https://github.com/aws-samples/aws-cdk-examples/tree/master/java) | _Stable_ |
+| [Go Examples](https://github.com/aws-samples/aws-cdk-examples/tree/master/go) | _None_ |
 
 
 ## Learning Resources <a name="Learning"></a>


### PR DESCRIPTION
Follow-up to https://github.com/aws-samples/aws-cdk-examples/commit/ee354a31dcfe374f3fad8e9406210a8f109daf5c - adding https://github.com/aws-samples/aws-cdk-examples/tree/master/go to the list of examples here.

Fixes https://github.com/aws-samples/aws-cdk-examples/issues/544

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
