### PR TITLE
fix: wrong expected template for java esc example

### DIFF
--- a/java/ecs/fargate-load-balanced-service/src/test/resources/com/amazonaws/cdk/examples/expected.cfn.json
+++ b/java/ecs/fargate-load-balanced-service/src/test/resources/com/amazonaws/cdk/examples/expected.cfn.json
@@ -567,7 +567,6 @@
                     "MaximumPercent": 200,
                     "MinimumHealthyPercent": 50
                 },
-                "DesiredCount": 1,
                 "EnableECSManagedTags": false,
                 "HealthCheckGracePeriodSeconds": 60,
                 "LaunchType": "FARGATE",


### PR DESCRIPTION
`com.amazonaws.cdk.examples.ECSFargateLoadBalancedStackTest` is currently broken because the expected template is stale. 

This [PR](https://github.com/aws/aws-cdk/pull/17865) in the CDK, along with the migration of the examples to v2, made it so the `DesiredCount` property is now not part of the template. This is the expected behavior. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
