### PR TITLE
feat: upgrade Typescript examples to CDK v2

### DIFF
--- a/scripts/build-typescript.sh
+++ b/scripts/build-typescript.sh
@@ -12,8 +12,6 @@ for pkgJson in $(find typescript -name cdk.json | grep -v node_modules | sort); 
         cd $(dirname $pkgJson)
         if [[ -f DO_NOT_AUTOTEST ]]; then exit 0; fi
 
-        verify_star_dependencies
-
         rm -rf package-lock.json node_modules
         npm install
         npm run build

--- a/scripts/build-typescript.sh
+++ b/scripts/build-typescript.sh
@@ -2,25 +2,8 @@
 set -euxo pipefail
 scriptdir=$(cd $(dirname $0) && pwd)
 
-# Make sure that the package.json has * dependencies
-# for the @aws-cdk libraries.
-#
-# This looks weird, but we do it pre-1.0 to make sure
-# the examples are always up to date with the changing
-# API
-verify_star_dependencies() {
-    broken=$(grep '@aws-cdk' package.json | grep -v '*' || true)
-    if [[ "$broken" != "" ]]; then
-        echo '================================================='
-        echo ' These @aws-cdk dependencies must depend on version "*"'
-        echo $broken
-        echo '================================================='
-        exit 1
-    fi
-}
-
 # Find and build all NPM projects
-for pkgJson in $(find typescript -name cdk.json | grep -v node_modules); do
+for pkgJson in $(find typescript -name cdk.json | grep -v node_modules | sort); do
     (
         echo "=============================="
         echo "building project: $(dirname $pkgJson)"

--- a/typescript/amplify-console-app/index.ts
+++ b/typescript/amplify-console-app/index.ts
@@ -1,8 +1,9 @@
-import cdk = require('@aws-cdk/core');
-import { CfnApp, CfnBranch } from '@aws-cdk/aws-amplify';
+import cdk = require('aws-cdk-lib');
+import { CfnApp, CfnBranch } from 'aws-cdk-lib/aws-amplify';
+import { Construct } from 'constructs';
 
 export class AmplifyConsoleAppCdkStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const amplifyApp = new CfnApp(this, 'test-app', {

--- a/typescript/amplify-console-app/package.json
+++ b/typescript/amplify-console-app/package.json
@@ -16,10 +16,10 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-amplify": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/api-cors-lambda-crud-dynamodb/index.ts
+++ b/typescript/api-cors-lambda-crud-dynamodb/index.ts
@@ -1,8 +1,8 @@
-import { IResource, LambdaIntegration, MockIntegration, PassthroughBehavior, RestApi } from '@aws-cdk/aws-apigateway';
-import { AttributeType, Table } from '@aws-cdk/aws-dynamodb';
-import { Runtime } from '@aws-cdk/aws-lambda';
-import { App, Stack, RemovalPolicy } from '@aws-cdk/core';
-import { NodejsFunction, NodejsFunctionProps } from '@aws-cdk/aws-lambda-nodejs';
+import { IResource, LambdaIntegration, MockIntegration, PassthroughBehavior, RestApi } from 'aws-cdk-lib/aws-apigateway';
+import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { App, Stack, RemovalPolicy } from 'aws-cdk-lib';
+import { NodejsFunction, NodejsFunctionProps } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { join } from 'path'
 
 export class ApiLambdaCrudDynamoDBStack extends Stack {

--- a/typescript/api-cors-lambda-crud-dynamodb/package.json
+++ b/typescript/api-cors-lambda-crud-dynamodb/package.json
@@ -18,13 +18,10 @@
     "@types/node": "*",
     "aws-cdk": "*",
     "esbuild": "*",
-    "typescript": "^3.8"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "*",
-    "@aws-cdk/aws-dynamodb": "*",
-    "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/core": "*",
-    "@aws-cdk/aws-lambda-nodejs": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/api-websocket-lambda-dynamodb/index.ts
+++ b/typescript/api-websocket-lambda-dynamodb/index.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-import {AssetCode, Function, Runtime} from "@aws-cdk/aws-lambda";
-import {CfnApi, CfnDeployment, CfnIntegration, CfnRoute, CfnStage} from "@aws-cdk/aws-apigatewayv2";
-import {App, ConcreteDependable, Construct, Duration, RemovalPolicy, Stack, StackProps} from '@aws-cdk/core';
-import {Effect, PolicyStatement, Role, ServicePrincipal} from "@aws-cdk/aws-iam";
-import {AttributeType, Table} from "@aws-cdk/aws-dynamodb";
+import {AssetCode, Function, Runtime} from "aws-cdk-lib/aws-lambda";
+import {CfnApi, CfnDeployment, CfnIntegration, CfnRoute, CfnStage} from "aws-cdk-lib/aws-apigatewayv2";
+import {App, Duration, RemovalPolicy, Stack, StackProps} from 'aws-cdk-lib';
+import {Effect, PolicyStatement, Role, ServicePrincipal} from "aws-cdk-lib/aws-iam";
+import { AttributeType, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Construct } from 'constructs';
 
 import config from './config.json';
 
@@ -148,11 +149,9 @@ class ChatAppStack extends Stack {
             stageName: "dev"
         });
 
-        const dependencies = new ConcreteDependable();
-        dependencies.add(connectRoute)
-        dependencies.add(disconnectRoute)
-        dependencies.add(messageRoute)
-        deployment.node.addDependency(dependencies);
+        deployment.node.addDependency(connectRoute)
+        deployment.node.addDependency(disconnectRoute)
+        deployment.node.addDependency(messageRoute)
     }
 }
 const app = new App();

--- a/typescript/api-websocket-lambda-dynamodb/package.json
+++ b/typescript/api-websocket-lambda-dynamodb/package.json
@@ -17,12 +17,10 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigatewayv2": "*",
-    "@aws-cdk/aws-dynamodb": "*",
-    "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/application-load-balancer/index.ts
+++ b/typescript/application-load-balancer/index.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-import autoscaling = require('@aws-cdk/aws-autoscaling');
-import ec2 = require('@aws-cdk/aws-ec2');
-import elbv2 = require('@aws-cdk/aws-elasticloadbalancingv2');
-import cdk = require('@aws-cdk/core');
+import autoscaling = require('aws-cdk-lib/aws-autoscaling');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import elbv2 = require('aws-cdk-lib/aws-elasticloadbalancingv2');
+import cdk = require('aws-cdk-lib');
 
 class LoadBalancerStack extends cdk.Stack {
   constructor(app: cdk.App, id: string) {
@@ -33,7 +33,7 @@ class LoadBalancerStack extends cdk.Stack {
     listener.connections.allowDefaultPortFromAnyIpv4('Open to the world');
 
     asg.scaleOnRequestCount('AModestLoad', {
-      targetRequestsPerSecond: 1
+      targetRequestsPerMinute: 60,
     });
   }
 }

--- a/typescript/application-load-balancer/package.json
+++ b/typescript/application-load-balancer/package.json
@@ -17,12 +17,10 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-autoscaling": "*",
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-elasticloadbalancingv2": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/appsync-graphql-dynamodb/index.ts
+++ b/typescript/appsync-graphql-dynamodb/index.ts
@@ -1,12 +1,12 @@
-import cdk = require('@aws-cdk/core');
-import { CfnGraphQLApi, CfnApiKey, CfnGraphQLSchema, CfnDataSource, CfnResolver } from '@aws-cdk/aws-appsync';
-import { Table, AttributeType, StreamViewType, BillingMode } from '@aws-cdk/aws-dynamodb';
-import { Role, ServicePrincipal, ManagedPolicy } from '@aws-cdk/aws-iam';
-
+import cdk = require('aws-cdk-lib');
+import { CfnGraphQLApi, CfnApiKey, CfnGraphQLSchema, CfnDataSource, CfnResolver } from 'aws-cdk-lib/aws-appsync';
+import { Table, AttributeType, StreamViewType, BillingMode } from 'aws-cdk-lib/aws-dynamodb';
+import { Role, ServicePrincipal, ManagedPolicy } from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
 
 export class AppSyncCdkStack extends cdk.Stack {
 
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const tableName = 'items'
@@ -54,7 +54,7 @@ export class AppSyncCdkStack extends cdk.Stack {
       stream: StreamViewType.NEW_IMAGE,
 
       // The default removal policy is RETAIN, which means that cdk destroy will not attempt to delete
-      // the new table, and it will remain in your account until manually deleted. By setting the policy to 
+      // the new table, and it will remain in your account until manually deleted. By setting the policy to
       // DESTROY, cdk destroy will delete the table (even if it has data in it)
       removalPolicy: cdk.RemovalPolicy.DESTROY, // NOT recommended for production code
     });

--- a/typescript/appsync-graphql-dynamodb/package.json
+++ b/typescript/appsync-graphql-dynamodb/package.json
@@ -16,12 +16,10 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-appsync": "*",
-    "@aws-cdk/aws-dynamodb": "*",
-    "@aws-cdk/aws-iam": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/appsync-graphql-eventbridge/index.ts
+++ b/typescript/appsync-graphql-eventbridge/index.ts
@@ -1,18 +1,19 @@
-import cdk = require("@aws-cdk/core");
+import cdk = require("aws-cdk-lib");
 import {
   CfnGraphQLApi,
   CfnApiKey,
   CfnGraphQLSchema,
   CfnDataSource,
   CfnResolver
-} from "@aws-cdk/aws-appsync";
-import { Role, ServicePrincipal, PolicyStatement } from "@aws-cdk/aws-iam";
-import { Rule } from "@aws-cdk/aws-events";
-import lambda = require("@aws-cdk/aws-lambda");
-import targets = require("@aws-cdk/aws-events-targets");
+} from "aws-cdk-lib/aws-appsync";
+import { Role, ServicePrincipal, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { Rule } from "aws-cdk-lib/aws-events";
+import lambda = require("aws-cdk-lib/aws-lambda");
+import targets = require("aws-cdk-lib/aws-events-targets");
+import { Construct } from 'constructs';
 
 export class AppSyncCdkStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const appSync2EventBridgeGraphQLApi = new CfnGraphQLApi(
@@ -33,15 +34,15 @@ export class AppSyncCdkStack extends cdk.Stack {
       definition: `type Event {
         result: String
       }
-      
+
       type Mutation {
         putEvent(event: String!): Event
       }
-      
+
       type Query {
         getEvent: Event
       }
-      
+
       schema {
         query: Query
         mutation: Mutation
@@ -91,7 +92,7 @@ export class AppSyncCdkStack extends cdk.Stack {
             "x-amz-target":"AWSEvents.PutEvents"
           },
           "body": {
-            "Entries":[ 
+            "Entries":[
               {
                 "Source":"appsync",
                 "EventBusName": "default",

--- a/typescript/appsync-graphql-eventbridge/package.json
+++ b/typescript/appsync-graphql-eventbridge/package.json
@@ -15,16 +15,12 @@
   "devDependencies": {
     "@types/node": "10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.7.2",
+    "typescript": "~3.9.7",
     "ts-node": "^8.1.0"
   },
   "dependencies": {
-    "@aws-cdk/aws-appsync": "*",
-    "@aws-cdk/aws-iam": "*",
-    "@aws-cdk/aws-events": "*",
-    "@aws-cdk/aws-events-targets": "*",
-    "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/core": "*",
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.9"
   }
 }

--- a/typescript/classic-load-balancer/index.ts
+++ b/typescript/classic-load-balancer/index.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-import autoscaling = require('@aws-cdk/aws-autoscaling');
-import ec2 = require('@aws-cdk/aws-ec2');
-import elb = require('@aws-cdk/aws-elasticloadbalancing');
-import cdk = require('@aws-cdk/core');
+import autoscaling = require('aws-cdk-lib/aws-autoscaling');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import elb = require('aws-cdk-lib/aws-elasticloadbalancing');
+import cdk = require('aws-cdk-lib');
 
 class LoadBalancerStack extends cdk.Stack {
   constructor(app: cdk.App, id: string) {

--- a/typescript/classic-load-balancer/package.json
+++ b/typescript/classic-load-balancer/package.json
@@ -17,12 +17,10 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-autoscaling": "*",
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-elasticloadbalancing": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/cognito-api-lambda/index.ts
+++ b/typescript/cognito-api-lambda/index.ts
@@ -1,7 +1,7 @@
-import { LambdaRestApi, CfnAuthorizer, LambdaIntegration, AuthorizationType } from '@aws-cdk/aws-apigateway';
-import { AssetCode, Function, Runtime } from '@aws-cdk/aws-lambda';
-import { App, Stack } from '@aws-cdk/core';
-import { UserPool } from '@aws-cdk/aws-cognito'
+import { LambdaRestApi, CfnAuthorizer, LambdaIntegration, AuthorizationType } from 'aws-cdk-lib/aws-apigateway';
+import { AssetCode, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { App, Stack } from 'aws-cdk-lib';
+import { UserPool } from 'aws-cdk-lib/aws-cognito'
 
 export class CognitoProtectedApi extends Stack {
   constructor(app: App, id: string) {

--- a/typescript/cognito-api-lambda/package.json
+++ b/typescript/cognito-api-lambda/package.json
@@ -15,13 +15,10 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "*",
-    "@aws-cdk/aws-cognito": "*",
-    "@aws-cdk/aws-dynamodb": "*",
-    "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/custom-logical-names/base-stack.ts
+++ b/typescript/custom-logical-names/base-stack.ts
@@ -1,4 +1,4 @@
-import { Stack, CfnElement } from '@aws-cdk/core';
+import { Stack, CfnElement } from 'aws-cdk-lib';
 
 /**
  * A base stack class that implements custom logical name

--- a/typescript/custom-logical-names/index.ts
+++ b/typescript/custom-logical-names/index.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { BaseStack } from './base-stack';
-import { App, Construct, StackProps } from '@aws-cdk/core';
-import s3 = require('@aws-cdk/aws-s3');
-import sns = require('@aws-cdk/aws-sns');
+import { App, StackProps } from 'aws-cdk-lib';
+import s3 = require('aws-cdk-lib/aws-s3');
+import sns = require('aws-cdk-lib/aws-sns');
+import { Construct } from 'constructs';
 
 class MyStack extends BaseStack {
   constructor(scope: Construct, id: string, props?: StackProps) {

--- a/typescript/custom-logical-names/package.json
+++ b/typescript/custom-logical-names/package.json
@@ -12,12 +12,11 @@
   "devDependencies": {
     "aws-cdk": "*",
     "ts-node": "^8.1.0",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-s3": "*",
-    "@aws-cdk/aws-sns": "*",
-    "@aws-cdk/core": "*",
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.9"
   }
 }

--- a/typescript/custom-resource-provider/index.ts
+++ b/typescript/custom-resource-provider/index.ts
@@ -1,4 +1,4 @@
-import cdk = require('@aws-cdk/core');
+import cdk = require('aws-cdk-lib');
 import { MyCustomResource } from './my-custom-resource';
 
 /**

--- a/typescript/custom-resource-provider/my-custom-resource.ts
+++ b/typescript/custom-resource-provider/my-custom-resource.ts
@@ -1,7 +1,8 @@
-import * as cdk from '@aws-cdk/core';
-import * as logs from '@aws-cdk/aws-logs';
-import * as cr from '@aws-cdk/custom-resources';
-import * as lambda from '@aws-cdk/aws-lambda';
+import * as cdk from 'aws-cdk-lib';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as cr from 'aws-cdk-lib/custom-resources';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
 import fs = require('fs');
 
 export interface MyCustomResourceProps {
@@ -11,10 +12,10 @@ export interface MyCustomResourceProps {
   Message: string;
 }
 
-export class MyCustomResource extends cdk.Construct {
+export class MyCustomResource extends Construct {
   public readonly response: string;
 
-  constructor(scope: cdk.Construct, id: string, props: MyCustomResourceProps) {
+  constructor(scope: Construct, id: string, props: MyCustomResourceProps) {
     super(scope, id);
 
 

--- a/typescript/custom-resource-provider/package.json
+++ b/typescript/custom-resource-provider/package.json
@@ -21,9 +21,8 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/core": "*",
-    "source-map-support": "^0.5.16",
-    "@aws-cdk/aws-logs": "*",
-    "@aws-cdk/custom-resources": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0",
+    "source-map-support": "^0.5.16"
   }
 }

--- a/typescript/custom-resource/index.ts
+++ b/typescript/custom-resource/index.ts
@@ -1,4 +1,4 @@
-import cdk = require('@aws-cdk/core');
+import cdk = require('aws-cdk-lib');
 import { MyCustomResource } from './my-custom-resource';
 
 /**

--- a/typescript/custom-resource/package.json
+++ b/typescript/custom-resource/package.json
@@ -17,11 +17,10 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-cloudformation": "*",
-    "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/ec2-instance/bin/ec2-cdk.ts
+++ b/typescript/ec2-instance/bin/ec2-cdk.ts
@@ -1,4 +1,4 @@
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { Ec2CdkStack } from '../lib/ec2-cdk-stack';
 
 const app = new cdk.App();

--- a/typescript/ec2-instance/cdk.json
+++ b/typescript/ec2-instance/cdk.json
@@ -1,13 +1,3 @@
 {
-  "app": "bin/ec2-cdk.js",
-  "context": {
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true
-  }
+  "app": "bin/ec2-cdk.js"
 }

--- a/typescript/ec2-instance/lib/ec2-cdk-stack.ts
+++ b/typescript/ec2-instance/lib/ec2-cdk-stack.ts
@@ -1,20 +1,22 @@
-import * as ec2 from "@aws-cdk/aws-ec2";
-import * as cdk from '@aws-cdk/core';
-import * as iam from '@aws-cdk/aws-iam'
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam'
 import * as path from 'path';
-import { KeyPair } from 'cdk-ec2-key-pair';
-import { Asset } from '@aws-cdk/aws-s3-assets';
+// import { KeyPair } from 'cdk-ec2-key-pair';
+import { Asset } from 'aws-cdk-lib/aws-s3-assets';
+import { Construct } from 'constructs';
 
 export class Ec2CdkStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     // Create a Key Pair to be used with this EC2 Instance
-    const key = new KeyPair(this, 'KeyPair', {
-      name: 'cdk-keypair',
-      description: 'Key Pair created with CDK Deployment',
-    });
-    key.grantReadOnPublicKey
+    // Temporarily disabled since `cdk-ec2-key-pair` is not yet CDK v2 compatible
+    // const key = new KeyPair(this, 'KeyPair', {
+    //   name: 'cdk-keypair',
+    //   description: 'Key Pair created with CDK Deployment',
+    // });
+    // key.grantReadOnPublicKey
 
     // Create new VPC with 2 Subnets
     const vpc = new ec2.Vpc(this, 'VPC', {
@@ -52,7 +54,7 @@ export class Ec2CdkStack extends cdk.Stack {
       instanceType: ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.MICRO),
       machineImage: ami,
       securityGroup: securityGroup,
-      keyName: key.keyPairName,
+      // keyName: key.keyPairName,
       role: role
     });
 
@@ -71,7 +73,7 @@ export class Ec2CdkStack extends cdk.Stack {
 
     // Create outputs for connecting
     new cdk.CfnOutput(this, 'IP Address', { value: ec2Instance.instancePublicIp });
-    new cdk.CfnOutput(this, 'Key Name', { value: key.keyPairName })
+    // new cdk.CfnOutput(this, 'Key Name', { value: key.keyPairName })
     new cdk.CfnOutput(this, 'Download Key Command', { value: 'aws secretsmanager get-secret-value --secret-id ec2-ssh-key/cdk-keypair/private --query SecretString --output text > cdk-key.pem && chmod 400 cdk-key.pem' })
     new cdk.CfnOutput(this, 'ssh command', { value: 'ssh -i cdk-key.pem -o IdentitiesOnly=yes ec2-user@' + ec2Instance.instancePublicIp })
   }

--- a/typescript/ec2-instance/package.json
+++ b/typescript/ec2-instance/package.json
@@ -15,10 +15,8 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/core": "*",
-    "cdk-ec2-key-pair": "*",
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/typescript/ecs/cluster/index.ts
+++ b/typescript/ecs/cluster/index.ts
@@ -1,7 +1,7 @@
-import autoscaling = require('@aws-cdk/aws-autoscaling');
-import ec2 = require('@aws-cdk/aws-ec2');
-import ecs = require('@aws-cdk/aws-ecs');
-import cdk = require('@aws-cdk/core');
+import autoscaling = require('aws-cdk-lib/aws-autoscaling');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import ecs = require('aws-cdk-lib/aws-ecs');
+import cdk = require('aws-cdk-lib');
 
 class ECSCluster extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
@@ -11,17 +11,14 @@ class ECSCluster extends cdk.Stack {
 
     const asg = new autoscaling.AutoScalingGroup(this, 'MyFleet', {
       instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.XLARGE),
-      machineImage: new ecs.EcsOptimizedAmi(),
-      updateType: autoscaling.UpdateType.REPLACING_UPDATE,
+      machineImage: ecs.EcsOptimizedImage.amazonLinux2(),
       desiredCapacity: 3,
       vpc,
     });
 
     const cluster = new ecs.Cluster(this, 'EcsCluster', { vpc });
-    cluster.addAutoScalingGroup(asg);
-    cluster.addCapacity('DefaultAutoScalingGroup', {
-      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO)
-    });
+    const capacityProvider = new ecs.AsgCapacityProvider(this, 'AsgCapacityProvider', { autoScalingGroup: asg });
+    cluster.addAsgCapacityProvider(capacityProvider);
   }
 }
 

--- a/typescript/ecs/cluster/package.json
+++ b/typescript/ecs/cluster/package.json
@@ -17,11 +17,10 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-ecs": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/cross-stack-load-balancer/index.ts
+++ b/typescript/ecs/cross-stack-load-balancer/index.ts
@@ -1,8 +1,9 @@
-import ecs = require('@aws-cdk/aws-ecs');
-import ec2 = require('@aws-cdk/aws-ec2');
-import { Stack, Construct, StackProps, App } from '@aws-cdk/core';
+import ecs = require('aws-cdk-lib/aws-ecs');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import { Stack, StackProps, App } from 'aws-cdk-lib';
 import { SplitAtListener_LoadBalancerStack, SplitAtListener_ServiceStack } from './split-at-listener';
 import { SplitAtTargetGroup_LoadBalancerStack, SplitAtTargetGroup_ServiceStack } from './split-at-targetgroup';
+import { Construct } from 'constructs';
 
 /**
  * Shared infrastructure -- VPC and Cluster

--- a/typescript/ecs/cross-stack-load-balancer/package.json
+++ b/typescript/ecs/cross-stack-load-balancer/package.json
@@ -17,12 +17,10 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-ecs": "*",
-    "@aws-cdk/aws-elasticloadbalancingv2": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/cross-stack-load-balancer/split-at-listener.ts
+++ b/typescript/ecs/cross-stack-load-balancer/split-at-listener.ts
@@ -1,7 +1,8 @@
-import ecs = require('@aws-cdk/aws-ecs');
-import ec2 = require('@aws-cdk/aws-ec2');
-import elbv2 = require('@aws-cdk/aws-elasticloadbalancingv2');
-import { Stack, Construct, StackProps, CfnOutput } from '@aws-cdk/core';
+import ecs = require('aws-cdk-lib/aws-ecs');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import elbv2 = require('aws-cdk-lib/aws-elasticloadbalancingv2');
+import { Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 
 //---------------------------------------------------------------------------

--- a/typescript/ecs/cross-stack-load-balancer/split-at-targetgroup.ts
+++ b/typescript/ecs/cross-stack-load-balancer/split-at-targetgroup.ts
@@ -1,7 +1,8 @@
-import ecs = require('@aws-cdk/aws-ecs');
-import ec2 = require('@aws-cdk/aws-ec2');
-import elbv2 = require('@aws-cdk/aws-elasticloadbalancingv2');
-import { Stack, Construct, StackProps, CfnOutput } from '@aws-cdk/core';
+import ecs = require('aws-cdk-lib/aws-ecs');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import elbv2 = require('aws-cdk-lib/aws-elasticloadbalancingv2');
+import { Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 
 //---------------------------------------------------------------------------

--- a/typescript/ecs/ecs-network-load-balanced-service/index.ts
+++ b/typescript/ecs/ecs-network-load-balanced-service/index.ts
@@ -1,7 +1,7 @@
-import ec2 = require('@aws-cdk/aws-ec2');
-import ecs = require('@aws-cdk/aws-ecs');
-import ecs_patterns = require('@aws-cdk/aws-ecs-patterns');
-import cdk = require('@aws-cdk/core');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import ecs = require('aws-cdk-lib/aws-ecs');
+import ecs_patterns = require('aws-cdk-lib/aws-ecs-patterns');
+import cdk = require('aws-cdk-lib');
 
 /**
  * The port range to open up for dynamic port mapping

--- a/typescript/ecs/ecs-network-load-balanced-service/package.json
+++ b/typescript/ecs/ecs-network-load-balanced-service/package.json
@@ -17,12 +17,10 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-ecs": "*",
-    "@aws-cdk/aws-ecs-patterns": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/ecs-service-with-advanced-alb-config/index.ts
+++ b/typescript/ecs/ecs-service-with-advanced-alb-config/index.ts
@@ -1,7 +1,7 @@
-import ecs = require('@aws-cdk/aws-ecs');
-import ec2 = require('@aws-cdk/aws-ec2');
-import elbv2 = require('@aws-cdk/aws-elasticloadbalancingv2');
-import cdk = require('@aws-cdk/core');
+import ecs = require('aws-cdk-lib/aws-ecs');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import elbv2 = require('aws-cdk-lib/aws-elasticloadbalancingv2');
+import cdk = require('aws-cdk-lib');
 
 const app = new cdk.App();
 const stack = new cdk.Stack(app, 'aws-ecs-integ-ecs');

--- a/typescript/ecs/ecs-service-with-advanced-alb-config/package.json
+++ b/typescript/ecs/ecs-service-with-advanced-alb-config/package.json
@@ -17,12 +17,10 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-ecs": "*",
-    "@aws-cdk/aws-elasticloadbalancingv2": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/ecs-service-with-logging/index.ts
+++ b/typescript/ecs/ecs-service-with-logging/index.ts
@@ -1,6 +1,6 @@
-import ec2 = require('@aws-cdk/aws-ec2');
-import ecs = require('@aws-cdk/aws-ecs');
-import cdk = require('@aws-cdk/core');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import ecs = require('aws-cdk-lib/aws-ecs');
+import cdk = require('aws-cdk-lib');
 
 class WillkommenECS extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {

--- a/typescript/ecs/ecs-service-with-logging/package.json
+++ b/typescript/ecs/ecs-service-with-logging/package.json
@@ -17,11 +17,10 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-ecs": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/ecs-service-with-task-networking/index.ts
+++ b/typescript/ecs/ecs-service-with-task-networking/index.ts
@@ -1,6 +1,6 @@
-import cdk = require('@aws-cdk/core');
-import ec2 = require('@aws-cdk/aws-ec2');
-import ecs = require('@aws-cdk/aws-ecs');
+import cdk = require('aws-cdk-lib');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import ecs = require('aws-cdk-lib/aws-ecs');
 
 // Based on https://aws.amazon.com/blogs/compute/introducing-cloud-native-networking-for-ecs-containers/
 const app = new cdk.App();
@@ -32,8 +32,8 @@ webContainer.addPortMappings({
 });
 
 // Create a security group that allows HTTP traffic on port 80 for our containers without modifying the security group on the instance
-const securityGroup = new ec2.SecurityGroup(stack, 'nginx--7623', { 
-  vpc, 
+const securityGroup = new ec2.SecurityGroup(stack, 'nginx--7623', {
+  vpc,
   allowAllOutbound: false,
 });
 
@@ -43,7 +43,7 @@ securityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(80));
 new ecs.Ec2Service(stack, 'awsvpc-ecs-demo-service', {
   cluster,
   taskDefinition,
-  securityGroup,
+  securityGroups: [securityGroup],
 });
 
 app.synth();

--- a/typescript/ecs/ecs-service-with-task-networking/package.json
+++ b/typescript/ecs/ecs-service-with-task-networking/package.json
@@ -17,12 +17,10 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-ecs": "*",
-    "@aws-cdk/aws-elasticloadbalancingv2": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/ecs-service-with-task-placement/index.ts
+++ b/typescript/ecs/ecs-service-with-task-placement/index.ts
@@ -1,6 +1,6 @@
-import ecs = require('@aws-cdk/aws-ecs');
-import ec2 = require('@aws-cdk/aws-ec2');
-import cdk = require('@aws-cdk/core');
+import ecs = require('aws-cdk-lib/aws-ecs');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import cdk = require('aws-cdk-lib');
 
 const app = new cdk.App();
 const stack = new cdk.Stack(app, 'aws-ecs-integ-ecs');

--- a/typescript/ecs/ecs-service-with-task-placement/package.json
+++ b/typescript/ecs/ecs-service-with-task-placement/package.json
@@ -17,12 +17,10 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-ecs": "*",
-    "@aws-cdk/aws-elasticloadbalancingv2": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/fargate-application-load-balanced-service/index.ts
+++ b/typescript/ecs/fargate-application-load-balanced-service/index.ts
@@ -1,7 +1,7 @@
-import ec2 = require('@aws-cdk/aws-ec2');
-import ecs = require('@aws-cdk/aws-ecs');
-import ecs_patterns = require('@aws-cdk/aws-ecs-patterns');
-import cdk = require('@aws-cdk/core');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import ecs = require('aws-cdk-lib/aws-ecs');
+import ecs_patterns = require('aws-cdk-lib/aws-ecs-patterns');
+import cdk = require('aws-cdk-lib');
 
 class BonjourFargate extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {

--- a/typescript/ecs/fargate-application-load-balanced-service/package.json
+++ b/typescript/ecs/fargate-application-load-balanced-service/package.json
@@ -17,12 +17,10 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-ecs": "*",
-    "@aws-cdk/aws-ecs-patterns": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/fargate-service-with-auto-scaling/index.ts
+++ b/typescript/ecs/fargate-service-with-auto-scaling/index.ts
@@ -1,7 +1,7 @@
-import ecs = require('@aws-cdk/aws-ecs');
-import ecs_patterns = require('@aws-cdk/aws-ecs-patterns');
-import ec2 = require('@aws-cdk/aws-ec2');
-import cdk = require('@aws-cdk/core');
+import ecs = require('aws-cdk-lib/aws-ecs');
+import ecs_patterns = require('aws-cdk-lib/aws-ecs-patterns');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import cdk = require('aws-cdk-lib');
 
 class AutoScalingFargateService extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {

--- a/typescript/ecs/fargate-service-with-auto-scaling/package.json
+++ b/typescript/ecs/fargate-service-with-auto-scaling/package.json
@@ -17,13 +17,10 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-ecs": "*",
-    "@aws-cdk/aws-ecs-patterns": "*",
-    "@aws-cdk/aws-elasticloadbalancingv2": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/fargate-service-with-efs/efs-mount-fargate-cr.ts
+++ b/typescript/ecs/fargate-service-with-efs/efs-mount-fargate-cr.ts
@@ -1,9 +1,9 @@
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as cdk from '@aws-cdk/core';
-import * as iam from '@aws-cdk/aws-iam';
-import * as cr from '@aws-cdk/custom-resources';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as cr from 'aws-cdk-lib/custom-resources';
 import fs = require('fs');
-
+import { Construct } from 'constructs';
 
 export interface FargateEfsCustomResourceProps {
   /**
@@ -17,10 +17,10 @@ export interface FargateEfsCustomResourceProps {
 }
 
 
-export class FargateEfsCustomResource extends cdk.Construct {
+export class FargateEfsCustomResource extends Construct {
   public readonly response: string;
 
-  constructor(scope: cdk.Construct, id: string, props: FargateEfsCustomResourceProps) {
+  constructor(scope: Construct, id: string, props: FargateEfsCustomResourceProps) {
     super(scope, id);
 
     const onEvent = new lambda.SingletonFunction(this, 'Singleton', {

--- a/typescript/ecs/fargate-service-with-efs/index.ts
+++ b/typescript/ecs/fargate-service-with-efs/index.ts
@@ -1,9 +1,9 @@
-import * as cdk from '@aws-cdk/core';
-import * as ec2 from '@aws-cdk/aws-ec2';
-import * as ecs from '@aws-cdk/aws-ecs';
-import * as ecs_patterns from '@aws-cdk/aws-ecs-patterns';
-import * as efs from '@aws-cdk/aws-efs';
-import * as cr from '@aws-cdk/custom-resources';
+import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as ecs_patterns from 'aws-cdk-lib/aws-ecs-patterns';
+import * as efs from 'aws-cdk-lib/aws-efs';
+import * as cr from 'aws-cdk-lib/custom-resources';
 import {FargateEfsCustomResource} from "./efs-mount-fargate-cr";
 
 

--- a/typescript/ecs/fargate-service-with-efs/package.json
+++ b/typescript/ecs/fargate-service-with-efs/package.json
@@ -17,14 +17,10 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "^3.9.5"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-ecs": "*",
-    "@aws-cdk/aws-ecs-patterns": "*",
-    "@aws-cdk/aws-efs": "*",
-    "@aws-cdk/core": "*",
-    "@aws-cdk/custom-resources": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/fargate-service-with-local-image/index.ts
+++ b/typescript/ecs/fargate-service-with-local-image/index.ts
@@ -1,7 +1,7 @@
-import ec2 = require('@aws-cdk/aws-ec2');
-import ecs = require('@aws-cdk/aws-ecs');
-import ecs_patterns = require('@aws-cdk/aws-ecs-patterns');
-import cdk = require('@aws-cdk/core');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import ecs = require('aws-cdk-lib/aws-ecs');
+import ecs_patterns = require('aws-cdk-lib/aws-ecs-patterns');
+import cdk = require('aws-cdk-lib');
 import path = require('path');
 
 const app = new cdk.App();

--- a/typescript/ecs/fargate-service-with-local-image/package.json
+++ b/typescript/ecs/fargate-service-with-local-image/package.json
@@ -17,12 +17,10 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-ecs": "*",
-    "@aws-cdk/aws-ecs-patterns": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/fargate-service-with-logging/index.ts
+++ b/typescript/ecs/fargate-service-with-logging/index.ts
@@ -1,6 +1,6 @@
-import ec2 = require('@aws-cdk/aws-ec2');
-import ecs = require('@aws-cdk/aws-ecs');
-import cdk = require('@aws-cdk/core');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import ecs = require('aws-cdk-lib/aws-ecs');
+import cdk = require('aws-cdk-lib');
 
 class WillkommenFargate extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {

--- a/typescript/ecs/fargate-service-with-logging/package.json
+++ b/typescript/ecs/fargate-service-with-logging/package.json
@@ -17,11 +17,10 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-ecs": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/eks/cluster/index.ts
+++ b/typescript/eks/cluster/index.ts
@@ -1,8 +1,8 @@
-import autoscaling = require('@aws-cdk/aws-autoscaling');
-import iam = require('@aws-cdk/aws-iam');
-import ec2 = require('@aws-cdk/aws-ec2');
-import eks = require('@aws-cdk/aws-eks');
-import cdk = require('@aws-cdk/core');
+import autoscaling = require('aws-cdk-lib/aws-autoscaling');
+import iam = require('aws-cdk-lib/aws-iam');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import eks = require('aws-cdk-lib/aws-eks');
+import cdk = require('aws-cdk-lib');
 
 class EKSCluster extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {

--- a/typescript/eks/cluster/package.json
+++ b/typescript/eks/cluster/package.json
@@ -17,14 +17,11 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-autoscaling": "*",
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-eks": "*",
-    "@aws-cdk/aws-iam": "*",
-    "@aws-cdk/core": "*",
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0",
     "aws-cdk": "*"
   }
 }

--- a/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/index.ts
@@ -1,9 +1,9 @@
-import cdk = require('@aws-cdk/core');
-import cpactions = require('@aws-cdk/aws-codepipeline-actions');
-import cp = require('@aws-cdk/aws-codepipeline');
-import cc = require('@aws-cdk/aws-codecommit');
-import lambda = require('@aws-cdk/aws-lambda');
-import s3 = require('@aws-cdk/aws-s3');
+import cdk = require('aws-cdk-lib');
+import cpactions = require('aws-cdk-lib/aws-codepipeline-actions');
+import cp = require('aws-cdk-lib/aws-codepipeline');
+import cc = require('aws-cdk-lib/aws-codecommit');
+import lambda = require('aws-cdk-lib/aws-lambda');
+import s3 = require('aws-cdk-lib/aws-s3');
 
 export class CdkStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
@@ -18,14 +18,14 @@ export class CdkStack extends cdk.Stack {
 
     const bucket = new s3.Bucket(this, 'BlueGreenBucket', {
       // The default removal policy is RETAIN, which means that cdk destroy will not attempt to delete
-      // the new bucket, and it will remain in your account until manually deleted. By setting the policy to 
+      // the new bucket, and it will remain in your account until manually deleted. By setting the policy to
       // DESTROY, cdk destroy will attempt to delete the bucket, but will error if the bucket is not empty.
       removalPolicy: cdk.RemovalPolicy.DESTROY, // NOT recommended for production code
     });
 
     const handler = new lambda.Function(this, 'BlueGreenLambda', {
       runtime: lambda.Runtime.PYTHON_3_6,
-      code: lambda.Code.asset('resources'),
+      code: lambda.Code.fromAsset('resources'),
       handler: 'blue_green.lambda_handler',
       environment: {
         BUCKET: bucket.bucketName

--- a/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/package.json
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/package.json
@@ -16,17 +16,12 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/node": "^8.10.40",
-    "typescript": "~3.7.2",
+    "typescript": "~3.9.7",
     "aws-cdk": "*"
   },
   "dependencies": {
-    "@aws-cdk/aws-elasticbeanstalk": "*",
-    "@aws-cdk/aws-codepipeline-actions": "*",
-    "@aws-cdk/aws-codepipeline": "*",
-    "@aws-cdk/aws-codecommit": "*",
-    "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/aws-s3": "*",
-    "@aws-cdk/core": "*",
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.9"
   }
 }

--- a/typescript/elasticbeanstalk/elasticbeanstalk-environment/index.ts
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-environment/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import * as cdk from '@aws-cdk/core';
-import * as elasticbeanstalk from '@aws-cdk/aws-elasticbeanstalk';
+import * as cdk from 'aws-cdk-lib';
+import * as elasticbeanstalk from 'aws-cdk-lib/aws-elasticbeanstalk';
 
 
 export class CdkStack extends cdk.Stack {

--- a/typescript/elasticbeanstalk/elasticbeanstalk-environment/package.json
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-environment/package.json
@@ -16,12 +16,12 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/node": "^8.10.40",
-    "typescript": "~3.7.2",
+    "typescript": "~3.9.7",
     "aws-cdk": "*"
   },
   "dependencies": {
-    "@aws-cdk/aws-elasticbeanstalk": "*",
-    "@aws-cdk/core": "*",
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.9"
   }
 }

--- a/typescript/fsx-ad/index.ts
+++ b/typescript/fsx-ad/index.ts
@@ -1,8 +1,8 @@
-import * as cdk from '@aws-cdk/core';
-import * as ec2 from '@aws-cdk/aws-ec2';
-import * as ad from '@aws-cdk/aws-directoryservice';
-import * as fsx from '@aws-cdk/aws-fsx';
-import * as sm from '@aws-cdk/aws-secretsmanager';
+import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ad from 'aws-cdk-lib/aws-directoryservice';
+import * as fsx from 'aws-cdk-lib/aws-fsx';
+import * as sm from 'aws-cdk-lib/aws-secretsmanager';
 
 class AdFsxStack extends cdk.Stack {
   constructor(app: cdk.App, id: string, adDnsDomainName: string) {

--- a/typescript/fsx-ad/package.json
+++ b/typescript/fsx-ad/package.json
@@ -20,10 +20,7 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-directoryservice": "*",
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-fsx": "*",
-    "@aws-cdk/aws-secretsmanager": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/http-proxy-apigateway/index.ts
+++ b/typescript/http-proxy-apigateway/index.ts
@@ -1,6 +1,6 @@
-import * as cdk from "@aws-cdk/core";
+import * as cdk from "aws-cdk-lib";
 
-import { EndpointType } from "@aws-cdk/aws-apigateway";
+import { EndpointType } from "aws-cdk-lib/aws-apigateway";
 
 import { Proxy } from "./proxy";
 

--- a/typescript/http-proxy-apigateway/package.json
+++ b/typescript/http-proxy-apigateway/package.json
@@ -17,10 +17,10 @@
   "devDependencies": {
     "@types/node": "^14.0.6",
     "aws-cdk": "*",
-    "typescript": "3.9.3"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/http-proxy-apigateway/proxy.ts
+++ b/typescript/http-proxy-apigateway/proxy.ts
@@ -1,6 +1,6 @@
-import { Construct, CfnOutput } from "@aws-cdk/core";
-
-import * as apiGateway from "@aws-cdk/aws-apigateway";
+import { CfnOutput } from "aws-cdk-lib";
+import * as apiGateway from "aws-cdk-lib/aws-apigateway";
+import { Construct } from 'constructs';
 
 export interface ProxyProps {
   readonly apiName: string;

--- a/typescript/lambda-api-ci/bin/ci.ts
+++ b/typescript/lambda-api-ci/bin/ci.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import "source-map-support/register"
-import cdk = require("@aws-cdk/core")
+import cdk = require("aws-cdk-lib")
 import { CIStack } from "../lib/ci-stack"
 
 const app = new cdk.App()

--- a/typescript/lambda-api-ci/bin/lambda.ts
+++ b/typescript/lambda-api-ci/bin/lambda.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import "source-map-support/register"
-import cdk = require("@aws-cdk/core")
+import cdk = require("aws-cdk-lib")
 import { CDKExampleLambdaApiStack } from "../lib/lambda-api-stack"
 
 export const lambdaApiStackName = "CDKExampleLambdaApiStack"

--- a/typescript/lambda-api-ci/lib/ci-stack.ts
+++ b/typescript/lambda-api-ci/lib/ci-stack.ts
@@ -1,9 +1,10 @@
-import { CodeCommitSourceAction, CodeBuildAction } from "@aws-cdk/aws-codepipeline-actions"
-import { PolicyStatement } from "@aws-cdk/aws-iam"
-import { Construct, Stack, StackProps } from "@aws-cdk/core"
-import { PipelineProject, LinuxBuildImage } from "@aws-cdk/aws-codebuild"
-import { Artifact, Pipeline } from "@aws-cdk/aws-codepipeline"
-import { Repository } from "@aws-cdk/aws-codecommit"
+import { CodeCommitSourceAction, CodeBuildAction } from "aws-cdk-lib/aws-codepipeline-actions"
+import { PolicyStatement } from "aws-cdk-lib/aws-iam"
+import { ArnFormat, Stack, StackProps } from "aws-cdk-lib"
+import { PipelineProject, LinuxBuildImage } from "aws-cdk-lib/aws-codebuild"
+import { Artifact, Pipeline } from "aws-cdk-lib/aws-codepipeline"
+import { Repository } from "aws-cdk-lib/aws-codecommit"
+import { Construct } from "constructs"
 import { lambdaApiStackName, lambdaFunctionName } from "../bin/lambda"
 
 interface CIStackProps extends StackProps {
@@ -76,7 +77,7 @@ export class CIStack extends Stack {
             this.formatArn({
                 service: "lambda",
                 resource: "function",
-                sep: ":",
+                arnFormat: ArnFormat.COLON_RESOURCE_NAME,
                 resourceName: lambdaFunctionName,
             }),
             "arn:aws:s3:::cdktoolkit-stagingbucket-*"

--- a/typescript/lambda-api-ci/lib/lambda-api-stack.ts
+++ b/typescript/lambda-api-ci/lib/lambda-api-stack.ts
@@ -1,8 +1,9 @@
-import { LambdaIntegration, MethodLoggingLevel, RestApi } from "@aws-cdk/aws-apigateway"
-import { PolicyStatement } from "@aws-cdk/aws-iam"
-import { Function, Runtime, AssetCode, Code } from "@aws-cdk/aws-lambda"
-import { Construct, Duration, Stack, StackProps } from "@aws-cdk/core"
-import s3 = require("@aws-cdk/aws-s3")
+import { LambdaIntegration, MethodLoggingLevel, RestApi } from "aws-cdk-lib/aws-apigateway"
+import { PolicyStatement } from "aws-cdk-lib/aws-iam"
+import { Function, Runtime, AssetCode, Code } from "aws-cdk-lib/aws-lambda"
+import { Duration, Stack, StackProps } from "aws-cdk-lib"
+import s3 = require("aws-cdk-lib/aws-s3")
+import { Construct } from "constructs"
 
 interface LambdaApiStackProps extends StackProps {
     functionName: string

--- a/typescript/lambda-api-ci/package.json
+++ b/typescript/lambda-api-ci/package.json
@@ -1,43 +1,45 @@
 {
-    "name": "lambda-api-ci",
-    "version": "0.1.0",
-    "bin": {
-        "lambda-api-ci": "bin/lambda-api-ci.js"
-    },
-    "scripts": {
-        "build": "npm run prettier && tsc && npm run build-lambda",
-        "build-lambda": "cd src && npm run build",
-        "watch": "tsc -w",
-        "test": "jest",
-        "cdk": "cdk",
-        "prettier": "prettier --write '**/{bin,lib,src,tst}/*.ts'"
-    },
-    "devDependencies": {
-        "aws-cdk": "*",
-        "@aws-cdk/core": "*",
-        "@aws-cdk/assert": "*",
-        "@aws-cdk/aws-apigateway": "*",
-        "@aws-cdk/aws-codebuild": "*",
-        "@aws-cdk/aws-codecommit": "*",
-        "@aws-cdk/aws-codepipeline": "*",
-        "@aws-cdk/aws-codepipeline-actions": "*",
-        "@aws-cdk/aws-cloudformation": "*",
-        "@types/node": "^13.7.0",
-        "ts-node": "^8.1.0",
-        "typescript": "^3.8.3",
-        "prettier": "^2.0.4"
-    },
-    "dependencies": {
-        "aws-sdk": "^2.617.0",
-        "source-map-support": "^0.5.9"
-    },
-    "description": "* `npm run build`   compile typescript to js  * `npm run watch`   watch for changes and compile  * `npm run test`    perform the jest unit tests  * `cdk deploy`      deploy this stack to your default AWS account/region  * `cdk diff`        compare deployed stack with current state  * `cdk synth`       emits the synthesized CloudFormation template",
-    "main": "jest.config.js",
-    "directories": {
-        "lib": "lib",
-        "test": "test"
-    },
-    "keywords": [],
-    "author": "",
-    "license": "ISC"
+  "name": "lambda-api-ci",
+  "version": "0.1.0",
+  "bin": {
+    "lambda-api-ci": "bin/lambda-api-ci.js"
+  },
+  "scripts": {
+    "build": "npm run prettier && tsc && npm run build-lambda",
+    "build-lambda": "cd src && npm run build",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk",
+    "prettier": "prettier --write '**/{bin,lib,src,tst}/*.ts'"
+  },
+  "devDependencies": {
+    "aws-cdk": "*",
+    "@aws-cdk/core": "*",
+    "@aws-cdk/assert": "*",
+    "@aws-cdk/aws-apigateway": "*",
+    "@aws-cdk/aws-codebuild": "*",
+    "@aws-cdk/aws-codecommit": "*",
+    "@aws-cdk/aws-codepipeline": "*",
+    "@aws-cdk/aws-codepipeline-actions": "*",
+    "@aws-cdk/aws-cloudformation": "*",
+    "@types/node": "^13.7.0",
+    "ts-node": "^8.1.0",
+    "typescript": "~3.9.7",
+    "prettier": "^2.0.4"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0",
+    "aws-sdk": "^2.617.0",
+    "source-map-support": "^0.5.9"
+  },
+  "description": "* `npm run build`   compile typescript to js  * `npm run watch`   watch for changes and compile  * `npm run test`    perform the jest unit tests  * `cdk deploy`      deploy this stack to your default AWS account/region  * `cdk diff`        compare deployed stack with current state  * `cdk synth`       emits the synthesized CloudFormation template",
+  "main": "jest.config.js",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
 }

--- a/typescript/lambda-api-ci/src/package.json
+++ b/typescript/lambda-api-ci/src/package.json
@@ -13,7 +13,7 @@
     "jest": "^24.9.0",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.1.0",
-    "typescript": "~3.8.3"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
     "aws-sdk": "^2.617.0"

--- a/typescript/lambda-cloudwatch-dashboard/bin/lambda-cloudwatch-dashboard.ts
+++ b/typescript/lambda-cloudwatch-dashboard/bin/lambda-cloudwatch-dashboard.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { LambdaCloudwatchDashboardStack } from '../lib/lambda-cloudwatch-dashboard-stack';
 
 export const cloudwatchDashboardName = "SampleLambdaDashboard"

--- a/typescript/lambda-cloudwatch-dashboard/cdk.json
+++ b/typescript/lambda-cloudwatch-dashboard/cdk.json
@@ -1,16 +1,3 @@
 {
-  "app": "npx ts-node --prefer-ts-exts bin/lambda-cloudwatch-dashboard.ts",
-  "context": {
-    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
-    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true
-  }
+  "app": "npx ts-node --prefer-ts-exts bin/lambda-cloudwatch-dashboard.ts"
 }

--- a/typescript/lambda-cloudwatch-dashboard/lib/lambda-cloudwatch-dashboard-stack.ts
+++ b/typescript/lambda-cloudwatch-dashboard/lib/lambda-cloudwatch-dashboard-stack.ts
@@ -1,7 +1,7 @@
-import { Construct, Duration, Stack, StackProps, CfnOutput, Aws } from "@aws-cdk/core";
-
-import { GraphWidget, Dashboard, LogQueryWidget, TextWidget } from '@aws-cdk/aws-cloudwatch';
-import { Function, Runtime, AssetCode } from "@aws-cdk/aws-lambda";
+import { Duration, Stack, StackProps, CfnOutput, Aws } from "aws-cdk-lib";
+import { GraphWidget, Dashboard, LogQueryWidget, TextWidget } from 'aws-cdk-lib/aws-cloudwatch';
+import { Function, Runtime, AssetCode } from "aws-cdk-lib/aws-lambda";
+import { Construct } from 'constructs';
 
 interface LambdaCloudwatchDashboardStackProps extends StackProps {
   dashboardName: string
@@ -66,10 +66,10 @@ export class LambdaCloudwatchDashboardStack extends Stack {
       queryLines:[
         "fields @timestamp, @message",
         "sort @timestamp desc",
-        "limit 20"], 
+        "limit 20"],
       width: 24,
       }))
-    
+
     // Generate Outputs
     const cloudwatchDashboardURL = `https://${Aws.REGION}.console.aws.amazon.com/cloudwatch/home?region=${Aws.REGION}#dashboards:name=${props.dashboardName}`;
     new CfnOutput(this, 'DashboardOutput', {

--- a/typescript/lambda-cloudwatch-dashboard/package.json
+++ b/typescript/lambda-cloudwatch-dashboard/package.json
@@ -21,9 +21,8 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/core": "*",
-    "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/aws-cloudwatch": "*",
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/typescript/lambda-cron/index.ts
+++ b/typescript/lambda-cron/index.ts
@@ -1,7 +1,7 @@
-import events = require('@aws-cdk/aws-events');
-import targets = require('@aws-cdk/aws-events-targets');
-import lambda = require('@aws-cdk/aws-lambda');
-import cdk = require('@aws-cdk/core');
+import events = require('aws-cdk-lib/aws-events');
+import targets = require('aws-cdk-lib/aws-events-targets');
+import lambda = require('aws-cdk-lib/aws-lambda');
+import cdk = require('aws-cdk-lib');
 
 import fs = require('fs');
 

--- a/typescript/lambda-cron/lambda-cron.test.ts
+++ b/typescript/lambda-cron/lambda-cron.test.ts
@@ -1,6 +1,6 @@
-import { Capture, Match, Template } from '@aws-cdk/assertions';
+import { Capture, Match, Template } from 'aws-cdk-lib/assertions';
 import { LambdaCronStack } from './index';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 
 const app = new cdk.App();
 const stack = new LambdaCronStack(app, 'testStack');

--- a/typescript/lambda-cron/package.json
+++ b/typescript/lambda-cron/package.json
@@ -23,10 +23,7 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/assertions": "*",
-    "@aws-cdk/aws-events": "*",
-    "@aws-cdk/aws-events-targets": "*",
-    "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/lambda-layer/bin/lambda-layer.ts
+++ b/typescript/lambda-layer/bin/lambda-layer.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import {LambdaLayerStack} from '../lib/lambda-layer-stack';
 
 const app = new cdk.App();

--- a/typescript/lambda-layer/lib/lambda-layer-stack.ts
+++ b/typescript/lambda-layer/lib/lambda-layer-stack.ts
@@ -1,8 +1,9 @@
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
 
 export class LambdaLayerStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const layer = new lambda.LayerVersion(this, 'HelperLayer', {

--- a/typescript/lambda-layer/package.json
+++ b/typescript/lambda-layer/package.json
@@ -18,8 +18,8 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/core": "*",
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/typescript/lambda-manage-s3-event-notification/bin/lambda-manage-s3-event-notifications.ts
+++ b/typescript/lambda-manage-s3-event-notification/bin/lambda-manage-s3-event-notifications.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT-0
 
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { SharedStack } from '../lib/shared-resources-stack';
 import { AStack, BStack } from '../lib/sample-service-stack';
 

--- a/typescript/lambda-manage-s3-event-notification/cdk.json
+++ b/typescript/lambda-manage-s3-event-notification/cdk.json
@@ -1,13 +1,3 @@
 {
-  "app": "npx ts-node --prefer-ts-exts bin/lambda-manage-s3-event-notifications.ts",
-  "context": {
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true
-  }
+  "app": "npx ts-node --prefer-ts-exts bin/lambda-manage-s3-event-notifications.ts"
 }

--- a/typescript/lambda-manage-s3-event-notification/lib/sample-service-stack.ts
+++ b/typescript/lambda-manage-s3-event-notification/lib/sample-service-stack.ts
@@ -1,18 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import * as cdk from '@aws-cdk/core';
-import * as sqs from '@aws-cdk/aws-sqs';
-import * as iam from '@aws-cdk/aws-iam';
-import * as sns from '@aws-cdk/aws-sns';
+import * as cdk from 'aws-cdk-lib';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import { Construct } from 'constructs';
 
 export interface AStackProps extends cdk.StackProps {
   readonly bucketName: string; // Bucket to enable SQS notifications
 }
 export class AStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props: AStackProps) {
+  constructor(scope: Construct, id: string, props: AStackProps) {
     super(scope, id, props);
-    
+
     const queue = new sqs.Queue(this, 'SampleQueue');
     queue.grant(new iam.ServicePrincipal('s3.amazonaws.com', {
       conditions: {
@@ -26,7 +27,7 @@ export class AStack extends cdk.Stack {
         }
       }
     }), 'sqs:SendMessage', 'sqs:GetQueueAttributes', 'sqs:GetQueueUrl');
-    
+
     const lambdaArn = cdk.Arn.format({
       service: 'lambda',
       resource: 'S3EventNotificationsManager'
@@ -63,7 +64,7 @@ export interface BStackProps extends cdk.StackProps {
   readonly bucketName: string; // Bucket to enable SNS notifications
 }
 export class BStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props: BStackProps) {
+  constructor(scope: Construct, id: string, props: BStackProps) {
     super(scope, id, props);
 
     const topic = new sns.Topic(this, 'SampleTopic');

--- a/typescript/lambda-manage-s3-event-notification/lib/shared-resources-stack.ts
+++ b/typescript/lambda-manage-s3-event-notification/lib/shared-resources-stack.ts
@@ -1,15 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import * as cdk from '@aws-cdk/core';
-import * as s3 from '@aws-cdk/aws-s3';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as iam from '@aws-cdk/aws-iam';
+import * as cdk from 'aws-cdk-lib';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
 import * as path from 'path';
 
 export class SharedStack extends cdk.Stack {
   public readonly bucketName: string;
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const bucket = new s3.Bucket(this, 'SampleBucket', {
@@ -25,7 +26,7 @@ export class SharedStack extends cdk.Stack {
       reservedConcurrentExecutions: 1,
       timeout: cdk.Duration.seconds(300)
     });
-    
+
     fn.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ['s3:GetBucketNotification', 's3:PutBucketNotification'],

--- a/typescript/lambda-manage-s3-event-notification/package.json
+++ b/typescript/lambda-manage-s3-event-notification/package.json
@@ -17,10 +17,8 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-iam": "*",
-    "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/aws-sns": "*",
-    "@aws-cdk/core": "*",
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/typescript/my-widget-service/index.ts
+++ b/typescript/my-widget-service/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import cdk = require('@aws-cdk/core');
+import cdk = require('aws-cdk-lib');
 import widget_service = require('./widget_service');
 
 export class MyWidgetServiceStack extends cdk.Stack {

--- a/typescript/my-widget-service/package.json
+++ b/typescript/my-widget-service/package.json
@@ -17,13 +17,11 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "*",
-    "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/aws-s3": "*",
-    "@aws-cdk/core": "*",
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0",
     "source-map-support": "*"
   }
 }

--- a/typescript/my-widget-service/widget_service.ts
+++ b/typescript/my-widget-service/widget_service.ts
@@ -27,18 +27,19 @@
 // OF ANY KIND, either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 // snippet-start:[cdk.typescript.widget_service]
-import cdk = require("@aws-cdk/core");
-import apigateway = require("@aws-cdk/aws-apigateway");
-import lambda = require("@aws-cdk/aws-lambda");
-import s3 = require("@aws-cdk/aws-s3");
+import cdk = require("aws-cdk-lib");
+import apigateway = require("aws-cdk-lib/aws-apigateway");
+import lambda = require("aws-cdk-lib/aws-lambda");
+import s3 = require("aws-cdk-lib/aws-s3");
+import { Construct } from 'constructs';
 
-export class WidgetService extends cdk.Construct {
-  constructor(scope: cdk.Construct, id: string) {
+export class WidgetService extends Construct {
+  constructor(scope: Construct, id: string) {
     super(scope, id);
 
     const bucket = new s3.Bucket(this, "WidgetStore", {
       // The default removal policy is RETAIN, which means that cdk destroy will not attempt to delete
-      // the new bucket, and it will remain in your account until manually deleted. By setting the policy to 
+      // the new bucket, and it will remain in your account until manually deleted. By setting the policy to
       // DESTROY, cdk destroy will attempt to delete the bucket, but will error if the bucket is not empty.
       removalPolicy: cdk.RemovalPolicy.DESTROY, // NOT recommended for production code
     });

--- a/typescript/neptune-with-vpc/app.ts
+++ b/typescript/neptune-with-vpc/app.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 
 import { NeptuneWithVpcStack } from './neptune-with-vpc-stack';
 

--- a/typescript/neptune-with-vpc/cdk.json
+++ b/typescript/neptune-with-vpc/cdk.json
@@ -1,10 +1,3 @@
 {
-  "app": "npx ts-node --prefer-ts-exts app.ts",
-  "context": {
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true
-  }
+  "app": "npx ts-node --prefer-ts-exts app.ts"
 }

--- a/typescript/neptune-with-vpc/neptune-with-vpc-stack.ts
+++ b/typescript/neptune-with-vpc/neptune-with-vpc-stack.ts
@@ -1,10 +1,11 @@
 
-import * as cdk from '@aws-cdk/core';
-import * as ec2 from '@aws-cdk/aws-ec2';
-import * as neptune from '@aws-cdk/aws-neptune';
+import * as cdk from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as neptune from '@aws-cdk/aws-neptune-alpha';
+import { Construct } from 'constructs';
 
 export class NeptuneWithVpcStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     // Create VPC for use with Neptune

--- a/typescript/neptune-with-vpc/package.json
+++ b/typescript/neptune-with-vpc/package.json
@@ -11,6 +11,9 @@
     "cdk": "cdk"
   },
   "dependencies": {
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0",
+    "@aws-cdk/aws-neptune-alpha": "^2.0.0-alpha.10",
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
     "jest": "^26.4.2",
@@ -18,10 +21,6 @@
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7",
     "aws-cdk": "*",
-    "@aws-cdk/assert": "*",
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-neptune": "*",
-    "@aws-cdk/core": "*",
     "source-map-support": "^0.5.16"
   }
 }

--- a/typescript/resource-overrides/index.ts
+++ b/typescript/resource-overrides/index.ts
@@ -1,7 +1,7 @@
-import autoscaling = require('@aws-cdk/aws-autoscaling');
-import ec2 = require('@aws-cdk/aws-ec2');
-import s3 = require('@aws-cdk/aws-s3');
-import cdk = require('@aws-cdk/core');
+import autoscaling = require('aws-cdk-lib/aws-autoscaling');
+import ec2 = require('aws-cdk-lib/aws-ec2');
+import s3 = require('aws-cdk-lib/aws-s3');
+import cdk = require('aws-cdk-lib');
 import assert = require('assert');
 
 class ResourceOverridesExample extends cdk.Stack {

--- a/typescript/resource-overrides/package.json
+++ b/typescript/resource-overrides/package.json
@@ -17,12 +17,10 @@
   "devDependencies": {
     "aws-cdk": "*",
     "@types/node": "^10.17.0",
-    "typescript": "~3.7.2"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-autoscaling": "*",
-    "@aws-cdk/aws-ec2": "*",
-    "@aws-cdk/aws-s3": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/static-site/index.ts
+++ b/typescript/static-site/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 import { StaticSite } from './static-site';
 
 /**

--- a/typescript/static-site/package.json
+++ b/typescript/static-site/package.json
@@ -16,17 +16,10 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "^3.8"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-certificatemanager": "*",
-    "@aws-cdk/aws-cloudfront": "*",
-    "@aws-cdk/aws-iam": "*",
-    "@aws-cdk/aws-route53": "*",
-    "@aws-cdk/aws-route53-targets": "*",
-    "@aws-cdk/aws-s3": "*",
-    "@aws-cdk/aws-s3-deployment": "*",
-    "@aws-cdk/core": "*",
-    "aws-cdk": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/static-site/static-site.ts
+++ b/typescript/static-site/static-site.ts
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
-import * as cdk from '@aws-cdk/core';
-import * as route53 from '@aws-cdk/aws-route53';
-import * as s3 from '@aws-cdk/aws-s3';
-import * as s3deploy from '@aws-cdk/aws-s3-deployment';
-import * as acm from '@aws-cdk/aws-certificatemanager';
-import * as targets from '@aws-cdk/aws-route53-targets';
-import * as cloudfront from '@aws-cdk/aws-cloudfront';
-import * as cloudwatch from "@aws-cdk/aws-cloudwatch";
-import * as iam from '@aws-cdk/aws-iam';
-import { Construct, Stack } from '@aws-cdk/core';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as targets from 'aws-cdk-lib/aws-route53-targets';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Aws, CfnOutput, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 export interface StaticSiteProps {
   domainName: string;
@@ -31,7 +31,7 @@ export class StaticSite extends Construct {
       comment: `OAI for ${name}`
     });
 
-    new cdk.CfnOutput(this, 'Site', { value: 'https://' + siteDomain });
+    new CfnOutput(this, 'Site', { value: 'https://' + siteDomain });
 
     // Content bucket
     const siteBucket = new s3.Bucket(this, 'SiteBucket', {
@@ -46,7 +46,7 @@ export class StaticSite extends Construct {
        * the new bucket, and it will remain in your account until manually deleted. By setting the policy to
        * DESTROY, cdk destroy will attempt to delete the bucket, but will error if the bucket is not empty.
        */
-      removalPolicy: cdk.RemovalPolicy.DESTROY, // NOT recommended for production code
+      removalPolicy: RemovalPolicy.DESTROY, // NOT recommended for production code
 
       /**
        * For sample purposes only, if you create an S3 bucket then populate it, stack destruction fails.  This
@@ -60,7 +60,7 @@ export class StaticSite extends Construct {
       resources: [siteBucket.arnForObjects('*')],
       principals: [new iam.CanonicalUserPrincipal(cloudfrontOAI.cloudFrontOriginAccessIdentityS3CanonicalUserId)]
     }));
-    new cdk.CfnOutput(this, 'Bucket', { value: siteBucket.bucketName });
+    new CfnOutput(this, 'Bucket', { value: siteBucket.bucketName });
 
     // TLS certificate
     const certificateArn = new acm.DnsValidatedCertificate(this, 'SiteCertificate', {
@@ -68,14 +68,14 @@ export class StaticSite extends Construct {
       hostedZone: zone,
       region: 'us-east-1', // Cloudfront only checks this region for certificates.
     }).certificateArn;
-    new cdk.CfnOutput(this, 'Certificate', { value: certificateArn });
+    new CfnOutput(this, 'Certificate', { value: certificateArn });
 
     // Specifies you want viewers to use HTTPS & TLS v1.1 to request your objects
     const viewerCertificate = cloudfront.ViewerCertificate.fromAcmCertificate({
       certificateArn: certificateArn,
       env: {
-        region: cdk.Aws.REGION,
-        account: cdk.Aws.ACCOUNT_ID
+        region: Aws.REGION,
+        account: Aws.ACCOUNT_ID
       },
       node: this.node,
       stack: parent,
@@ -108,7 +108,7 @@ export class StaticSite extends Construct {
         }
       ]
     });
-    new cdk.CfnOutput(this, 'DistributionId', { value: distribution.distributionId });
+    new CfnOutput(this, 'DistributionId', { value: distribution.distributionId });
 
     // Route53 alias record for the CloudFront distribution
     new route53.ARecord(this, 'SiteAliasRecord', {

--- a/typescript/stepfunctions-job-poller/index.ts
+++ b/typescript/stepfunctions-job-poller/index.ts
@@ -1,9 +1,9 @@
-import * as cdk from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda';
-import * as sfn from '@aws-cdk/aws-stepfunctions';
-import * as tasks from '@aws-cdk/aws-stepfunctions-tasks';
-import * as events from '@aws-cdk/aws-events';
-import * as targets from '@aws-cdk/aws-events-targets';
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
+import * as tasks from 'aws-cdk-lib/aws-stepfunctions-tasks';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
 import * as fs from 'fs'
 
 class JobPollerStack extends cdk.Stack {

--- a/typescript/stepfunctions-job-poller/package.json
+++ b/typescript/stepfunctions-job-poller/package.json
@@ -17,14 +17,10 @@
   "devDependencies": {
     "@types/node": "*",
     "aws-cdk": "*",
-    "typescript": "^3.8"
+    "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-events": "*",
-    "@aws-cdk/aws-events-targets": "*",
-    "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/aws-stepfunctions": "*",
-    "@aws-cdk/aws-stepfunctions-tasks": "*",
-    "@aws-cdk/core": "*"
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/waf/app.ts
+++ b/typescript/waf/app.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import 'source-map-support/register';
-import * as cdk from '@aws-cdk/core';
+import * as cdk from 'aws-cdk-lib';
 
 import { WafRegionalStack }   from './waf-regional';
 import { WafCloudFrontStack } from './waf-cloudfront';

--- a/typescript/waf/cdk.json
+++ b/typescript/waf/cdk.json
@@ -1,10 +1,3 @@
 {
-  "app": "npx ts-node --prefer-ts-exts app.ts",
-  "context": {
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true
-  }
+  "app": "npx ts-node --prefer-ts-exts app.ts"
 }

--- a/typescript/waf/package.json
+++ b/typescript/waf/package.json
@@ -17,12 +17,11 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
+    "aws-cdk-lib": "^2.0.0-rc.33",
+    "constructs": "^10.0.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
-    "@aws-cdk/assert": "*",
-    "@aws-cdk/aws-wafv2": "*",
-    "@aws-cdk/core": "*",
     "source-map-support": "^0.5.16"
   }
 }

--- a/typescript/waf/waf-cloudfront.ts
+++ b/typescript/waf/waf-cloudfront.ts
@@ -1,6 +1,7 @@
 
-import * as cdk from '@aws-cdk/core';
-import * as wafv2 from '@aws-cdk/aws-wafv2';
+import * as cdk from 'aws-cdk-lib';
+import * as wafv2 from 'aws-cdk-lib/aws-wafv2';
+import { Construct } from 'constructs';
 
 type listOfRules = {
   name: string;
@@ -118,7 +119,7 @@ export class WafCloudFrontStack extends cdk.Stack {
   } // function makeRules
 
 
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     /**

--- a/typescript/waf/waf-regional.ts
+++ b/typescript/waf/waf-regional.ts
@@ -1,6 +1,7 @@
 
-import * as cdk from '@aws-cdk/core';
-import * as wafv2 from '@aws-cdk/aws-wafv2';
+import * as cdk from 'aws-cdk-lib';
+import * as wafv2 from 'aws-cdk-lib/aws-wafv2';
+import { Construct } from 'constructs';
 
 type listOfRules = {
   name: string;
@@ -114,7 +115,7 @@ export class WafRegionalStack extends cdk.Stack {
   } // function makeRules
 
 
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     /**


### PR DESCRIPTION
This PR upgrades all of the Typescript examples to use the latest
release-candidate version of the CDKv2. The other examples (e.g., C#, Python)
were already upgraded in #573.

_Implementation note:_
* `package.json` changes were all done by bulk script.
* All imports were rewritten via `npx aws-cdk-migration rewrite-imports **/*.ts`, plus manually adjusting for constructs.
* All deprecated CDK APIs have been updated to the newer, non-deprecated versions.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
