### PR TITLE
fix: updated lambda runtime to python3_9

### DIFF
--- a/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
+++ b/java/lambda-cron/src/main/java/software/amazon/awscdk/examples/LambdaCronStack.java
@@ -22,7 +22,7 @@ class LambdaCronStack extends Stack {
             .code(Code.fromInline("def main(event, context):\n" + "    print(\"I'm running!\")\n"))
             .handler("index.main")
             .timeout(Duration.seconds(300))
-            .runtime(Runtime.PYTHON_2_7)
+            .runtime(Runtime.PYTHON_3_9)
             .uuid(UUID.randomUUID().toString())
             .build();
 

--- a/java/lambda-cron/src/test/resources/software/amazon/awscdk/examples/testCronLambdaExpected.json
+++ b/java/lambda-cron/src/test/resources/software/amazon/awscdk/examples/testCronLambdaExpected.json
@@ -53,7 +53,7 @@
         "Role" : {
           "Fn::GetAtt" : [ "SingletonLambda0dc9f04c622c4059b399834a2c1ac15fServiceRoleD59355BD", "Arn" ]
         },
-        "Runtime" : "python2.7",
+        "Runtime" : "python3.9",
         "Description" : "Lambda which prints \"I'm running\"",
         "Timeout" : 300,
         "Handler" : "index.main",


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->
`cdk deploy` of the example fails due to `python2.7` no longer being supported. Updated lambda runtime to latest `python 3.9`

Fixes # [616](https://github.com/aws-samples/aws-cdk-examples/issues/616)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
