### PR TITLE
feat: add ec2 keypair support to typescript ec2-instance example

### DIFF
--- a/typescript/ec2-instance/.gitignore
+++ b/typescript/ec2-instance/.gitignore
@@ -1,0 +1,1 @@
+cdk-key.pem

--- a/typescript/ec2-instance/README.md
+++ b/typescript/ec2-instance/README.md
@@ -17,13 +17,14 @@ Ensure aws-cdk is installed and [bootstrapped](https://docs.aws.amazon.com/cdk/l
 
 ```bash
 $ npm install -g aws-cdk
+$ npm install
+$ npm run build
 $ cdk bootstrap
 ```
 
-Then build and deploy.
+Then deploy the stack.
 
 ```bash
-$ npm run build
 $ cdk deploy
 ```
 

--- a/typescript/ec2-instance/package.json
+++ b/typescript/ec2-instance/package.json
@@ -17,6 +17,8 @@
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.16",
+    "cdk-iam-floyd": "^0.300.0",
+    "cdk-ec2-key-pair": "^3.2.0"
   }
 }


### PR DESCRIPTION
- Until now ec2-instance example did not include support for ec2 keypair. Thus, no way to login to newly provisioned ec2 with this example. This is now added by utilising cdk-ec2-key-pair v2 library
- Improved Readme with regard to install and build

Fixes # N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
