### PR TITLE
Fix: (#695) Fixed security groups to properly route traffic from ALB to ASG

### DIFF
--- a/java/ecs/fargate-load-balanced-service/src/main/java/com/amazonaws/cdk/examples/ECSFargateLoadBalancedStack.java
+++ b/java/ecs/fargate-load-balanced-service/src/main/java/com/amazonaws/cdk/examples/ECSFargateLoadBalancedStack.java
@@ -6,6 +6,8 @@ import software.amazon.awscdk.services.ec2.VpcProps;
 import software.amazon.awscdk.services.ecs.Cluster;
 import software.amazon.awscdk.services.ecs.ClusterProps;
 import software.amazon.awscdk.services.ecs.ContainerImage;
+import software.amazon.awscdk.services.ec2.Peer;
+import software.amazon.awscdk.services.ec2.Port;
 import software.amazon.awscdk.services.ecs.patterns.NetworkLoadBalancedFargateService;
 import software.amazon.awscdk.services.ecs.patterns.NetworkLoadBalancedFargateServiceProps;
 import software.amazon.awscdk.services.ecs.patterns.NetworkLoadBalancedTaskImageOptions;
@@ -27,7 +29,7 @@ public class ECSFargateLoadBalancedStack extends Stack {
         Cluster cluster = new Cluster(this, "Ec2Cluster", ClusterProps.builder().vpc(vpc).build());
 
         // Use the ECS Network Load Balanced Fargate Service construct to create a ECS service
-        new NetworkLoadBalancedFargateService(
+        NetworkLoadBalancedFargateService fargateService = new NetworkLoadBalancedFargateService(
                 this,
                 "FargateService",
                 NetworkLoadBalancedFargateServiceProps.builder()
@@ -36,5 +38,14 @@ public class ECSFargateLoadBalancedStack extends Stack {
                                 .image(ContainerImage.fromRegistry("amazon/amazon-ecs-sample"))
                                 .build())
                         .build());
+        
+        // Open port 80 inbound to IPs within VPC to allow network load balancer to connect to the service
+        fargateService.getService()
+            .getConnections()
+            .getSecurityGroups()
+            .get(0)
+            .addIngressRule(Peer.ipv4(vpc.getVpcCidrBlock()), Port.tcp(80), "allow http inbound from vpc");
+
+        
     }
 }

--- a/java/ecs/fargate-load-balanced-service/src/test/resources/com/amazonaws/cdk/examples/expected.cfn.json
+++ b/java/ecs/fargate-load-balanced-service/src/test/resources/com/amazonaws/cdk/examples/expected.cfn.json
@@ -620,6 +620,20 @@
                         "IpProtocol": "-1"
                     }
                 ],
+                "SecurityGroupIngress": [
+                    {
+                     "CidrIp": {
+                      "Fn::GetAtt": [
+                       "MyVpcF9F0CA6F",
+                       "CidrBlock"
+                      ]
+                     },
+                     "Description": "allow http inbound from vpc",
+                     "FromPort": 80,
+                     "IpProtocol": "tcp",
+                     "ToPort": 80
+                    }
+                ],
                 "VpcId": {
                     "Ref": "MyVpcF9F0CA6F"
                 }

--- a/python/ecs/ecs-load-balanced-service/app.py
+++ b/python/ecs/ecs-load-balanced-service/app.py
@@ -43,9 +43,11 @@ class BonjourECS(Stack):
             )
         )
 
+        asg.connections.allow_from_any_ipv4(port_range=ec2.Port.tcp_range(32768, 65535), description="allow incoming traffic from ALB")
+
         CfnOutput(
             self, "LoadBalancerDNS",
-            value=ecs_service.load_balancer.load_balancer_dns_name
+            value="http://"+ecs_service.load_balancer.load_balancer_dns_name
         )
 
 app = App()

--- a/typescript/ecs/ecs-network-load-balanced-service/index.ts
+++ b/typescript/ecs/ecs-network-load-balanced-service/index.ts
@@ -2,7 +2,6 @@ import ec2 = require('aws-cdk-lib/aws-ec2');
 import ecs = require('aws-cdk-lib/aws-ecs');
 import ecs_patterns = require('aws-cdk-lib/aws-ecs-patterns');
 import cdk = require('aws-cdk-lib');
-import { CfnOutput } from 'aws-cdk-lib';
 
 /**
  * The port range to open up for dynamic port mapping

--- a/typescript/ecs/ecs-network-load-balanced-service/index.ts
+++ b/typescript/ecs/ecs-network-load-balanced-service/index.ts
@@ -2,6 +2,7 @@ import ec2 = require('aws-cdk-lib/aws-ec2');
 import ecs = require('aws-cdk-lib/aws-ecs');
 import ecs_patterns = require('aws-cdk-lib/aws-ecs-patterns');
 import cdk = require('aws-cdk-lib');
+import { CfnOutput } from 'aws-cdk-lib';
 
 /**
  * The port range to open up for dynamic port mapping
@@ -34,6 +35,11 @@ class BonjourECS extends cdk.Stack {
     // Need target security group to allow all inbound traffic for
     // ephemeral port range (when host port is 0).
     ecsService.service.connections.allowFromAnyIpv4(EPHEMERAL_PORT_RANGE);
+
+    new cdk.CfnOutput(this, "networkLoadBalancerURL", {
+      value: "https://"+ecsService.loadBalancer.loadBalancerDnsName,
+      description: "Network LoadBalancer URL"
+    });
   }
 }
 

--- a/typescript/ecs/ecs-service-with-advanced-alb-config/index.ts
+++ b/typescript/ecs/ecs-service-with-advanced-alb-config/index.ts
@@ -42,7 +42,7 @@ const listener = lb.addListener('PublicListener', { port: 80, open: true });
 
 // Attach ALB to ECS Service
 listener.addTargets('ECS', {
-  port: 80,
+  port: 8080,
   targets: [service.loadBalancerTarget({
     containerName: 'web',
     containerPort: 80

--- a/typescript/rds/aurora/aurora.ts
+++ b/typescript/rds/aurora/aurora.ts
@@ -24,7 +24,7 @@ export interface AuroraProps extends StackProps {
    * @type {string}
    * @memberof AuroraProps
    */
-  readonly vpcId?: string;
+  readonly vpcId: string;
 
 
   /**
@@ -141,8 +141,8 @@ export class Aurora extends Stack {
 
     let subnetIds = props.subnetIds;
     let instanceType = props.instanceType;
-    let replicaInstances = props.replicaInstances;
-    let backupRetentionDays = props.backupRetentionDays;
+    let replicaInstances = props.replicaInstances ?? 1;
+    let backupRetentionDays = props.backupRetentionDays ?? 14;
 
     var ingressSources = [];
     if (typeof props.ingressSources !== 'undefined') {
@@ -154,10 +154,10 @@ export class Aurora extends Stack {
       throw new Error('Unknown Engine Please Use mysql or postgresql');
       process.exit(1);
     }
-    if (backupRetentionDays! < 14) {
+    if (backupRetentionDays < 14) {
       backupRetentionDays = 14;
     }
-    if (replicaInstances! < 1) {
+    if (replicaInstances < 1) {
       replicaInstances = 1;
     }
 
@@ -165,7 +165,7 @@ export class Aurora extends Stack {
 
     // vpc
     const vpc = ec2.Vpc.fromVpcAttributes(this, 'ExistingVPC', {
-      vpcId: props.vpcId!,
+      vpcId: props.vpcId,
       availabilityZones: azs,
     });
 
@@ -295,10 +295,10 @@ export class Aurora extends Stack {
       credentials: auroraClusterCrendentials,
       backup: {
         preferredWindow: props.backupWindow,
-        retention: Duration.days(props.backupRetentionDays!),
+        retention: Duration.days(backupRetentionDays),
       },
       parameterGroup: auroraParameterGroup,
-      instances: props.replicaInstances,
+      instances: replicaInstances,
       iamAuthentication: true,
       storageEncrypted: true,
       storageEncryptionKey: kmsKey,


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->
This issue addresses the bug found in #695.

The fix adds an ingress rule to the ASG security group that allows connectivity from the load balancer.

The issue was that the default security group of the autoscaling group did not have any ingress rules which led to the ALB being unable to connect to the ECS service (and subsequently showing a 503 or 504 error).

An additional change was made to set the host-port to '0' which allows ECS to define any host port to host the service.

I am also validating the following examples which have load balancers:

**Python**

| Example | Status | Notes |
| -- | -- | -- |
|[ecs-load-balanced-service](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/ecs/ecs-load-balanced-service) | Needed fix | ASG ingress rule added for connection from Network LB |
| [ecs-service-with-advanced-alb-config](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/ecs/ecs-service-with-advanced-alb-config) | Needed fix| ASG ingress rule added for connection from Application LB|
| [fargate-load-balanced-service](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/ecs/fargate-load-balanced-service) |OK||
| [fargate-service-with-autoscaling](https://github.com/aws-samples/aws-cdk-examples/tree/master/python/ecs/fargate-service-with-autoscaling) |OK||

**Typescript**

| Example | Status | Notes |
| -- | -- | -- |
|[ecs-network-load-balanced-service](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ecs/ecs-network-load-balanced-service) | OK | Added CfnOutput for loadbalancer URL so users could get the URL from their terminal on cdk deploy|
|[ecs-service-with-advanced-alb-config](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ecs/ecs-service-with-advanced-alb-config) | Needed fix | Load balancer target port didn't match the host port |
|[fargate-application-load-balanced-service](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ecs/fargate-application-load-balanced-service) | OK | |
|[fargate-service-with-auto-scaling](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ecs/fargate-service-with-auto-scaling) | OK | |
|[fargate-service-with-local-image](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ecs/fargate-service-with-local-image) | OK | |
|[fargate-service-with-logging](https://github.com/aws-samples/aws-cdk-examples/tree/master/typescript/ecs/fargate-service-with-logging) | OK | |

**Java**

| Example | Status | Notes |
| -- | -- | -- |
|[fargate-load-balanced-service](https://github.com/aws-samples/aws-cdk-examples/tree/master/java/ecs/fargate-load-balanced-service) | Needed fix | Fargate service default security group needed ingress on port 80 from VPC CIDR range to allow connectivity from network load balancer |

**Golang**

| Example | Status | Notes |
| -- | -- | -- |
|[fargate-alb-pattern](https://github.com/aws-samples/aws-cdk-examples/tree/master/go/ecs/fargate-alb-pattern) | OK | |
|[fargate-with-alb](https://github.com/aws-samples/aws-cdk-examples/tree/master/go/ecs/fargate-with-alb) | OK | |

**C#**

No examples

Fixes #695
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
