### PR TITLE
fix: Update java/my-widget-service to node 16

### DIFF
--- a/java/my-widget-service/src/main/java/software/amazon/awscdk/examples/MyWidgetServiceStack.java
+++ b/java/my-widget-service/src/main/java/software/amazon/awscdk/examples/MyWidgetServiceStack.java
@@ -48,7 +48,7 @@ public class MyWidgetServiceStack extends Stack {
             .code(Code.fromAsset("resources"))
             .handler("widgets.main")
             .timeout(Duration.seconds(300))
-            .runtime(Runtime.NODEJS_10_X)
+            .runtime(Runtime.NODEJS_16_X)
             .environment(environmentVariables)
             .build();
 

--- a/java/my-widget-service/src/test/resources/software/amazon/awscdk/examples/testMyWidgetServiceExpected.json
+++ b/java/my-widget-service/src/test/resources/software/amazon/awscdk/examples/testMyWidgetServiceExpected.json
@@ -743,7 +743,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs16.x",
         "Environment": {
           "Variables": {
             "BUCKET": {


### PR DESCRIPTION
CloudFormation templates in aws-cdk-examples have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs16.x).


Fixes #439 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
