### PR TITLE
fix: Java snapshot test is too brittle

### DIFF
--- a/java/hello-world/pom.xml
+++ b/java/hello-world/pom.xml
@@ -18,8 +18,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.9</source>
-                    <target>1.9</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/java/hello-world/pom.xml
+++ b/java/hello-world/pom.xml
@@ -18,8 +18,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.9</source>
+                    <target>1.9</target>
                 </configuration>
             </plugin>
 
@@ -56,6 +56,12 @@
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
             <version>[2.0.0,)</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>assertions-alpha</artifactId>
+            <version>2.0.0-rc.24</version>
         </dependency>
 
         <dependency>

--- a/java/hello-world/src/test/java/software/amazon/awscdk/examples/JDK9.java
+++ b/java/hello-world/src/test/java/software/amazon/awscdk/examples/JDK9.java
@@ -1,0 +1,50 @@
+package software.amazon.awscdk.examples;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Backported helpers from JDK9
+ *
+ * Unfortunately our tests must run on Java8, because superchain has the old version.
+ */
+public class JDK9 {
+  @SafeVarargs
+  static <K, V> Map<K, V> mapOf(Entry<? extends K, ? extends V>... entries) {
+    Map<K, V> ret = new HashMap<>();
+
+    for (Entry<? extends K, ? extends V> entry : entries) {
+      ret.put(entry.key, entry.value);
+    }
+
+    return ret;
+  }
+
+  @SafeVarargs
+  static <V> List<V> listOf(V... entries) {
+    List<V> ret = new ArrayList<>();
+
+    for (V entry : entries) {
+      ret.add(entry);
+    }
+
+    return ret;
+  }
+
+  static <K, V> Entry<K, V> entry(K k, V v) {
+    // KeyValueHolder checks for nulls
+    return new Entry<>(k, v);
+  }
+
+  public static class Entry<K,V>  {
+      public final K key;
+      public final V value;
+
+      Entry(K k, V v) {
+          key = k;
+          value = v;
+      }
+  }
+}

--- a/java/hello-world/src/test/java/software/amazon/awscdk/examples/SinkQueueTest.java
+++ b/java/hello-world/src/test/java/software/amazon/awscdk/examples/SinkQueueTest.java
@@ -4,9 +4,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.AbstractMap;
-import java.util.List;
 import java.util.Map;
-import static java.util.Map.entry;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -19,6 +17,10 @@ import software.amazon.awscdk.cxapi.CloudFormationStackArtifact;
 import software.amazon.awscdk.services.sns.Topic;
 import software.amazon.awscdk.services.sqs.QueueProps;
 import software.amazon.jsii.JsiiException;
+
+import static software.amazon.awscdk.examples.JDK9.entry;
+import static software.amazon.awscdk.examples.JDK9.listOf;
+import static software.amazon.awscdk.examples.JDK9.mapOf;
 
 public class SinkQueueTest {
 
@@ -70,11 +72,11 @@ public class SinkQueueTest {
     sink.subscribe(new Topic(stack, "Topic3"));
 
     Template template = Template.fromStack(stack);
-    template.hasResourceProperties("AWS::SNS::Subscription", Map.ofEntries(
+    template.hasResourceProperties("AWS::SNS::Subscription", mapOf(
       entry("Protocol", "sqs"),
-      entry("Endpoint", Map.ofEntries(
-        entry("Fn::GetAtt", List.of("MySinkQueueEFCD79C2", "Arn")))),
-      entry("TopicArn", Map.ofEntries(
+      entry("Endpoint", mapOf(
+        entry("Fn::GetAtt", listOf("MySinkQueueEFCD79C2", "Arn")))),
+      entry("TopicArn", mapOf(
         entry("Ref", "Topic198E71B3E")))));
   }
 


### PR DESCRIPTION
This test broke because a recent release added a dependency. 

Just check the important part of the template using the `assertions` library.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
