### PR TITLE
chore: upgrade dotnet projects to use .NET 6.0

### DIFF
--- a/csharp/CloudFront-S3-WAF/src/src.csproj
+++ b/csharp/CloudFront-S3-WAF/src/src.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/csharp/apigateway-cognito-lambda-dynamodb/src/CDK/cdk.csproj
+++ b/csharp/apigateway-cognito-lambda-dynamodb/src/CDK/cdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>apigateway_cognito_lambda_dynamodb</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/csharp/apigateway-cognito-lambda-dynamodb/src/Lambda/AuthFunction/AuthFunction.csproj
+++ b/csharp/apigateway-cognito-lambda-dynamodb/src/Lambda/AuthFunction/AuthFunction.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/csharp/apigateway-cognito-lambda-dynamodb/src/Lambda/BackendFunction/BackendFunction.csproj
+++ b/csharp/apigateway-cognito-lambda-dynamodb/src/Lambda/BackendFunction/BackendFunction.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/csharp/application-load-balancer/src/ApplicationLoadBalancer/ApplicationLoadBalancer.csproj
+++ b/csharp/application-load-balancer/src/ApplicationLoadBalancer/ApplicationLoadBalancer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- Roll forward to future major versions of the netcoreapp as needed -->
     <RollForward>Major</RollForward>
   </PropertyGroup>

--- a/csharp/appsync-graphql-dynamodb/src/AppsyncGraphqlDynamodb/AppsyncGraphqlDynamodb.csproj
+++ b/csharp/appsync-graphql-dynamodb/src/AppsyncGraphqlDynamodb/AppsyncGraphqlDynamodb.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- Roll forward to future major versions of the netcoreapp as needed -->
     <RollForward>Major</RollForward>
   </PropertyGroup>

--- a/csharp/capitalize-string/CapitalizeStringHandler/src/CapitalizeStringHandler/CapitalizeStringHandler.csproj
+++ b/csharp/capitalize-string/CapitalizeStringHandler/src/CapitalizeStringHandler/CapitalizeStringHandler.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>

--- a/csharp/capitalize-string/CapitalizeStringHandler/src/CapitalizeStringHandler/aws-lambda-tools-defaults.json
+++ b/csharp/capitalize-string/CapitalizeStringHandler/src/CapitalizeStringHandler/aws-lambda-tools-defaults.json
@@ -1,5 +1,5 @@
 ﻿{
-  "Information" : [
+  "Information": [
     "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
     "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
 
@@ -8,12 +8,12 @@
     "All the command line options for the Lambda command can be specified in this file."
   ],
 
-  "profile":"",
-  "region" : "",
-  "configuration" : "Release",
-  "framework" : "netcoreapp3.1",
-  "function-runtime":"dotnetcore3.1",
-  "function-memory-size" : 256,
-  "function-timeout" : 30,
-  "function-handler" : "CapitalizeStringHandler::CapitalizeStringHandler.Function::FunctionHandler"
+  "profile": "",
+  "region": "",
+  "configuration": "Release",
+  "framework": "net6.0",
+  "function-runtime": "dotnetcore3.1",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "CapitalizeStringHandler::CapitalizeStringHandler.Function::FunctionHandler"
 }

--- a/csharp/capitalize-string/CapitalizeStringHandler/test/CapitalizeStringHandler.Tests/CapitalizeStringHandler.Tests.csproj
+++ b/csharp/capitalize-string/CapitalizeStringHandler/test/CapitalizeStringHandler.Tests/CapitalizeStringHandler.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />

--- a/csharp/capitalize-string/README.md
+++ b/csharp/capitalize-string/README.md
@@ -77,7 +77,7 @@ https://docs.aws.amazon.com/lambda/latest/dg/dotnet-programming-model.html
     dotnet lambda package
     ```
 
-    This should have created a folder `bin/Release/netcoreapp3.1/publish/` which is the package
+    This should have created a folder `bin/Release/net6.0/publish/` which is the package
     that needs to be deployed to AWS Lambda as the function code.
 
 6. In the CDK project, create an instance of `Function` class from the Lambda module.

--- a/csharp/capitalize-string/src/CapitalizeString/CapitalizeString.csproj
+++ b/csharp/capitalize-string/src/CapitalizeString/CapitalizeString.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- Roll forward to future major versions of the netcoreapp as needed -->
     <RollForward>Major</RollForward>
   </PropertyGroup>

--- a/csharp/capitalize-string/src/CapitalizeString/CapitalizeStringStack.cs
+++ b/csharp/capitalize-string/src/CapitalizeString/CapitalizeStringStack.cs
@@ -11,7 +11,7 @@ namespace CapitalizeString
             Function fn = new Function(this, "capitalizestring", new FunctionProps
             {
                 Runtime = Runtime.DOTNET_CORE_3_1,
-                Code = Code.FromAsset("./CapitalizeStringHandler/src/CapitalizeStringHandler/bin/Release/netcoreapp3.1/publish"),
+                Code = Code.FromAsset("./CapitalizeStringHandler/src/CapitalizeStringHandler/bin/Release/net6.0/publish"),
                 Handler = "CapitalizeStringHandler::CapitalizeStringHandler.Function::FunctionHandler"
             });
         }

--- a/csharp/classic-load-balancer/src/ClassicLoadBalancer/ClassicLoadBalancer.csproj
+++ b/csharp/classic-load-balancer/src/ClassicLoadBalancer/ClassicLoadBalancer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- Roll forward to future major versions of the netcoreapp as needed -->
     <RollForward>Major</RollForward>
   </PropertyGroup>

--- a/csharp/elasticbeanstalk/elasticbeanstalk-bg-pipeline/src/ElasticbeanstalkBgPipeline/ElasticbeanstalkBgPipeline.csproj
+++ b/csharp/elasticbeanstalk/elasticbeanstalk-bg-pipeline/src/ElasticbeanstalkBgPipeline/ElasticbeanstalkBgPipeline.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- Roll forward to future major versions of the netcoreapp as needed -->
     <RollForward>Major</RollForward>
   </PropertyGroup>

--- a/csharp/elasticbeanstalk/elasticbeanstalk-environment/src/ElasticbeanstalkEnvironment/ElasticbeanstalkEnvironment.csproj
+++ b/csharp/elasticbeanstalk/elasticbeanstalk-environment/src/ElasticbeanstalkEnvironment/ElasticbeanstalkEnvironment.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- Roll forward to future major versions of the netcoreapp as needed -->
     <RollForward>Major</RollForward>
   </PropertyGroup>

--- a/csharp/eventbridge-firehose-s3-cdk/src/src.csproj
+++ b/csharp/eventbridge-firehose-s3-cdk/src/src.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/csharp/lambda-cron/src/LambdaCron.Tests/LambdaCron.Tests.csproj
+++ b/csharp/lambda-cron/src/LambdaCron.Tests/LambdaCron.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/csharp/lambda-cron/src/LambdaCron/LambdaCron.csproj
+++ b/csharp/lambda-cron/src/LambdaCron/LambdaCron.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- Roll forward to future major versions of the netcoreapp as needed -->
     <RollForward>Major</RollForward>
   </PropertyGroup>

--- a/csharp/my-widget-service/cdk.json
+++ b/csharp/my-widget-service/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "dotnet src/MyWidgetService/bin/Debug/netcoreapp3.1/MyWidgetService.dll"
+  "app": "dotnet src/MyWidgetService/bin/Debug/net6.0/MyWidgetService.dll"
 }

--- a/csharp/my-widget-service/src/MyWidgetService/MyWidgetService.csproj
+++ b/csharp/my-widget-service/src/MyWidgetService/MyWidgetService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- Roll forward to future major versions of the netcoreapp as needed -->
     <RollForward>Major</RollForward>
   </PropertyGroup>

--- a/csharp/random-writer/src/RandomWriter/RandomWriter.csproj
+++ b/csharp/random-writer/src/RandomWriter/RandomWriter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- Roll forward to future major versions of the netcoreapp as needed -->
     <RollForward>Major</RollForward>
   </PropertyGroup>

--- a/csharp/static-site/src/StaticSite/StaticSite.csproj
+++ b/csharp/static-site/src/StaticSite/StaticSite.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- Roll forward to future major versions of the netcoreapp as needed -->
     <RollForward>Major</RollForward>
   </PropertyGroup>

--- a/csharp/stepfunctions-job-poller/src/StepfunctionsJobPoller/StepfunctionsJobPoller.csproj
+++ b/csharp/stepfunctions-job-poller/src/StepfunctionsJobPoller/StepfunctionsJobPoller.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <!-- Roll forward to future major versions of the netcoreapp as needed -->
     <RollForward>Major</RollForward>
   </PropertyGroup>


### PR DESCRIPTION
.NET Core 3.1 is EOL
https://endoflife.date/dotnet

And the jsii/superchain image only ships with supported versions, so this fixes the failing main build.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
