### PR TITLE
Fix secretStringTemplate in mysql example

### DIFF
--- a/typescript/rds/mysql/mysql.ts
+++ b/typescript/rds/mysql/mysql.ts
@@ -182,7 +182,7 @@ export class Mysql extends Stack {
         excludeCharacters: "\"@/\\ '",
         generateStringKey: 'password',
         passwordLength: 30,
-        secretStringTemplate: `{"username":${mysqlUsername}}`,
+        secretStringTemplate: JSON.stringify({username: mysqlUsername}),
       },
     });
 


### PR DESCRIPTION
The template was invalid JSON as the username wasn't enclosed in quotes. Running JSON.stringify instead of manually creating the JSON makes more sense too. 

Fixes #735

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
