### PR TITLE
chore: fix java build break (s3 bucket name) and upgrade CDK version

### DIFF
--- a/java/alb-multi-rule-response/pom.xml
+++ b/java/alb-multi-rule-response/pom.xml
@@ -39,23 +39,23 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>core</artifactId>
-            <version>[1.26.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>elasticloadbalancingv2</artifactId>
-            <version>[1.26.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>ec2</artifactId>
-            <version>[1.26.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>autoscaling</artifactId>
-            <version>[1.26.0,2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/classic-load-balancer/pom.xml
+++ b/java/classic-load-balancer/pom.xml
@@ -55,22 +55,22 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>core</artifactId>
-            <version>[1.0.0,)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>ec2</artifactId>
-            <version>[1.0.0,)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>autoscaling</artifactId>
-            <version>[1.0.0,)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>elasticloadbalancing</artifactId>
-            <version>[1.0.0,)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>

--- a/java/codebuild/project/pom.xml
+++ b/java/codebuild/project/pom.xml
@@ -39,13 +39,13 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>core</artifactId>
-            <version>[1.21.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>codebuild</artifactId>
-            <version>[1.21.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/codebuild/project/src/main/java/com/myorg/ProjectStack.java
+++ b/java/codebuild/project/src/main/java/com/myorg/ProjectStack.java
@@ -51,7 +51,7 @@ public class ProjectStack extends Stack {
             }
         };
 
-        IBucket s3Bucket = Bucket.fromBucketName(this, id, "s3BucketName");
+        IBucket s3Bucket = Bucket.fromBucketName(this, id, "s3bucketname");
         ISource source = Source.s3(S3SourceProps.builder().bucket(s3Bucket).path("S3Path").build());
 
         IRole role = Role.fromRoleArn(this, "someId", "arn:partition:service:region:account-id:resource-type:resource-id");

--- a/java/codebuild/reportgroup/pom.xml
+++ b/java/codebuild/reportgroup/pom.xml
@@ -39,13 +39,13 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>core</artifactId>
-            <version>[1.21.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>codebuild</artifactId>
-            <version>[1.21.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/codebuild/sourceCredential/pom.xml
+++ b/java/codebuild/sourceCredential/pom.xml
@@ -39,13 +39,13 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>core</artifactId>
-            <version>[1.21.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>codebuild</artifactId>
-            <version>[1.21.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/custom-resource/pom.xml
+++ b/java/custom-resource/pom.xml
@@ -55,21 +55,21 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>core</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <!-- Respective AWS Construct Libraries -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>cloudformation</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>lambda</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
-       
+
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>
             <groupId>junit</groupId>

--- a/java/ecs/fargate-load-balanced-service/pom.xml
+++ b/java/ecs/fargate-load-balanced-service/pom.xml
@@ -39,19 +39,19 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>core</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <!-- Respective AWS Construct Libraries -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>ecs</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>ecs-patterns</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <dependency>

--- a/java/hello-world/pom.xml
+++ b/java/hello-world/pom.xml
@@ -55,38 +55,38 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>core</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>autoscaling</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>ec2</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>s3</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>sns</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>sqs</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
           <groupId>software.amazon.awscdk</groupId>
           <artifactId>sns-subscriptions</artifactId>
-          <version>[1.19.0, 2)</version>
+          <version>[1.132.0, 2)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/lambda-cron/pom.xml
+++ b/java/lambda-cron/pom.xml
@@ -55,19 +55,19 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>core</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>lambda</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>events-targets</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/my-widget-service/pom.xml
+++ b/java/my-widget-service/pom.xml
@@ -58,22 +58,22 @@
 		<dependency>
 			<groupId>software.amazon.awscdk</groupId>
 			<artifactId>core</artifactId>
-			<version>[1.19.0, 2)</version>
+			<version>[1.132.0, 2)</version>
 		</dependency>
 		<dependency>
 			<groupId>software.amazon.awscdk</groupId>
 			<artifactId>s3</artifactId>
-			<version>[1.19.0, 2)</version>
+			<version>[1.132.0, 2)</version>
 		</dependency>
 		<dependency>
 			<groupId>software.amazon.awscdk</groupId>
 			<artifactId>apigateway</artifactId>
-			<version>[1.19.0, 2)</version>
+			<version>[1.132.0, 2)</version>
 		</dependency>
 		<dependency>
 			<groupId>software.amazon.awscdk</groupId>
 			<artifactId>iam</artifactId>
-			<version>[1.19.0, 2)</version>
+			<version>[1.132.0, 2)</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/junit/junit -->
 		 <dependency>

--- a/java/resource-overrides/pom.xml
+++ b/java/resource-overrides/pom.xml
@@ -57,25 +57,25 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>core</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/s3 -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>s3</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/ec2 -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>ec2</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/autoscaling -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>autoscaling</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->

--- a/java/static-site/pom.xml
+++ b/java/static-site/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>core</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <!-- Respective AWS Construct Libraries -->
@@ -63,32 +63,32 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>cloudfront</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>route53</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>route53-targets</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>s3</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>s3-deployment</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>certificatemanager</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/stepfunctions-job-poller/pom.xml
+++ b/java/stepfunctions-job-poller/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>core</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <!-- Respective AWS Construct Libraries -->
@@ -62,12 +62,12 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>stepfunctions</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>stepfunctions-tasks</artifactId>
-            <version>[1.19.0, 2)</version>
+            <version>[1.132.0, 2)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->


### PR DESCRIPTION
```
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.6.0:java (default-cli) on project project: An exception occured while executing the Java class. Invalid S3 bucket name (value: s3BucketName)
[ERROR] Bucket name must only contain lowercase characters and the symbols, period (.) and dash (-) (offset: 2)
[ERROR] Error: Invalid S3 bucket name (value: s3BucketName)
```

Fixed the above error, and while I was at it, upgraded the CDK version(s) for all of the Java examples.