### PR TITLE
fix(java/resource-overrides): return AnalyticsConfigurationProperty instead of ImmutableMap

### DIFF
--- a/java/resource-overrides/src/main/java/software/amazon/awscdk/examples/ResourceOverridesStack.java
+++ b/java/resource-overrides/src/main/java/software/amazon/awscdk/examples/ResourceOverridesStack.java
@@ -78,25 +78,24 @@ class ResourceOverridesStack extends Stack {
     bucketResource.addPropertyOverride(
         "LoggingConfiguration.DestinationBucketName", otherBucket.getBucketName());
 
-    bucketResource.setAnalyticsConfigurations(
-        Collections.singletonList(
-            ImmutableMap.builder()
-                .put("id", "config1")
-                .put(
-                    "storageClassAnalysis",
-                    ImmutableMap.of(
-                        "dataExport",
-                        ImmutableMap.builder()
-                            .put("outputSchemaVersion", "1")
-                            .put(
-                                "destination",
-                                ImmutableMap.builder()
-                                    .put("format", "html")
-                                    // using L2 construct's method will work as expected
-                                    .put("bucketArn", otherBucket.getBucketArn())
+    CfnBucket.AnalyticsConfigurationProperty properties =
+        CfnBucket.AnalyticsConfigurationProperty.builder()
+            .id("config1")
+            .storageClassAnalysis(
+                CfnBucket.StorageClassAnalysisProperty.builder()
+                    .dataExport(
+                        CfnBucket.DataExportProperty.builder()
+                            .outputSchemaVersion("1")
+                            .destination(
+                                CfnBucket.DestinationProperty.builder()
+                                    .bucketArn(otherBucket.getBucketArn())
+                                    .format("html")
                                     .build())
-                            .build()))
-                .build()));
+                            .build())
+                    .build())
+            .build();
+
+    bucketResource.setAnalyticsConfigurations(Collections.singletonList(properties));
 
     //
     // It is also possible to request a deletion of a value by either assigning
@@ -144,7 +143,9 @@ class ResourceOverridesStack extends Stack {
         (CfnBucket)
             bucket.getNode().getChildren().stream()
                 .filter(
-                    child -> child instanceof CfnResource && ((CfnResource)child).getCfnResourceType().equals("AWS::S3::Bucket"))
+                    child ->
+                        child instanceof CfnResource
+                            && ((CfnResource) child).getCfnResourceType().equals("AWS::S3::Bucket"))
                 .findFirst()
                 .get();
 


### PR DESCRIPTION
Signed-off-by: Vinayak Kukreja <vinakuk@amazon.com>

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->
Currently the build is failing with the error,
```
java.lang.IllegalArgumentException: Expected value.get(0) to be one of: software.amazon.awscdk.services.s3.CfnBucket.AnalyticsConfigurationProperty, software.amazon.awscdk.IResolvable; received class com.google.common.collect.RegularImmutableMap
```
This PR fixes the error by returning AnalyticsConfigurationProperty instead of ImmutableMap.

Fixes # https://github.com/aws-samples/aws-cdk-examples/issues/732

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
