### PR TITLE
fix: github set-output deprecated

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -31,31 +31,26 @@ jobs:
               case $path1 in
               csharp)
                 echo "C#"
-                echo "::set-output name=has_csharp_changes::true"
                 docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-csharp.sh $path2"
                 ;;
 
               go)
                 echo "Go"
-                echo "::set-output name=has_go_changes::true"
                 docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-go.sh $path2"
                 ;;
 
               java)
                 echo "Java"
-                echo "::set-output name=has_java_changes::true"
                 docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-java.sh $path2"
                 ;;
 
               python)
                 echo "Python"
-                echo "::set-output name=has_python_changes::true"
                 docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-python.sh $path2"
                 ;;
 
               typescript)
                 echo "TypeScript"
-                echo "::set-output name=has_typescript_changes::true"
                 docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-typescript.sh $path2"
                 ;;
 


### PR DESCRIPTION


Fixes github warning. Removed as those lines are not needed at this time.
> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
