### PR TITLE
chore: force the version in an example to be V1

### DIFF
--- a/typescript/s3-object-lambda/package.json
+++ b/typescript/s3-object-lambda/package.json
@@ -11,18 +11,18 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "*",
+    "@aws-cdk/assert": "^1.154.0",
     "@types/node": "10.17.27",
-    "aws-cdk": "*",
+    "aws-cdk": "^1.154.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/aws-iam": "*",
-    "@aws-cdk/aws-lambda": "*",
-    "@aws-cdk/aws-s3": "*",
-    "@aws-cdk/aws-s3objectlambda": "*",
-    "@aws-cdk/core": "*",
+    "@aws-cdk/aws-iam": "^1.154.0",
+    "@aws-cdk/aws-lambda": "^1.154.0",
+    "@aws-cdk/aws-s3": "^1.154.0",
+    "@aws-cdk/aws-s3objectlambda": "^1.154.0",
+    "@aws-cdk/core": "^1.154.0",
     "aws-sdk": "^2.1004.0",
     "source-map-support": "^0.5.16"
   }


### PR DESCRIPTION
Currently, the pipeline that builds these packages is failing because the `s3-object-lambda` example assumes that there is only one version of the CDK; this forces it to use v1. This example should be migrated to v2 in the future. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
