### PR TITLE
Add missing dependencies to appsync-graphql-dynamodb example

### DIFF
--- a/typescript/appsync-graphql-dynamodb/index.ts
+++ b/typescript/appsync-graphql-dynamodb/index.ts
@@ -91,6 +91,7 @@ export class AppSyncCdkStack extends cdk.Stack {
       responseMappingTemplate: `$util.toJson($ctx.result)`
     });
     getOneResolver.addDependsOn(apiSchema);
+    getOneResolver.addDependsOn(dataSource);
 
     const getAllResolver = new CfnResolver(this, 'GetAllQueryResolver', {
       apiId: itemsGraphQLApi.attrApiId,
@@ -106,6 +107,7 @@ export class AppSyncCdkStack extends cdk.Stack {
       responseMappingTemplate: `$util.toJson($ctx.result)`
     });
     getAllResolver.addDependsOn(apiSchema);
+    getAllResolver.addDependsOn(dataSource);
 
     const saveResolver = new CfnResolver(this, 'SaveMutationResolver', {
       apiId: itemsGraphQLApi.attrApiId,
@@ -125,6 +127,7 @@ export class AppSyncCdkStack extends cdk.Stack {
       responseMappingTemplate: `$util.toJson($ctx.result)`
     });
     saveResolver.addDependsOn(apiSchema);
+    saveResolver.addDependsOn(dataSource);
 
     const deleteResolver = new CfnResolver(this, 'DeleteMutationResolver', {
       apiId: itemsGraphQLApi.attrApiId,
@@ -141,7 +144,7 @@ export class AppSyncCdkStack extends cdk.Stack {
       responseMappingTemplate: `$util.toJson($ctx.result)`
     });
     deleteResolver.addDependsOn(apiSchema);
-
+    deleteResolver.addDependsOn(dataSource);
   }
 }
 


### PR DESCRIPTION
Fixes inability to destroy appsync-graphql-dynamodb example

Fixes #
https://github.com/aws-samples/aws-cdk-examples/issues/698
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
