### PR TITLE
fix typo in app.py

### DIFF
--- a/python/ec2-cloudwatch/app.py
+++ b/python/ec2-cloudwatch/app.py
@@ -5,7 +5,7 @@ from ec2_cloudwatch.ec2_cloudwatch_stack import Ec2CloudwatchStack
 
 app = App()
 
-# # Replace the accoount and region with your information
+# # Replace the account and region with your information
 # env = core.Environment(account="You account information", region="cn-northwest-1")
 # Ec2CloudwatchStack(app, "ec2-cloudwatch", env=env)
 


### PR DESCRIPTION
A one character change, the word "account" was misspelled. 