### PR TITLE
fix(python) lambda cron runtime

### DIFF
--- a/typescript/lambda-cron/index.ts
+++ b/typescript/lambda-cron/index.ts
@@ -13,7 +13,7 @@ export class LambdaCronStack extends cdk.Stack {
       code: new lambda.InlineCode(fs.readFileSync('lambda-handler.py', { encoding: 'utf-8' })),
       handler: 'index.main',
       timeout: cdk.Duration.seconds(300),
-      runtime: lambda.Runtime.PYTHON_3_6,
+      runtime: lambda.Runtime.PYTHON_3_9,
     });
 
     // Run 6:00 PM UTC every Monday through Friday

--- a/typescript/lambda-cron/lambda-cron.test.ts
+++ b/typescript/lambda-cron/lambda-cron.test.ts
@@ -20,7 +20,7 @@ describe('lambda tests', () => {
           ZipFile: `def main(event, context):\n    print(\"I'm running!\")`,
         },
         Handler: 'index.main',
-        Runtime: 'python3.6',
+        Runtime: 'python3.9',
         Timeout: 300,
       },
       DependsOn: [ dependencyCapture ],


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Received the following error when deploying CDK:

```
Resource handler returned message: "The runtime parameter of python3.6 is no longer supported for creating or updating AWS Lambda functions.
```

Updating Python version. Deployed successfully and tested Lambda function.

Fixes # <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
