### PR TITLE
chore: upgrading C# examples to latest CDK and netcoreapp3.1.

### DIFF
--- a/csharp/application-load-balancer/src/ApplicationLoadBalancer/ApplicationLoadBalancer.csproj
+++ b/csharp/application-load-balancer/src/ApplicationLoadBalancer/ApplicationLoadBalancer.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.EC2" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.ElasticLoadBalancingV2" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.AutoScaling" Version="1.18.0" />
+    <PackageReference Include="Amazon.CDK" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.EC2" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.ElasticLoadBalancingV2" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.AutoScaling" Version="*" />
   </ItemGroup>
 
 </Project>

--- a/csharp/appsync-graphql-dynamodb/src/AppsyncGraphqlDynamodb/AppsyncGraphqlDynamodb.csproj
+++ b/csharp/appsync-graphql-dynamodb/src/AppsyncGraphqlDynamodb/AppsyncGraphqlDynamodb.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.AppSync" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.DynamoDB" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.IAM" Version="1.18.0" />
+    <PackageReference Include="Amazon.CDK" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.AppSync" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.DynamoDB" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.IAM" Version="*" />
   </ItemGroup>
 
 </Project>

--- a/csharp/my-widget-service/cdk.json
+++ b/csharp/my-widget-service/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "dotnet src/MyWidgetService/bin/Debug/netcoreapp3.0/MyWidgetService.dll"
+  "app": "dotnet src/MyWidgetService/bin/Debug/netcoreapp3.1/MyWidgetService.dll"
 }

--- a/csharp/my-widget-service/src/MyWidgetService/MyWidgetService.csproj
+++ b/csharp/my-widget-service/src/MyWidgetService/MyWidgetService.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK" Version="1.14.0-devpreview" />
-    <PackageReference Include="Amazon.CDK.AWS.ApiGateway" Version="1.14.0-devpreview" />
-    <PackageReference Include="Amazon.CDK.AWS.Lambda" Version="1.14.0-devpreview" />
-    <PackageReference Include="Amazon.CDK.AWS.S3" Version="1.14.0-devpreview" />
-    <PackageReference Include="Amazon.JSII.Analyzers" Version="0.19.0" PrivateAssets="all" />
+    <PackageReference Include="Amazon.CDK" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.ApiGateway" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.Lambda" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.S3" Version="*" />
+    <PackageReference Include="Amazon.JSII.Analyzers" Version="*" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/csharp/static-site/src/StaticSite/StaticSite.csproj
+++ b/csharp/static-site/src/StaticSite/StaticSite.csproj
@@ -2,18 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.CloudFront" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.Route53" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.Route53.Targets" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.S3" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.S3.Deployment" Version="1.18.0" />
-    <PackageReference Include="Amazon.CDK.AWS.CertificateManager" Version="1.18.0" />    
+    <PackageReference Include="Amazon.CDK" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.CloudFront" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.Route53" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.Route53.Targets" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.S3" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.S3.Deployment" Version="*" />
+    <PackageReference Include="Amazon.CDK.AWS.CertificateManager" Version="*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrade C# examples; the current examples fail to build due to outdated versions of jsii.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
