### PR TITLE
CDK Go - Fixing README Typo

### DIFF
--- a/go/ecs/cluster/README.md
+++ b/go/ecs/cluster/README.md
@@ -1,6 +1,6 @@
-# ESC Cluster
+# ECS Cluster
 
-This is an example of how to provision ECS cluster with CDK.
+This is an example of how to provision an ECS cluster with CDK.
 
 **NOTICE**: Go support is still in Developer Preview. This implies that APIs may
 change while we address early feedback from the community. We would love to hear


### PR DESCRIPTION
Found a typo in the ECS Cluster README - this PR corrects it. 

#811 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
