### PR TITLE
fix(python/ecs-service-with-advanced-alb-config): Modified instance type in asg to t3.micro and changed stack name to meet capacity provider naming convention

### DIFF
--- a/python/ecs/ecs-service-with-advanced-alb-config/app.py
+++ b/python/ecs/ecs-service-with-advanced-alb-config/app.py
@@ -29,7 +29,7 @@ asg = autoscaling.AutoScalingGroup(
     vpc=vpc,
 )
 capacity_provider = ecs.AsgCapacityProvider(stack, "AsgCapacityProvider",
-    auto_scaling_group=asg,
+    auto_scaling_group=asg
 )
 cluster.add_asg_capacity_provider(capacity_provider)
 

--- a/python/ecs/ecs-service-with-advanced-alb-config/app.py
+++ b/python/ecs/ecs-service-with-advanced-alb-config/app.py
@@ -7,7 +7,7 @@ from aws_cdk import (
 )
 
 app = App()
-stack = Stack(app, "aws-ec2-integ-ecs")
+stack = Stack(app, "sample-aws-ec2-integ-ecs")
 
 # Create a cluster
 vpc = ec2.Vpc(
@@ -30,7 +30,6 @@ asg = autoscaling.AutoScalingGroup(
 )
 capacity_provider = ecs.AsgCapacityProvider(stack, "AsgCapacityProvider",
     auto_scaling_group=asg,
-    capacity_provider_name='AsgCapacityProvider'
 )
 cluster.add_asg_capacity_provider(capacity_provider)
 

--- a/python/ecs/ecs-service-with-advanced-alb-config/app.py
+++ b/python/ecs/ecs-service-with-advanced-alb-config/app.py
@@ -1,4 +1,3 @@
-from os import name
 from aws_cdk import (
     aws_autoscaling as autoscaling,
     aws_ec2 as ec2,

--- a/python/ecs/ecs-service-with-advanced-alb-config/app.py
+++ b/python/ecs/ecs-service-with-advanced-alb-config/app.py
@@ -1,3 +1,4 @@
+from os import name
 from aws_cdk import (
     aws_autoscaling as autoscaling,
     aws_ec2 as ec2,
@@ -23,13 +24,14 @@ cluster = ecs.Cluster(
 asg = autoscaling.AutoScalingGroup(
     stack, "DefaultAutoScalingGroup",
     instance_type=ec2.InstanceType.of(
-                         ec2.InstanceClass.STANDARD5,
+                         ec2.InstanceClass.BURSTABLE3,
                          ec2.InstanceSize.MICRO),
     machine_image=ecs.EcsOptimizedImage.amazon_linux2(),
     vpc=vpc,
 )
 capacity_provider = ecs.AsgCapacityProvider(stack, "AsgCapacityProvider",
-    auto_scaling_group=asg
+    auto_scaling_group=asg,
+    capacity_provider_name='AsgCapacityProvider'
 )
 cluster.add_asg_capacity_provider(capacity_provider)
 

--- a/typescript/api-cors-lambda-crud-dynamodb/cdk.json
+++ b/typescript/api-cors-lambda-crud-dynamodb/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "index.js"
+  "app": "node index"
 }


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->
This PR addresses issues that were discovered in #626 by changing the instance type of the ASG to t3.micro (previously m5.micro which doesn't exist) and renaming the capacity provider to a fixed name to meet the naming convention -- the previous name was the autogenerated concatenation of the stack name and construct id... since the stack name is 'aws-ec2-integ-ecs' the interpolated capacity provider name would begin with 'aws' and not comply with the naming requirements.

Fixes #626 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
