### PR TITLE
fix: ResourceOverridesStackTest is failing after service principals logic update

### DIFF
--- a/java/resource-overrides/src/test/resources/software/amazon/awscdk/examples/testResourceOverrides.expected.json
+++ b/java/resource-overrides/src/test/resources/software/amazon/awscdk/examples/testResourceOverrides.expected.json
@@ -305,17 +305,7 @@
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": {
-                "Service": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "ec2.",
-                      {
-                        "Ref": "AWS::URLSuffix"
-                      }
-                    ]
-                  ]
-                }
+                "Service": "ec2.amazonaws.com"
               }
             }
           ],


### PR DESCRIPTION
After https://github.com/aws/aws-cdk/pull/22819, the service principal always resolves to 'service.amazonaws.com'.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
