### PR TITLE
Clean the python venv between project builds

### DIFF
--- a/scripts/build-python.sh
+++ b/scripts/build-python.sh
@@ -23,5 +23,9 @@ for requirements in $(find $scriptdir/../python -name requirements.txt  -not -pa
         pip install -r requirements.txt
 
         $scriptdir/synth.sh
+        
+        # It is critical that we clean up the pip venv before we build the next python project
+        # Otherwise, if anything gets pinned in a requirements.txt, you end up with a weird broken environment
+        pip freeze | xargs pip uninstall -y
     )
 done


### PR DESCRIPTION
We need to clean out the pip venv between project builds, or we inherit a mess if _anything_ is pinned at all.

Fixes #837

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
