### PR TITLE
fix(python/new-vpc-alb-asg-mysql): Added `vpc_subnets` prop to RDS DB instance

### DIFF
--- a/python/new-vpc-alb-asg-mysql/cdk_vpc_ec2/cdk_rds_stack.py
+++ b/python/new-vpc-alb-asg-mysql/cdk_vpc_ec2/cdk_rds_stack.py
@@ -17,7 +17,7 @@ class CdkRdsStack(core.Stack):
         #                                         )
         #                                         instance_props=rds.InstanceProps(
         #                                             vpc=vpc,
-        #                                             vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.ISOLATED),
+        #                                             vpc_subnets=ec2.SubnetSelection(subnet_group_name="DB"),
         #                                             instance_type=ec2.InstanceType(instance_type_identifier="t2.small")
         #                                         ),
         #                                         instances=2,
@@ -37,6 +37,7 @@ class CdkRdsStack(core.Stack):
                                              instance_type=ec2.InstanceType.of(
                                                  ec2.InstanceClass.BURSTABLE2, ec2.InstanceSize.SMALL),
                                              vpc=vpc,
+                                             vpc_subnets=ec2.SubnetSelection(subnet_group_name="DB"),
                                              multi_az=True,
                                              allocated_storage=100,
                                              storage_type=rds.StorageType.GP2,


### PR DESCRIPTION
## Summary

This PR specifies the VPC subnets for the DatabaseInstance so that the database is placed in "DB" (isolated) subnets.

Fixes: https://github.com/aws-samples/aws-cdk-examples/issues/539

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
