### PR TITLE
Allow cdk.context.json to be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -375,7 +375,6 @@ $RECYCLE.BIN/
 
 ### CDK-specific ignores ###
 *.swp
-cdk.context.json
 package-lock.json
 yarn.lock
 .cdk.staging


### PR DESCRIPTION
The CDK docs state cdk.context.json file should be committed. Otherwise you may run into inconsistent deployments.

See https://docs.aws.amazon.com/cdk/v2/guide/context.html#:~:text=Because%20they%20are%20part%20of%20your%20application%27s%20state%2C%20cdk.json%20and%20cdk.context.json

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
