### PR TITLE
ci(mergify): removed semantic checks

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,7 +17,6 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - -approved-reviews-by~=author
       - "#changes-requested-reviews-by=0"
-      - status-success=Semantic Pull Request
       - status-success=build
 
   - name: remove stale reviews
@@ -25,9 +24,3 @@ pull_request_rules:
       dismiss_reviews: {}
     conditions:
       - base=master
-  - name: if fails conventional commits
-    actions:
-      comment:
-        message: Title does not follow the guidelines of [Conventional Commits](https://www.conventionalcommits.org). Please adjust title before merge.
-    conditions:
-      - -status-success=Semantic Pull Request


### PR DESCRIPTION
## Summary

This PR removes semantic checks from the Mergify config. Semantic Pull Request's service is currently down and we need to unblock PRs.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
