### PR TITLE
chore: build failing with 'unable to resolve dependency tree'

### DIFF
--- a/typescript/s3-kms-cross-account-replication/package.json
+++ b/typescript/s3-kms-cross-account-replication/package.json
@@ -22,7 +22,7 @@
     "typescript": "~4.2.0"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.19.0",
+    "aws-cdk-lib": "^2.19.0",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }


### PR DESCRIPTION
The pipeline build is failing with `unable to resolve dependency tree`.

```
npm ERR! While resolving: s3-encrypted-cross-account-replication-cdk@0.1.0
npm ERR! Found: aws-cdk-lib@2.19.0
npm ERR! node_modules/aws-cdk-lib
npm ERR!   aws-cdk-lib@"2.19.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer aws-cdk-lib@"^2.78.0" from cdk-nag@2.27.3
npm ERR! node_modules/cdk-nag
npm ERR!   dev cdk-nag@"^2.0.0" from the root project
```



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
