### PR TITLE
fix: Addressed issue where distribution ViewerCertificate attributes were being placed in wrong place in Distribution hierarchy

### DIFF
--- a/typescript/static-site/index.ts
+++ b/typescript/static-site/index.ts
@@ -10,7 +10,7 @@ import { StaticSite } from './static-site';
  *   "context": {
  *     "domain": "mystaticsite.com",
  *     "subdomain": "www",
- *     "accountId": 1234567890,
+ *     "accountId": "1234567890",
  *   }
  * }
 **/

--- a/typescript/static-site/static-site.ts
+++ b/typescript/static-site/static-site.ts
@@ -6,7 +6,7 @@ import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as s3deploy from 'aws-cdk-lib/aws-s3-deployment';
 import * as targets from 'aws-cdk-lib/aws-route53-targets';
 import * as cloudfront_origins from 'aws-cdk-lib/aws-cloudfront-origins';
-import { CfnOutput, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import { CfnOutput, Duration, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 
@@ -36,8 +36,6 @@ export class StaticSite extends Construct {
     // Content bucket
     const siteBucket = new s3.Bucket(this, 'SiteBucket', {
       bucketName: siteDomain,
-      // websiteIndexDocument: 'index.html',
-      // websiteErrorDocument: 'error.html',
       publicReadAccess: false,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
 
@@ -78,6 +76,14 @@ export class StaticSite extends Construct {
       defaultRootObject: "index.html",
       domainNames: [siteDomain],
       minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
+      errorResponses:[
+        {
+          httpStatus: 403,
+          responseHttpStatus: 403,
+          responsePagePath: '/error.html',
+          ttl: Duration.minutes(30),
+        }
+      ],
       defaultBehavior: {
         origin: new cloudfront_origins.S3Origin(siteBucket, {originAccessIdentity: cloudfrontOAI}),
         compress: true,
@@ -85,8 +91,6 @@ export class StaticSite extends Construct {
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
       }
     })
-
-    
 
     new CfnOutput(this, 'DistributionId', { value: distribution.distributionId });
 

--- a/typescript/static-site/static-site.ts
+++ b/typescript/static-site/static-site.ts
@@ -86,12 +86,7 @@ export class StaticSite extends Construct {
       }
     })
 
-    // This is a workaround for https://github.com/aws/aws-cdk/issues/19539
-    // const cfnDistribution = distribution.node.defaultChild as cloudfront.CfnDistribution
-    // cfnDistribution.addDeletionOverride('DistributionConfig.Origins.0.CustomOriginConfig')
-    // cfnDistribution.addPropertyOverride('DistributionConfig.Origins.0.DomainName', siteDomain+".s3.us-east-1.amazonaws.com")
-    // cfnDistribution.addPropertyOverride('DistributionConfig.Origins.0.S3OriginConfig.OriginAccessIdentity', cloudfrontOAI.cloudFrontOriginAccessIdentityS3CanonicalUserId)
-
+    
 
     new CfnOutput(this, 'DistributionId', { value: distribution.distributionId });
 

--- a/typescript/static-site/static-site.ts
+++ b/typescript/static-site/static-site.ts
@@ -36,8 +36,8 @@ export class StaticSite extends Construct {
     // Content bucket
     const siteBucket = new s3.Bucket(this, 'SiteBucket', {
       bucketName: siteDomain,
-      websiteIndexDocument: 'index.html',
-      websiteErrorDocument: 'error.html',
+      // websiteIndexDocument: 'index.html',
+      // websiteErrorDocument: 'error.html',
       publicReadAccess: false,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
 
@@ -86,7 +86,12 @@ export class StaticSite extends Construct {
       }
     })
 
-    
+    // This is a workaround for https://github.com/aws/aws-cdk/issues/19539
+    // const cfnDistribution = distribution.node.defaultChild as cloudfront.CfnDistribution
+    // cfnDistribution.addDeletionOverride('DistributionConfig.Origins.0.CustomOriginConfig')
+    // cfnDistribution.addPropertyOverride('DistributionConfig.Origins.0.DomainName', siteDomain+".s3.us-east-1.amazonaws.com")
+    // cfnDistribution.addPropertyOverride('DistributionConfig.Origins.0.S3OriginConfig.OriginAccessIdentity', cloudfrontOAI.cloudFrontOriginAccessIdentityS3CanonicalUserId)
+
 
     new CfnOutput(this, 'DistributionId', { value: distribution.distributionId });
 

--- a/typescript/static-site/static-site.ts
+++ b/typescript/static-site/static-site.ts
@@ -82,8 +82,8 @@ export class StaticSite extends Construct {
     })
 
     const cfnDistribution = distribution.node.defaultChild as cloudfront.CfnDistribution
-    cfnDistribution.addPropertyOverride('MinimumProtocolVersion', 'TLS_V1_1_2016')
-    cfnDistribution.addPropertyOverride('ViewerCertificate.SslSupportMethod', 'sni-only')
+    cfnDistribution.addPropertyOverride('DistributionConfig.ViewerCertificate.MinimumProtocolVersion', 'TLSv1.1_2016')
+    cfnDistribution.addPropertyOverride('DistributionConfig.ViewerCertificate.SslSupportMethod', 'sni-only')
 
     new CfnOutput(this, 'DistributionId', { value: distribution.distributionId });
 


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->
*Requesting @peterwoodworth review this please*

This PR addresses an issue that was introduced in PR #625... the issue is related to the placement of the ViewerCertificate attributes in a Distribution resource.  From below we see the original synthesized CFN
```
"StaticSiteSiteDistributionE3AF6299": {
      "Type": "AWS::CloudFront::Distribution",
      "Properties": {
        "DistributionConfig": {
          "Aliases": [
            ...
          ],
          "DefaultCacheBehavior": {
            ...
          "Origins": [
            ...
          ],
          "ViewerCertificate": {
            "AcmCertificateArn": {
              "Fn::GetAtt": [
                "StaticSiteSiteCertificateCertificateRequestorResourceB92D481B",
                "Arn"
              ]
            },
            "MinimumProtocolVersion": "TLSv1.2_2021",
            "SslSupportMethod": "sni-only"
          }
        },
        "ViewerCertificate": {
          "MinimumProtocolVersion": "TLS_V1_1_2016",
          "SslSupportMethod": "sni-only"
        }
      },
    },
```
From the above, which was generated from the code in my previous commit, the MinimumProtocolVersion and SslSupportMethod attributes were being placed in the high-level Distribution resource when it should be placed within the DistributionConfig property of the resource.

Going into static-site.ts, from the code block where we use addPropertyOverride, I did this:

cfnDistribution.addPropertyOverride('MinimumProtocolVersion', 'TLS_V1_1_2016') cfnDistribution.addPropertyOverride('ViewerCertificate.SslSupportMethod', 'sni-only')

when it should have been this:

cfnDistribution.addPropertyOverride('DistributionConfig.ViewerCertificate.MinimumProtocolVersion', 'TLSv1.1_2016') cfnDistribution.addPropertyOverride('DistributionConfig.ViewerCertificate.SslSupportMethod', 'sni-only')

I bought a $3 domain in R53 and validated deployment in my own AWS account.

Fixes #609


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
