### PR TITLE
TypeScript - Build & Deploy Docker Image With AWS CodePipeline

### DIFF
--- a/typescript/codepipeline-build-deploy/.gitignore
+++ b/typescript/codepipeline-build-deploy/.gitignore
@@ -1,0 +1,8 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/typescript/codepipeline-build-deploy/.npmignore
+++ b/typescript/codepipeline-build-deploy/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/typescript/codepipeline-build-deploy/README.md
+++ b/typescript/codepipeline-build-deploy/README.md
@@ -1,0 +1,81 @@
+# Building and Deploying a Docker Image With AWS CodePipeline
+
+## <!--BEGIN STABILITY BANNER-->
+
+![Stability: Stable](https://img.shields.io/badge/stability-Stable-success.svg?style=for-the-badge)
+
+> **This is a stable example. It should successfully build out of the box**
+>
+> This example is built on Construct Libraries marked "Stable" and does not have any infrastructure prerequisites to build.
+
+---
+
+<!--END STABILITY BANNER-->
+
+## Overview
+
+This AWS Cloud Development Kit (CDK) TypeScript example demonstrates how to configure AWS CodePipeline with CodeCommit, CodeBuild, and CodeDeploy to build and deploy a Docker image to an Elastic Container Service (ECS) cluster running [AWS Fargate](https://aws.amazon.com/fargate/) (serverless compute for containers).
+
+## Real-world Example
+
+When working in fast-paced development environments, CI/CD (Continuous Integration and Continuous Delivery) pipelines are used to automatically build, test, and deploy application changes across multiple accounts and environments. This allows new features and bug fixes to be tested and deployed quickly to continuously improve the application.
+
+## Requirements
+
+- [TypeScript v3.8+](https://www.typescriptlang.org/)
+    - [AWS CDK in TypeScript](https://docs.aws.amazon.com/cdk/v2/guide/work-with-cdk-typescript.html)
+- [AWS CDK v2.x](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html)
+
+## AWS Services Utilized
+
+- CodePipeline
+- CodeCommit
+- CodeBuild
+- CodeDeploy
+- Elastic Container Service (ECS)
+- Fargate
+- Elastic Container Registry (ECR)
+- Lambda
+
+## Deploying
+
+- Authenticate to an AWS account via a Command Line Interface (CLI).
+- Navigate to this `codepipeline-build-deploy` directory.
+- `cdk synth` to generate and review the CloudFormation template.
+- `cdk diff` to compare local changes with what is currently deployed.
+- `npm run test` to run the tests we specify in `codepipeline-build-deploy.test.ts`.
+- `cdk deploy` to deploy the stack to the AWS account you're authenticated to.
+
+## Output
+
+After a successful deployment, CDK will output a public endpoint for:
+
+- Application Load Balancer (ALB)
+
+## Testing
+
+- To test that the Docker image was built and deployed successfully to ECS, we can use the Application Load Balancer (ALB) public endpoint, e.g. `http://xyz123.us-east-1.elb.amazonaws.com`.
+- The simple containerized application contains multiple pages for testing:
+  - `/index.html`
+  - `/about.html`
+  - `/contact.html`
+  - `/error.html`
+- Navigate to the AWS CodePipeline console and select `ImageBuildDeployPipeline`. Then click on `Release change` to trigger the pipeline and observe the workflow in action end-to-end.
+- Navigate to the AWS Console to view the services that were deployed:
+  - CodePipeline pipeline
+  - CodeCommit repository
+  - CodeBuild project
+  - CodeDeploy application
+  - ECS cluster
+  - ECS service on Fargate
+  - ECR image repository
+  - Lambda functions
+
+## Further Improvements
+
+- Add [manual approval actions](https://docs.aws.amazon.com/codepipeline/latest/userguide/approvals-action-add.html) to the CodePipeline workflow.
+- [Deploy to multiple accounts](https://docs.aws.amazon.com/codedeploy/latest/userguide/deployments-cross-account.html) with CodeDeploy.
+- Set up Elastic Container Registry (ECR) repository [cross-account or cross-region replication](https://docs.aws.amazon.com/AmazonECR/latest/userguide/replication.html).
+- Protect the public Application Load Balancer (ALB) from attacks and malicious traffic using [Web Application Firewall (WAF)](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html).
+- [Enable SSL/TLS](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html) at the Application Load Balancer (ALB) using AWS Certificate Manager.
+- Set up a [Route 53 domain](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-elb-load-balancer.html) to route traffic to an Application Load Balancer (ALB).

--- a/typescript/codepipeline-build-deploy/app/Dockerfile
+++ b/typescript/codepipeline-build-deploy/app/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/nginx/nginx:stable-alpine
+
+COPY ./site-assets/ /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/typescript/codepipeline-build-deploy/app/README.md
+++ b/typescript/codepipeline-build-deploy/app/README.md
@@ -1,0 +1,5 @@
+# Simple Containerized Application
+
+## Overview
+
+This repository contains a simple application that will run in an Nginx container. The image will be built with Docker and stored in Amazon Elastic Container Registry (ECR).

--- a/typescript/codepipeline-build-deploy/app/appspec.yaml
+++ b/typescript/codepipeline-build-deploy/app/appspec.yaml
@@ -1,0 +1,9 @@
+version: 0.0
+Resources:
+  - TargetService:
+      Type: AWS::ECS::Service
+      Properties:
+        TaskDefinition: "TASK_DEFINITION_ARN"
+        LoadBalancerInfo:
+          ContainerName: "web"
+          ContainerPort: "80"

--- a/typescript/codepipeline-build-deploy/app/buildspec.yaml
+++ b/typescript/codepipeline-build-deploy/app/buildspec.yaml
@@ -1,0 +1,28 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - aws --version
+      - aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+  build:
+    commands:
+      - echo Building the Docker image...
+      - docker build -t $IMAGE_REPO_NAME:$IMAGE_TAG .
+      - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
+  post_build:
+    commands:
+      - echo Pushing the Docker image...
+      - docker push $AWS_ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
+      - echo Container image to be used $REPOSITORY_URI:$IMAGE_TAG
+      - sed -i "s|REPOSITORY_URI|${REPOSITORY_URI}|g" taskdef.json
+      - sed -i "s|IMAGE_TAG|${IMAGE_TAG}|g" taskdef.json
+      - sed -i "s|TASK_ROLE_ARN|${TASK_ROLE_ARN}|g" taskdef.json
+      - sed -i "s|EXECUTION_ROLE_ARN|${EXECUTION_ROLE_ARN}|g" taskdef.json
+      - sed -i "s|TASK_DEFINITION_ARN|${TASK_DEFINITION_ARN}|g" appspec.yaml
+      - cat appspec.yaml && cat taskdef.json
+artifacts:
+  files:
+    - "appspec.yaml"
+    - "taskdef.json"

--- a/typescript/codepipeline-build-deploy/app/site-assets/about.html
+++ b/typescript/codepipeline-build-deploy/app/site-assets/about.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="styles.css" />
+    <title>About</title>
+  </head>
+  <body>
+    <h1>About Us</h1>
+    <ul>
+      <li><a href="index.html">Home</a></li>
+      <li>|</li>
+      <li id="current"><a href="about.html">About</a></li>
+      <li>|</li>
+      <li><a href="contact.html">Contact</a></li>
+    </ul>
+  </body>
+</html>

--- a/typescript/codepipeline-build-deploy/app/site-assets/contact.html
+++ b/typescript/codepipeline-build-deploy/app/site-assets/contact.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="styles.css" />
+    <title>Contact</title>
+  </head>
+  <body>
+    <h1>Contact Us</h1>
+    <ul>
+      <li><a href="index.html">Home</a></li>
+      <li>|</li>
+      <li><a href="about.html">About</a></li>
+      <li>|</li>
+      <li id="current"><a href="contact.html">Contact</a></li>
+    </ul>
+  </body>
+</html>

--- a/typescript/codepipeline-build-deploy/app/site-assets/error.html
+++ b/typescript/codepipeline-build-deploy/app/site-assets/error.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="styles.css" />
+    <title>Error</title>
+  </head>
+  <body id="error">
+    <h1>Sorry, that page doesn't exist...</h1>
+  </body>
+</html>

--- a/typescript/codepipeline-build-deploy/app/site-assets/index.html
+++ b/typescript/codepipeline-build-deploy/app/site-assets/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="styles.css" />
+    <title>Homepage!</title>
+  </head>
+  <body>
+    <h1>Welcome to the Homepage!</h1>
+    <ul>
+      <li id="current"><a href="index.html">Home</a></li>
+      <li>|</li>
+      <li><a href="about.html">About</a></li>
+      <li>|</li>
+      <li><a href="contact.html">Contact</a></li>
+    </ul>
+  </body>
+</html>

--- a/typescript/codepipeline-build-deploy/app/site-assets/styles.css
+++ b/typescript/codepipeline-build-deploy/app/site-assets/styles.css
@@ -1,0 +1,38 @@
+body {
+  text-align: center;
+  color: whitesmoke;
+  background-color: rgb(0, 128, 0, 0.5);
+  font-family: Verdana, Geneva, Tahoma, sans-serif;
+}
+
+#current {
+  font-weight: bold;
+}
+
+#error {
+  background-color: rgb(255, 0, 0, 0.5);
+}
+
+ul {
+  background-color: rgb(127, 255, 212, 0.2);
+  list-style-type: none;
+  padding: 10px;
+}
+
+li {
+  display: inline;
+  margin: 20px;
+  border-bottom: 3px solid transparent;
+}
+
+li a {
+  text-decoration: none;
+  color: white;
+}
+
+li a:hover {
+  color: rgb(127, 255, 0, 70);
+  padding: 5px 10px;
+  border-radius: 10px;
+  background-color: darkcyan;
+}

--- a/typescript/codepipeline-build-deploy/app/taskdef.json
+++ b/typescript/codepipeline-build-deploy/app/taskdef.json
@@ -1,0 +1,22 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "web",
+      "image": "REPOSITORY_URI:IMAGE_TAG",
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true
+    }
+  ],
+  "taskRoleArn": "TASK_ROLE_ARN",
+  "executionRoleArn": "EXECUTION_ROLE_ARN",
+  "family": "codedeploy-sample",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "256",
+  "memory": "512"
+}

--- a/typescript/codepipeline-build-deploy/bin/codepipeline-build-deploy.ts
+++ b/typescript/codepipeline-build-deploy/bin/codepipeline-build-deploy.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { CodepipelineBuildDeployStack } from '../lib/codepipeline-build-deploy-stack';
+
+const app = new cdk.App();
+new CodepipelineBuildDeployStack(app, 'CodepipelineBuildDeployStack', {
+  /* If you don't specify 'env', this stack will be environment-agnostic.
+   * Account/Region-dependent features and context lookups will not work,
+   * but a single synthesized template can be deployed anywhere. */
+
+  /* Uncomment the next line to specialize this stack for the AWS Account
+   * and Region that are implied by the current CLI configuration. */
+  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+
+  /* Uncomment the next line if you know exactly what Account and Region you
+   * want to deploy the stack to. */
+  // env: { account: '123456789012', region: 'us-east-1' },
+
+  /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
+});

--- a/typescript/codepipeline-build-deploy/cdk.json
+++ b/typescript/codepipeline-build-deploy/cdk.json
@@ -1,0 +1,51 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/codepipeline-build-deploy.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true
+  }
+}

--- a/typescript/codepipeline-build-deploy/jest.config.js
+++ b/typescript/codepipeline-build-deploy/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  }
+};

--- a/typescript/codepipeline-build-deploy/lambda/trigger-build.js
+++ b/typescript/codepipeline-build-deploy/lambda/trigger-build.js
@@ -1,0 +1,21 @@
+const {
+  CodeBuildClient,
+  StartBuildCommand,
+} = require("@aws-sdk/client-codebuild");
+
+exports.handler = async (event) => {
+  const region = process.env.REGION;
+  const buildProjectName = process.env.CODEBUILD_PROJECT_NAME;
+
+  const codebuild = new CodeBuildClient({ region: region });
+  const buildCommand = new StartBuildCommand({ projectName: buildProjectName });
+
+  console.log("Triggering CodeBuild Project...");
+  const buildResponse = await codebuild.send(buildCommand);
+  console.log(buildResponse);
+
+  return {
+    statusCode: 200,
+    body: "CodeBuild Project building...",
+  };
+};

--- a/typescript/codepipeline-build-deploy/lib/codepipeline-build-deploy-stack.ts
+++ b/typescript/codepipeline-build-deploy/lib/codepipeline-build-deploy-stack.ts
@@ -1,0 +1,268 @@
+import * as cdk from "aws-cdk-lib";
+import * as codebuild from "aws-cdk-lib/aws-codebuild";
+import * as codecommit from "aws-cdk-lib/aws-codecommit";
+import * as codedeploy from "aws-cdk-lib/aws-codedeploy";
+import * as pipeline from "aws-cdk-lib/aws-codepipeline";
+import * as pipelineactions from "aws-cdk-lib/aws-codepipeline-actions";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as ecr from "aws-cdk-lib/aws-ecr";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as elb from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as assets from "aws-cdk-lib/aws-s3-assets";
+import * as custom from "aws-cdk-lib/custom-resources";
+import { Construct } from "constructs";
+import * as path from "path";
+
+export class CodepipelineBuildDeployStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // Creates an AWS CodeCommit repository
+    const codeRepo = new codecommit.Repository(this, "codeRepo", {
+      repositoryName: "simple-app-code-repo",
+      // Copies files from ./app directory to the repo as the initial commit
+      code: codecommit.Code.fromDirectory(
+        path.join(__dirname, "../app"),
+        "main"
+      ),
+    });
+
+    // Creates an Elastic Container Registry (ECR) image repository
+    const imageRepo = new ecr.Repository(this, "imageRepo");
+
+    // Creates a Task Definition for the ECS Fargate service
+    const fargateTaskDef = new ecs.FargateTaskDefinition(
+      this,
+      "FargateTaskDef"
+    );
+    fargateTaskDef.addContainer("container", {
+      containerName: "web",
+      image: ecs.ContainerImage.fromEcrRepository(imageRepo),
+      portMappings: [{ containerPort: 80 }],
+    });
+
+    // CodeBuild project that builds the Docker image
+    const buildImage = new codebuild.Project(this, "BuildImage", {
+      buildSpec: codebuild.BuildSpec.fromSourceFilename("buildspec.yaml"),
+      source: codebuild.Source.codeCommit({ repository: codeRepo }),
+      environment: {
+        privileged: true,
+        environmentVariables: {
+          AWS_ACCOUNT_ID: { value: process.env?.CDK_DEFAULT_ACCOUNT || "" },
+          REGION: { value: process.env?.CDK_DEFAULT_REGION || "" },
+          IMAGE_TAG: { value: "latest" },
+          IMAGE_REPO_NAME: { value: imageRepo.repositoryName },
+          REPOSITORY_URI: { value: imageRepo.repositoryUri },
+          TASK_DEFINITION_ARN: { value: fargateTaskDef.taskDefinitionArn },
+          TASK_ROLE_ARN: { value: fargateTaskDef.taskRole.roleArn },
+          EXECUTION_ROLE_ARN: { value: fargateTaskDef.executionRole?.roleArn },
+        },
+      },
+    });
+
+    // Grants CodeBuild project access to pull/push images from/to ECR repo
+    imageRepo.grantPullPush(buildImage);
+
+    // Lambda function that triggers CodeBuild image build project
+    const triggerCodeBuild = new lambda.Function(this, "BuildLambda", {
+      architecture: lambda.Architecture.ARM_64,
+      code: lambda.Code.fromAsset("./lambda"),
+      handler: "trigger-build.handler",
+      runtime: lambda.Runtime.NODEJS_18_X,
+      environment: {
+        REGION: process.env.CDK_DEFAULT_REGION!,
+        CODEBUILD_PROJECT_NAME: buildImage.projectName,
+      },
+      // Allows this Lambda function to trigger the buildImage CodeBuild project
+      initialPolicy: [
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ["codebuild:StartBuild"],
+          resources: [buildImage.projectArn],
+        }),
+      ],
+    });
+
+    // Triggers a Lambda function using AWS SDK
+    const triggerLambda = new custom.AwsCustomResource(
+      this,
+      "BuildLambdaTrigger",
+      {
+        installLatestAwsSdk: true,
+        policy: custom.AwsCustomResourcePolicy.fromStatements([
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ["lambda:InvokeFunction"],
+            resources: [triggerCodeBuild.functionArn],
+          }),
+        ]),
+        onCreate: {
+          service: "Lambda",
+          action: "invoke",
+          physicalResourceId: custom.PhysicalResourceId.of("id"),
+          parameters: {
+            FunctionName: triggerCodeBuild.functionName,
+            InvocationType: "Event",
+          },
+        },
+        onUpdate: {
+          service: "Lambda",
+          action: "invoke",
+          parameters: {
+            FunctionName: triggerCodeBuild.functionName,
+            InvocationType: "Event",
+          },
+        },
+      }
+    );
+
+    // Creates VPC for the ECS Cluster
+    const clusterVpc = new ec2.Vpc(this, "ClusterVpc", {
+      ipAddresses: ec2.IpAddresses.cidr("10.50.0.0/16"),
+    });
+
+    // Deploys the cluster VPC after the initial image build triggers
+    clusterVpc.node.addDependency(triggerLambda);
+
+    // Creates a new blue Target Group that routes traffic from the public Application Load Balancer (ALB) to the
+    // registered targets within the Target Group e.g. (EC2 instances, IP addresses, Lambda functions)
+    // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html
+    const targetGroupBlue = new elb.ApplicationTargetGroup(
+      this,
+      "BlueTargetGroup",
+      {
+        targetGroupName: "alb-blue-tg",
+        targetType: elb.TargetType.IP,
+        port: 80,
+        vpc: clusterVpc,
+      }
+    );
+
+    // Creates a new green Target Group
+    const targetGroupGreen = new elb.ApplicationTargetGroup(
+      this,
+      "GreenTargetGroup",
+      {
+        targetGroupName: "alb-green-tg",
+        targetType: elb.TargetType.IP,
+        port: 80,
+        vpc: clusterVpc,
+      }
+    );
+
+    // Creates a Security Group for the Application Load Balancer (ALB)
+    const albSg = new ec2.SecurityGroup(this, "SecurityGroup", {
+      vpc: clusterVpc,
+      allowAllOutbound: true,
+    });
+    albSg.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(80),
+      "Allows access on port 80/http",
+      false
+    );
+
+    // Creates a public ALB
+    const publicAlb = new elb.ApplicationLoadBalancer(this, "PublicAlb", {
+      vpc: clusterVpc,
+      internetFacing: true,
+      securityGroup: albSg,
+    });
+
+    // Adds a listener on port 80 to the ALB
+    const albListener = publicAlb.addListener("AlbListener80", {
+      open: false,
+      port: 80,
+      defaultTargetGroups: [targetGroupBlue],
+    });
+
+    // Creates an ECS Fargate service
+    const fargateService = new ecs.FargateService(this, "FargateService", {
+      desiredCount: 1,
+      serviceName: "fargate-frontend-service",
+      taskDefinition: fargateTaskDef,
+      cluster: new ecs.Cluster(this, "EcsCluster", {
+        enableFargateCapacityProviders: true,
+        vpc: clusterVpc,
+      }),
+      // Sets CodeDeploy as the deployment controller
+      deploymentController: {
+        type: ecs.DeploymentControllerType.CODE_DEPLOY,
+      },
+    });
+
+    // Adds the ECS Fargate service to the ALB target group
+    fargateService.attachToApplicationTargetGroup(targetGroupBlue);
+
+    // Creates new pipeline artifacts
+    const sourceArtifact = new pipeline.Artifact("SourceArtifact");
+    const buildArtifact = new pipeline.Artifact("BuildArtifact");
+
+    // Creates the source stage for CodePipeline
+    const sourceStage = {
+      stageName: "Source",
+      actions: [
+        new pipelineactions.CodeCommitSourceAction({
+          actionName: "CodeCommit",
+          branch: "main",
+          output: sourceArtifact,
+          repository: codeRepo,
+        }),
+      ],
+    };
+
+    // Creates the build stage for CodePipeline
+    const buildStage = {
+      stageName: "Build",
+      actions: [
+        new pipelineactions.CodeBuildAction({
+          actionName: "DockerBuildPush",
+          input: new pipeline.Artifact("SourceArtifact"),
+          project: buildImage,
+          outputs: [buildArtifact],
+        }),
+      ],
+    };
+
+    // Creates a new CodeDeploy Deployment Group
+    const deploymentGroup = new codedeploy.EcsDeploymentGroup(
+      this,
+      "CodeDeployGroup",
+      {
+        service: fargateService,
+        // Configurations for CodeDeploy Blue/Green deployments
+        blueGreenDeploymentConfig: {
+          listener: albListener,
+          blueTargetGroup: targetGroupBlue,
+          greenTargetGroup: targetGroupGreen,
+        },
+      }
+    );
+
+    // Creates the deploy stage for CodePipeline
+    const deployStage = {
+      stageName: "Deploy",
+      actions: [
+        new pipelineactions.CodeDeployEcsDeployAction({
+          actionName: "EcsFargateDeploy",
+          appSpecTemplateInput: buildArtifact,
+          taskDefinitionTemplateInput: buildArtifact,
+          deploymentGroup: deploymentGroup,
+        }),
+      ],
+    };
+
+    // Creates an AWS CodePipeline with source, build, and deploy stages
+    new pipeline.Pipeline(this, "BuildDeployPipeline", {
+      pipelineName: "ImageBuildDeployPipeline",
+      stages: [sourceStage, buildStage, deployStage],
+    });
+
+    // Outputs the ALB public endpoint
+    new cdk.CfnOutput(this, "PublicAlbEndpoint", {
+      value: "http://" + publicAlb.loadBalancerDnsName,
+    });
+  }
+}

--- a/typescript/codepipeline-build-deploy/package.json
+++ b/typescript/codepipeline-build-deploy/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "codepipeline-build-deploy",
+  "version": "0.1.0",
+  "bin": {
+    "codepipeline-build-deploy": "bin/codepipeline-build-deploy.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "test": "jest",
+    "cdk": "cdk"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.4.0",
+    "@types/node": "18.14.6",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.0.5",
+    "aws-cdk": "2.72.1",
+    "ts-node": "^10.9.1",
+    "typescript": "~4.9.5"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "2.72.1",
+    "constructs": "^10.0.0",
+    "source-map-support": "^0.5.21"
+  }
+}

--- a/typescript/codepipeline-build-deploy/test/codepipeline-build-deploy.test.ts
+++ b/typescript/codepipeline-build-deploy/test/codepipeline-build-deploy.test.ts
@@ -1,0 +1,50 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { CodepipelineBuildDeployStack } from "../lib/codepipeline-build-deploy-stack";
+
+// Checks if the ECS Deployment Controller is set to AWS CodeDeploy
+test("Deployment Controller Set", () => {
+  const app = new cdk.App();
+  const stack = new CodepipelineBuildDeployStack(app, "MyTestStack");
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties("AWS::ECS::Service", {
+    DeploymentController: {
+      Type: "CODE_DEPLOY",
+    },
+  });
+});
+
+// Checks if the ALB Security Group allows all traffic on port 80
+test("Security Group Port 80 Open", () => {
+  const app = new cdk.App();
+  const stack = new CodepipelineBuildDeployStack(app, "MyTestStack");
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties("AWS::EC2::SecurityGroup", {
+    SecurityGroupIngress: [
+      {
+        CidrIp: "0.0.0.0/0",
+        FromPort: 80,
+        IpProtocol: "tcp",
+        ToPort: 80,
+      },
+    ],
+  });
+});
+
+// Checks if public access to the S3 Bucket is disabled
+test("S3 Bucket Restricted", () => {
+  const app = new cdk.App();
+  const stack = new CodepipelineBuildDeployStack(app, "MyTestStack");
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties("AWS::S3::Bucket", {
+    PublicAccessBlockConfiguration: {
+      BlockPublicAcls: true,
+      BlockPublicPolicy: true,
+      IgnorePublicAcls: true,
+      RestrictPublicBuckets: true,
+    },
+  });
+});

--- a/typescript/codepipeline-build-deploy/tsconfig.json
+++ b/typescript/codepipeline-build-deploy/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": [
+      "es2020"
+    ],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "cdk.out"
+  ]
+}


### PR DESCRIPTION
# Overview
- Adds a new CDK TypeScript sample that demonstrates how to configure AWS CodePipeline with CodeCommit, CodeBuild, and CodeDeploy to build and deploy a Docker image to an ECS Fargate service.
- Contains a detailed README providing an overview, requirements, and deployment / testing guidance.
- Contains custom TypeScript tests to run before deploying.

---

Fixes #811 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
