### PR TITLE
chore(deps): update typescript to 4.6.0

### DIFF
--- a/typescript/amplify-console-app/package.json
+++ b/typescript/amplify-console-app/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/api-cors-lambda-crud-dynamodb/package.json
+++ b/typescript/api-cors-lambda-crud-dynamodb/package.json
@@ -18,7 +18,7 @@
     "@types/node": "*",
     "aws-cdk": "*",
     "esbuild": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/api-websocket-lambda-dynamodb/package.json
+++ b/typescript/api-websocket-lambda-dynamodb/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/application-load-balancer/package.json
+++ b/typescript/application-load-balancer/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/appsync-graphql-dynamodb/package.json
+++ b/typescript/appsync-graphql-dynamodb/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/appsync-graphql-eventbridge/package.json
+++ b/typescript/appsync-graphql-eventbridge/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.9.7",
+    "typescript": "~4.6.0",
     "ts-node": "^8.1.0"
   },
   "dependencies": {

--- a/typescript/classic-load-balancer/package.json
+++ b/typescript/classic-load-balancer/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/cognito-api-lambda/package.json
+++ b/typescript/cognito-api-lambda/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/custom-logical-names/package.json
+++ b/typescript/custom-logical-names/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "aws-cdk": "*",
     "ts-node": "^8.1.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/custom-resource-provider/package.json
+++ b/typescript/custom-resource-provider/package.json
@@ -18,7 +18,7 @@
     "ts-jest": "^26.2.0",
     "aws-cdk": "*",
     "ts-node": "^9.0.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/custom-resource/package.json
+++ b/typescript/custom-resource/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ec2-instance/package.json
+++ b/typescript/ec2-instance/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@types/node": "10.17.27",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/cluster/package.json
+++ b/typescript/ecs/cluster/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/cross-stack-load-balancer/package.json
+++ b/typescript/ecs/cross-stack-load-balancer/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/ecs-network-load-balanced-service/package.json
+++ b/typescript/ecs/ecs-network-load-balanced-service/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/ecs-service-with-advanced-alb-config/package.json
+++ b/typescript/ecs/ecs-service-with-advanced-alb-config/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/ecs-service-with-logging/package.json
+++ b/typescript/ecs/ecs-service-with-logging/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/ecs-service-with-task-networking/package.json
+++ b/typescript/ecs/ecs-service-with-task-networking/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/ecs-service-with-task-placement/package.json
+++ b/typescript/ecs/ecs-service-with-task-placement/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/fargate-application-load-balanced-service/package.json
+++ b/typescript/ecs/fargate-application-load-balanced-service/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/fargate-service-with-auto-scaling/package.json
+++ b/typescript/ecs/fargate-service-with-auto-scaling/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/fargate-service-with-efs/package.json
+++ b/typescript/ecs/fargate-service-with-efs/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/fargate-service-with-local-image/package.json
+++ b/typescript/ecs/fargate-service-with-local-image/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/fargate-service-with-logging/package.json
+++ b/typescript/ecs/fargate-service-with-logging/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/eks/cluster/package.json
+++ b/typescript/eks/cluster/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/package.json
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/package.json
@@ -16,7 +16,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/node": "^8.10.40",
-    "typescript": "~3.9.7",
+    "typescript": "~4.6.0",
     "aws-cdk": "*"
   },
   "dependencies": {

--- a/typescript/elasticbeanstalk/elasticbeanstalk-environment/package.json
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-environment/package.json
@@ -16,7 +16,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/node": "^8.10.40",
-    "typescript": "~3.9.7",
+    "typescript": "~4.6.0",
     "aws-cdk": "*"
   },
   "dependencies": {

--- a/typescript/fsx-ad/package.json
+++ b/typescript/fsx-ad/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/http-proxy-apigateway/package.json
+++ b/typescript/http-proxy-apigateway/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^14.0.6",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/lambda-api-ci/package.json
+++ b/typescript/lambda-api-ci/package.json
@@ -24,7 +24,7 @@
     "@aws-cdk/aws-cloudformation": "*",
     "@types/node": "^13.7.0",
     "ts-node": "^8.1.0",
-    "typescript": "~3.9.7",
+    "typescript": "~4.6.0",
     "prettier": "^2.0.4"
   },
   "dependencies": {

--- a/typescript/lambda-api-ci/src/handler.ts
+++ b/typescript/lambda-api-ci/src/handler.ts
@@ -32,7 +32,12 @@ const handler = async function (event: any, context: any) {
             body: "We only accept GET /",
         }
     } catch (error) {
-        const body = error.stack || JSON.stringify(error, null, 2)
+        let body
+        if (error instanceof Error) {
+            body = error.stack
+        } else {
+            body = JSON.stringify(error, null, 2)
+        }
         return {
             statusCode: 400,
             headers: {},

--- a/typescript/lambda-api-ci/src/package.json
+++ b/typescript/lambda-api-ci/src/package.json
@@ -13,7 +13,7 @@
     "jest": "^24.9.0",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.1.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-sdk": "^2.617.0"

--- a/typescript/lambda-cloudwatch-dashboard/package.json
+++ b/typescript/lambda-cloudwatch-dashboard/package.json
@@ -18,7 +18,7 @@
     "ts-jest": "^26.2.0",
     "aws-cdk": "*",
     "ts-node": "^9.0.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/lambda-cron/package.json
+++ b/typescript/lambda-cron/package.json
@@ -20,7 +20,7 @@
     "@types/jest": "^26.0.24",
     "aws-cdk": "*",
     "jest": "^26.6.3",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/lambda-layer/package.json
+++ b/typescript/lambda-layer/package.json
@@ -15,7 +15,7 @@
     "@types/node": "10.17.27",
     "aws-cdk": "*",
     "ts-node": "^9.0.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/lambda-manage-s3-event-notification/package.json
+++ b/typescript/lambda-manage-s3-event-notification/package.json
@@ -14,7 +14,7 @@
     "@types/node": "^10.17.27",
     "aws-cdk": "*",
     "ts-node": "^9.0.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/my-widget-service/package.json
+++ b/typescript/my-widget-service/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/neptune-with-vpc/package.json
+++ b/typescript/neptune-with-vpc/package.json
@@ -19,7 +19,7 @@
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
-    "typescript": "~3.9.7",
+    "typescript": "~4.6.0",
     "aws-cdk": "*",
     "source-map-support": "^0.5.16"
   }

--- a/typescript/rds/aurora/package.json
+++ b/typescript/rds/aurora/package.json
@@ -14,9 +14,10 @@
     "@types/jest": "^26.0.10",
     "@types/node": "*",
     "jest": "^26.4.2",
+    "aws-cdk": "*",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/rds/mysql/package.json
+++ b/typescript/rds/mysql/package.json
@@ -16,7 +16,8 @@
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
-    "typescript": "~3.9.7"
+    "aws-cdk": "*",
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/rds/oracle/package.json
+++ b/typescript/rds/oracle/package.json
@@ -14,9 +14,10 @@
     "@types/jest": "^26.0.10",
     "@types/node": "*",
      "jest": "^26.4.2",
+    "aws-cdk": "*",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/rekognition-lambda-s3-trigger/package.json
+++ b/typescript/rekognition-lambda-s3-trigger/package.json
@@ -14,7 +14,7 @@
     "@types/node": "10.17.27",
     "aws-cdk": "*",
     "ts-node": "^9.0.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "*",

--- a/typescript/resource-overrides/package.json
+++ b/typescript/resource-overrides/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "aws-cdk": "*",
     "@types/node": "^10.17.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/s3-object-lambda/package.json
+++ b/typescript/s3-object-lambda/package.json
@@ -15,7 +15,7 @@
     "@types/node": "10.17.27",
     "aws-cdk": "^1.154.0",
     "ts-node": "^9.0.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "@aws-cdk/aws-iam": "^1.154.0",

--- a/typescript/servicecatalog/portfolio-with-ec2-product/package.json
+++ b/typescript/servicecatalog/portfolio-with-ec2-product/package.json
@@ -17,7 +17,7 @@
     "ts-jest": "^26.2.0",
     "aws-cdk": "*",
     "ts-node": "^9.0.0",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "*",

--- a/typescript/static-site/package.json
+++ b/typescript/static-site/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/stepfunctions-job-poller/package.json
+++ b/typescript/stepfunctions-job-poller/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "*",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/waf/package.json
+++ b/typescript/waf/package.json
@@ -14,7 +14,7 @@
     "@types/jest": "^26.0.10",
     "@types/node": "*",
     "aws-cdk": "*",
-    "typescript": "~3.9.7"
+    "typescript": "~4.6.0"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",


### PR DESCRIPTION
re https://github.com/aws/aws-cdk/issues/20319

The other option is to do what is mentioned in the referenced issue and
add a devDependency for `@types/prettier`, but since it is possible to
upgrade `typescript` that seems like the better option.

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
