### PR TITLE
feat(typescript): add reusable construct to manage backup plans

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -52,3 +52,4 @@ $ cdk destroy
 | [custom-logical-names](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/custom-logical-names/) | Example of how to override logical name allocation |
 | [fargate-service-with-efs](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ecs/fargate-service-with-efs/) | Starting a container fronted by an application load balancer on Fargate with an EFS Mount |
 | [http-proxy-apigateway](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/http-proxy-apigateway/) | Use ApiGateway to set up a http proxy |
+| [backup-plan](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/backup-plan/) | Reusable CDK Construct to create and associate a Backup Plan |

--- a/typescript/backup-plan/.npmignore
+++ b/typescript/backup-plan/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/typescript/backup-plan/README.md
+++ b/typescript/backup-plan/README.md
@@ -1,0 +1,212 @@
+# BackupPlan Construct
+
+<!--BEGIN STABILITY BANNER-->
+---
+
+![Stability: Stable](https://img.shields.io/badge/stability-Stable-success.svg?style=for-the-badge)
+
+> **This is a stable example. It should successfully build out of the box**
+>
+> This example uses the core CDK library, and does not have any infrastructure prerequisites to build.
+---
+<!--END STABILITY BANNER-->
+
+## Overview
+
+This construct creates a [Backup Plan](https://docs.aws.amazon.com/aws-backup/latest/devguide/about-backup-plans.html) using [AWS Backups](https://docs.aws.amazon.com/aws-backup/latest/devguide/whatisbackup.html). Construct allows to indicate how frequently and what resources to backup.
+
+---
+
+## API
+
+#### Initializers <a name="Initializers" id="backup-plan.Backup.Initializer"></a>
+
+```typescript
+import { Backup } from 'backup-plan'
+
+new Backup(scope: Construct, id: string, props: BackupProps)
+```
+
+| **Name**                                                                                                     | **Type**                                                                                    | **Description**   |
+| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- | ----------------- |
+| <code><a href="#backup-plan.Backup.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code>                                                           | *No description.* |
+| <code><a href="#backup-plan.Backup.Initializer.parameter.id">id</a></code>       | <code>string</code>                                                                         | *No description.* |
+| <code><a href="#backup-plan.Backup.Initializer.parameter.props">props</a></code> | <code><a href="#backup-plan.BackupProps">BackupProps</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="backup-plan.Backup.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="backup-plan.Backup.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="backup-plan.Backup.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#backup-plan.BackupProps">BackupProps</a>
+
+---
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name**                                                                                                  | **Type**                                       | **Description** |
+| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | --------------- |
+| <code><a href="#backup-plan.Backup.property.backupPlan">backupPlan</a></code> | <code>aws-cdk-lib.aws_backup.BackupPlan</code> | Backup plan.    |
+
+---
+
+##### `backupPlan`<sup>Required</sup> <a name="backupPlan" id="backup-plan.Backup.property.backupPlan"></a>
+
+```typescript
+public readonly backupPlan: BackupPlan;
+```
+
+- *Type:* aws-cdk-lib.aws_backup.BackupPlan
+
+---
+
+### BackupProps <a name="BackupProps" id="backup-plan.BackupProps"></a>
+
+#### Initializer <a name="Initializer" id="backup-plan.BackupProps.Initializer"></a>
+
+```typescript
+import { BackupProps } from 'backup-plan'
+
+const backupProps: BackupProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#backup-plan.BackupProps.property.backupPlanName">backupPlanName</a></code> | <code>string</code> | The display name of the backup plan. |
+| <code><a href="#backup-plan.BackupProps.property.resources">resources</a></code> | <code>aws-cdk-lib.aws_backup.BackupResource[]</code> | Resources to apply backup plan. |
+| <code><a href="#backup-plan.BackupProps.property.backupCompletionWindow">backupCompletionWindow</a></code> | <code>aws-cdk-lib.Duration</code> | The duration after a backup job is successfully started before it must be completed or it is canceled by AWS Backup. |
+| <code><a href="#backup-plan.BackupProps.property.backupRateHour">backupRateHour</a></code> | <code>number</code> | How frequently backup jobs would be started. |
+| <code><a href="#backup-plan.BackupProps.property.backupStartWindow">backupStartWindow</a></code> | <code>aws-cdk-lib.Duration</code> | The duration after a backup is scheduled before a job is canceled if it doesn't start successfully. |
+| <code><a href="#backup-plan.BackupProps.property.deleteBackupAfter">deleteBackupAfter</a></code> | <code>aws-cdk-lib.Duration</code> | Specifies the duration after creation that a recovery point is deleted. |
+| <code><a href="#backup-plan.BackupProps.property.moveBackupToColdStorageAfter">moveBackupToColdStorageAfter</a></code> | <code>aws-cdk-lib.Duration</code> | Specifies the duration after creation that a recovery point is moved to cold storage. |
+
+---
+
+##### `backupPlanName`<sup>Required</sup> <a name="backupPlanName" id="backup-plan.BackupProps.property.backupPlanName"></a>
+
+```typescript
+public readonly backupPlanName: string;
+```
+
+- *Type:* string
+
+The display name of the backup plan.
+
+---
+
+##### `resources`<sup>Required</sup> <a name="resources" id="backup-plan.BackupProps.property.resources"></a>
+
+```typescript
+public readonly resources: BackupResource[];
+```
+
+- *Type:* aws-cdk-lib.aws_backup.BackupResource[]
+
+Resources to apply backup plan.
+
+---
+
+##### `backupCompletionWindow`<sup>Optional</sup> <a name="backupCompletionWindow" id="backup-plan.BackupProps.property.backupCompletionWindow"></a>
+
+```typescript
+public readonly backupCompletionWindow: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* 3 hours
+
+The duration after a backup job is successfully started before it must be completed or it is canceled by AWS Backup.
+
+Note: `backupCompletionWindow` must be at least 60 minutes greater than @backupStartWindows
+
+---
+
+##### `backupRateHour`<sup>Optional</sup> <a name="backupRateHour" id="backup-plan.BackupProps.property.backupRateHour"></a>
+
+```typescript
+public readonly backupRateHour: number;
+```
+
+- *Type:* number
+- *Default:* 24 hours
+
+How frequently backup jobs would be started.
+
+---
+
+##### `backupStartWindow`<sup>Optional</sup> <a name="backupStartWindow" id="backup-plan.BackupProps.property.backupStartWindow"></a>
+
+```typescript
+public readonly backupStartWindow: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* 1 hour less than
+
+The duration after a backup is scheduled before a job is canceled if it doesn't start successfully.
+
+---
+
+##### `deleteBackupAfter`<sup>Optional</sup> <a name="deleteBackupAfter" id="backup-plan.BackupProps.property.deleteBackupAfter"></a>
+
+```typescript
+public readonly deleteBackupAfter: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* 30 days
+
+Specifies the duration after creation that a recovery point is deleted.
+
+Must be greater than moveToColdStorageAfter.
+
+---
+
+##### `moveBackupToColdStorageAfter`<sup>Optional</sup> <a name="moveBackupToColdStorageAfter" id="backup-plan.BackupProps.property.moveBackupToColdStorageAfter"></a>
+
+```typescript
+public readonly moveBackupToColdStorageAfter: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* recovery point is never moved to cold storage
+
+Specifies the duration after creation that a recovery point is moved to cold storage.
+
+---
+
+## Usage
+
+```typescript
+const vpc = new ec2.Vpc(testStack, 'TestVPC');
+const engine = rds.DatabaseInstanceEngine.postgres({ version: rds.PostgresEngineVersion.VER_12_3 });
+// create rds DB
+const db = new rds.DatabaseInstance(testStack, 'TestInstance', {
+    engine,
+    vpc,
+    credentials: rds.Credentials.fromGeneratedSecret('postgres'),
+});
+// create a backup plan for `db`
+new Backup(stack, 'TestBk', {
+    backupPlanName: 'TestPkPlan',
+    backupRateHour: 3,  // backup every 3 hours
+    backupCompletionWindow: cdk.Duration.hours(2), // backup should take up to 2 hours
+    resources: [bk.BackupResource.fromRdsDatabaseInstance(db)],
+});
+```
+
+NOTE: [Tagging](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_backup.BackupResource.html#static-fromwbrtagkey-value-operation) and/or [ARN](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_backup.BackupResource.html#static-fromwbrarnarn) can be used to reference resources not directly available in the [static methods section](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_backup.BackupResource.html#methods). 

--- a/typescript/backup-plan/lib/index.ts
+++ b/typescript/backup-plan/lib/index.ts
@@ -1,0 +1,120 @@
+import {
+  Duration,
+  CfnOutput,
+  aws_backup as bk,
+  aws_events as events,
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+export interface BackupProps {
+  /**
+   * Resources to apply backup plan.
+   */
+  readonly resources: bk.BackupResource[];
+
+  /**
+   * The display name of the backup plan.
+   */
+  readonly backupPlanName: string;
+
+  /**
+   * The duration after a backup job is successfully
+   * started before it must be completed or it is
+   * canceled by AWS Backup.
+   *
+   * Note: `backupCompletionWindow` must be at least 60 minutes greater
+   * than @backupStartWindows
+   *
+   * @default - 3 hours
+   */
+  readonly backupCompletionWindow?: Duration;
+
+  /**
+   * The duration after a backup is scheduled before
+   * a job is canceled if it doesn't start successfully.
+   *
+   * @default - 1 hour less than @backupCompletionWindow
+   */
+  readonly backupStartWindow?: Duration;
+
+  /**
+   * Specifies the duration after creation that a recovery point is deleted.
+   * Must be greater than moveToColdStorageAfter.
+   *
+   * @default - 30 days
+   */
+  readonly deleteBackupAfter?: Duration;
+
+  /**
+   * Specifies the duration after creation that a recovery point is moved to cold storage.
+   *
+   * @default - recovery point is never moved to cold storage
+   */
+  readonly moveBackupToColdStorageAfter?: Duration;
+
+  /**
+   * How frequently backup jobs would be started.
+   *
+   * @default - 24 hours
+   */
+  readonly backupRateHour?: number;
+}
+
+/**
+ * Construct to create a Backup Plan with specific backing cadence.
+ *
+ * @stability stable
+ */
+export class Backup extends Construct {
+  /**
+   * Backup plan
+   */
+  public readonly backupPlan: bk.BackupPlan;
+  /**
+   * 
+   * @param scope Construct's scope
+   * @param id Construct's id
+   * @param props Construct's props
+   */
+  constructor(scope: Construct, id: string, props: BackupProps) {
+    super(scope, id);
+
+    const hourlyRate = `0/${props.backupRateHour || 24}`;
+
+    const completionWindow = props.backupCompletionWindow || Duration.hours(3);
+    const startWindow = props.backupStartWindow || Duration.hours(completionWindow.toHours() - 1);
+
+    if ((completionWindow.toHours() - startWindow.toHours()) < 1)
+      throw Error('Backup completion window must be at least 60 minutes greater than backup start window');
+
+    const scheduledBkRule = new bk.BackupPlanRule({
+      completionWindow,
+      startWindow,
+      deleteAfter: props.deleteBackupAfter || Duration.days(30),
+      // Only cron expressions are supported
+      scheduleExpression: events.Schedule.cron({
+        minute: '0',
+        hour: hourlyRate,
+      }),
+      moveToColdStorageAfter: props.moveBackupToColdStorageAfter,
+    });
+
+    this.backupPlan = new bk.BackupPlan(this, 'BackupPlan', {
+      backupPlanName: props.backupPlanName,
+      backupPlanRules: [scheduledBkRule],
+    });
+
+    this.backupPlan.addSelection('BackupSelection', {
+      resources: props.resources,
+    });
+
+    // Outputs
+    const outputVars = {
+      BackupPlanId: this.backupPlan.backupPlanId,
+      BackupPlanArn: this.backupPlan.backupPlanArn,
+    };
+    Object.entries(outputVars).forEach(
+      ([outName, outValue]) => new CfnOutput(this, outName, { value: outValue }),
+    );
+  }
+}

--- a/typescript/backup-plan/package.json
+++ b/typescript/backup-plan/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "backup-plan",
+  "version": "0.1.0",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "eslint": "npx eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern lib test"
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.10",
+    "@types/node": "10.17.27",
+    "@typescript-eslint/eslint-plugin": "^5.22.0",
+    "@typescript-eslint/parser": "^5.22.0",
+    "aws-cdk-lib": "2.17.0",
+    "constructs": "^10.0.0",
+    "eslint": "^8.14.0",
+    "jest": "^26.4.2",
+    "ts-jest": "^26.2.0",
+    "typescript": "~3.9.7"
+  },
+  "peerDependencies": {
+    "aws-cdk-lib": "2.17.0",
+    "constructs": "^10.0.0"
+  }
+}

--- a/typescript/backup-plan/test/backup-plan.test.ts
+++ b/typescript/backup-plan/test/backup-plan.test.ts
@@ -1,0 +1,100 @@
+import * as cdk from 'aws-cdk-lib';
+import { aws_rds as rds, aws_ec2 as ec2, aws_backup as bk } from 'aws-cdk-lib';
+import {
+  Match,
+  Template,
+} from 'aws-cdk-lib/assertions';
+import { Backup } from '../lib/index';
+
+let testTemplate: Template;
+
+
+const createRequiredResources = () => {
+  const app = new cdk.App();
+  const testStack = new cdk.Stack(app, 'testStack', {
+    env: { account: '111122223333', region: 'us-east-1' },
+  });
+  const vpc = new ec2.Vpc(testStack, 'TestVPC');
+  const engine = rds.DatabaseInstanceEngine.postgres({ version: rds.PostgresEngineVersion.VER_12_3 });
+  const db = new rds.DatabaseInstance(testStack, 'TestInstance', {
+    engine,
+    vpc,
+    credentials: rds.Credentials.fromGeneratedSecret('postgres'), // Creates an admin user of postgres with a generated password
+  });
+  return { db, stack: testStack };
+};
+
+beforeAll(() => {
+  const { stack, db } = createRequiredResources();
+  new Backup(stack, 'TestBk', {
+    backupPlanName: 'TestPkPlan',
+    backupRateHour: 2,
+    backupCompletionWindow: cdk.Duration.hours(2),
+    resources: [bk.BackupResource.fromRdsDatabaseInstance(db)],
+  });
+
+  testTemplate = Template.fromStack(stack);
+});
+
+test('backup plan is created', () => {
+  testTemplate.hasResourceProperties('AWS::Backup::BackupPlan', {
+    BackupPlan: {
+      BackupPlanName: 'TestPkPlan',
+      BackupPlanRule: [
+        {
+          CompletionWindowMinutes: 120,
+          Lifecycle: {
+            DeleteAfterDays: 30,
+          },
+          RuleName: 'BackupPlanRule0',
+          ScheduleExpression: 'cron(0 0/2 * * ? *)',
+          StartWindowMinutes: 60,
+          TargetBackupVault: Match.anyValue(),
+        },
+      ],
+    },
+  });
+});
+
+test('backup vault is created', () => {
+  testTemplate.resourceCountIs('AWS::Backup::BackupVault', 1);
+});
+
+test('validate default args', () => {
+  const { stack, db } = createRequiredResources();
+  new Backup(stack, 'TestBk', {
+    backupPlanName: 'TestPkPlan2',
+    resources: [bk.BackupResource.fromRdsDatabaseInstance(db)],
+  });
+  const template = Template.fromStack(stack);
+  template.hasResourceProperties('AWS::Backup::BackupPlan', {
+    BackupPlan: {
+      BackupPlanName: 'TestPkPlan2',
+      BackupPlanRule: [
+        {
+          CompletionWindowMinutes: 180,
+          Lifecycle: {
+            DeleteAfterDays: 30,
+          },
+          RuleName: 'BackupPlanRule0',
+          ScheduleExpression: 'cron(0 0/24 * * ? *)',
+          StartWindowMinutes: 120,
+          TargetBackupVault: Match.anyValue(),
+        },
+      ],
+    },
+  });
+});
+
+test('validate start window must be at least 60 min less than completion window', () => {
+  const { stack, db } = createRequiredResources();
+  expect(() => (
+    new Backup(stack, 'TestBk', {
+      backupPlanName: 'TestPkPlan2',
+      resources: [bk.BackupResource.fromRdsDatabaseInstance(db)],
+      backupCompletionWindow: cdk.Duration.hours(1),
+      backupStartWindow: cdk.Duration.hours(2),
+    })
+  )).toThrow('Backup completion window must be at least 60 minutes greater than backup start window');
+});
+

--- a/typescript/backup-plan/tsconfig.json
+++ b/typescript/backup-plan/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "commonjs",
+    "lib": [
+      "es2018"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}


### PR DESCRIPTION

Fixes #668

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
