### PR TITLE
feat(build): Parallelize the build step

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
       - name: Runs docker builds with JSII superchain
         run: |
           echo "::group::Build changes for ${{ matrix.language }}"
@@ -26,16 +24,18 @@ jobs:
 
           langfiles=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^$buildlang" )
           if [[ $langfiles == "" ]]; then 
-            return
+            echo "Nothing to do"
+            echo "::endgroup::"
+            exit 0
           fi
 
           echo "# Build summary for ${buildlang}" >> $GITHUB_STEP_SUMMARY
           buildpath=""
           # For each file that is in the changed set
-          for file in $(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^$buildlang" )
+          for file in $langfiles
           do
             # Split the path into the language, example, and 
-            IFS="/" read path1 path2 path3 <<< $file
+            IFS="/" read path1 path2 extra <<<"$file"
             if [[ $path1 != $buildlang ]]; then
               continue
             fi 
@@ -44,17 +44,12 @@ jobs:
             fi
             buildpath=$path1/$path2
             echo "Build Path ${buildpath}"
-            case $path1 in 
-            $buildlang)
-              docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-${buildlang}.sh $path2"
-              if [[ $? == 0 ]; then
-                echo "- :o: $buildpath" >> $GITHUB_STEP_SUMMARY
-              else
-                echo "- :x: $buildpath" >> $GITHUB_STEP_SUMMARY
-              fi 
-              ;;
-            *) ;;
-            esac
+            docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-${buildlang}.sh $path2"
+            if [[ $? == 0 ]]; then
+              echo "- :o: $buildpath" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "- :x: $buildpath" >> $GITHUB_STEP_SUMMARY
+            fi 
           done
           echo "::endgroup::"
 

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -20,6 +20,8 @@ jobs:
           fetch-depth: 2
       - name: Runs docker builds with JSII superchain
         run: |
+          echo "::group::Build changes for ${{ matrix.language }}"
+          echo ""
           buildlang="${{ matrix.language }}"
 
           langfiles=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^$buildlang" )
@@ -27,7 +29,6 @@ jobs:
             return
           fi
 
-          echo "::group::Build changes for ${buildlang}"
           echo "# Build summary for ${buildlang}" >> $GITHUB_STEP_SUMMARY
           buildpath=""
           # For each file that is in the changed set

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 2
       - name: Runs docker builds with JSII superchain
         run: |
-            buildlang=${{ matrix.language }}
+            buildlang="${{ matrix.language }}"
 
             langfiles=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^$buildlang" )
             if [[ $langfiles == "" ]]; then 

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -20,39 +20,40 @@ jobs:
           fetch-depth: 2
       - name: Runs docker builds with JSII superchain
         run: |
-            buildlang="${{ matrix.language }}"
+          buildlang="${{ matrix.language }}"
 
-            langfiles=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^$buildlang" )
-            if [[ $langfiles == "" ]]; then 
-              return
+          langfiles=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^$buildlang" )
+          if [[ $langfiles == "" ]]; then 
+            return
+          fi
+
+          echo "::group::Build changes for ${buildlang}"
+          echo "# Build summary for ${buildlang}" >> $GITHUB_STEP_SUMMARY
+          buildpath=""
+          # For each file that is in the changed set
+          for file in $(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^$buildlang" )
+          do
+            # Split the path into the language, example, and 
+            IFS="/" read path1 path2 path3 <<< $file
+            if [[ $path1 != $buildlang ]]; then
+              continue
+            fi 
+            if [[ "$buildpath" == "$path1/$path2" ]]; then
+              continue
             fi
-
-            echo "::group::Build changes for ${buildlang}"
-            echo "# Build summary for ${buildlang}" >> $GITHUB_STEP_SUMMARY
-            buildpath=""
-            # For each file that is in the changed set
-            for file in $(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^$buildlang" )
-            do
-              # Split the path into the language, example, and 
-              IFS="/" read path1 path2 path3 <<< $file
-              if [[ $path1 != $buildlang ]]; then
-                continue
+            buildpath=$path1/$path2
+            echo "Build Path ${buildpath}"
+            case $path1 in 
+            $buildlang)
+              docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-${buildlang}.sh $path2"
+              if [[ $? == 0 ]; then
+                echo "- :o: $buildpath" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "- :x: $buildpath" >> $GITHUB_STEP_SUMMARY
               fi 
-              if [[ "$buildpath" == "$path1/$path2" ]]; then
-                continue
-              fi
-              buildpath=$path1/$path2
-              echo "Build Path ${buildpath}"
-              case $path1 in 
-              $buildlang)
-                docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-${buildlang}.sh $path2"
-                if [[ $? == 0 ]; then
-                  echo "- :o: $buildpath" >> $GITHUB_STEP_SUMMARY
-                else
-                  echo "- :x: $buildpath" >> $GITHUB_STEP_SUMMARY
-                fi 
-                ;;
-              *) ;;
-              esac
-            done
-            echo "::endgroup::"
+              ;;
+            *) ;;
+            esac
+          done
+          echo "::endgroup::"
+

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 18
       - uses: actions/setup-java@v3
         with:
-          distribution: 'coretto'
+          distribution: 'corretto'
           java-version: '17'
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -14,6 +14,10 @@ jobs:
       matrix:
         language: ['csharp', 'go','python', 'java', 'typescript']
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
       - name: Runs docker builds with JSII superchain
         run: |
             buildlang=${{ matrix.language }}

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -3,11 +3,6 @@ name: Build Pull Request
 on: [pull_request]
 
 jobs:
-  checkout:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -16,41 +11,48 @@ jobs:
     steps:
       - name: Set up Go
         uses: actions/setup-go@v4
+        if: ${{ matrix.language == 'go' }}
         with:
           go-version: '1.20'
       - uses: actions/setup-node@v3
+        if: ${{matrix.language == 'typescript'}}
         with:
           node-version: 18
       - uses: actions/setup-java@v3
+        if: ${{matrix.language == 'java'}}
         with:
           distribution: 'corretto'
           java-version: '17'
       - uses: actions/setup-python@v4
+        if: ${{matrix.language == 'python'}}
         with:
           python-version: '3.10'
       - uses: actions/setup-dotnet@v3
+        if: ${{matrix.language == 'csharp'}}
         with:
           dotnet-version: 8
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Runs docker builds with JSII superchain
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v37
+        with:
+          files: ${{matrix.language}}/
+          files_ignore: "*.md"
+        
+      - name: Build changed files
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         run: |
           echo "::group::Build changes for ${{ matrix.language }}"
           echo ""
           buildlang="${{ matrix.language }}"
 
-          langfiles=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^$buildlang" )
-          if [[ $langfiles == "" ]]; then 
-            echo "Nothing to do"
-            touch success
-            echo "::endgroup::"
-            exit 0
-          fi
-
           echo "# Build summary for ${buildlang}" >> $GITHUB_STEP_SUMMARY
           buildpath=""
           # For each file that is in the changed set
-          for file in $langfiles
+          for file in ${{ steps.changed-files-specific.outputs.all_modified_files }}
           do
             # Split the path into the language, example, and 
             IFS="/" read path1 path2 extra <<<"$file"

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -3,91 +3,52 @@ name: Build Pull Request
 on: [pull_request]
 
 jobs:
-  check_file_changes:
-    name: Check file changes
-    outputs:
-      has_csharp_changes: ${{ steps.check_files.outputs.has_csharp_changes }}
-      has_go_changes: ${{ steps.check_files.outputs.has_go_changes }}
-      has_java_changes: ${{ steps.check_files.outputs.has_java_changes }}
-      has_python_changes: ${{ steps.check_files.outputs.has_python_changes }}
-      has_typescript_changes: ${{ steps.check_files.outputs.has_typescript_changes }}
-
+  checkout:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 2
-
-      - name: Check files
-        id: check_files
-        run: |
-          echo "========== categorization of changed files =========="
-          for file in $(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})
-          do
-            echo -n "$file => "
-
-            case $file in
-            csharp/*)
-              echo "C#"
-              echo "::set-output name=has_csharp_changes::true"
-              ;;
-
-            go/*)
-              echo "Go"
-              echo "::set-output name=has_go_changes::true"
-              ;;
-
-            java/*)
-              echo "Java"
-              echo "::set-output name=has_java_changes::true"
-              ;;
-
-            python/*)
-              echo "Python"
-              echo "::set-output name=has_python_changes::true"
-              ;;
-
-            typescript/*)
-              echo "TypeScript"
-              echo "::set-output name=has_typescript_changes::true"
-              ;;
-
-            *)
-              echo "<unmatched>"
-              ;;
-            esac
-          done
-
   build:
-    needs: check_file_changes
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: ['csharp', 'go','python', 'java', 'typescript']
     steps:
-    - uses: actions/checkout@v2
-    - name: Runs docker builds with JSII superchain
-      run: |
-        HAS_CSHARP_CHANGES="${{needs.check_file_changes.outputs.has_csharp_changes}}"
-        HAS_GO_CHANGES="${{needs.check_file_changes.outputs.has_go_changes}}"
-        HAS_JAVA_CHANGES="${{needs.check_file_changes.outputs.has_java_changes}}"
-        HAS_PYTHON_CHANGES="${{needs.check_file_changes.outputs.has_python_changes}}"
-        HAS_TYPESCRIPT_CHANGES="${{needs.check_file_changes.outputs.has_typescript_changes}}"
+      - name: Runs docker builds with JSII superchain
+        run: |
+            buildlang=${{ matrix.language }}
 
-        if [ "${HAS_CSHARP_CHANGES}" == "true" ]; then
-          docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-csharp.sh"
-        fi
+            langfiles =  $(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^$buildlang" )
+            if [[ $langfiles == "" ]]; then 
+              return
+            fi
 
-        if [ "${HAS_GO_CHANGES}" == "true" ]; then
-          docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-go.sh"
-        fi
-
-        if [ "${HAS_JAVA_CHANGES}" == "true" ]; then
-          docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-java.sh"
-        fi
-
-        if [ "${HAS_PYTHON_CHANGES}" == "true" ]; then
-          docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-python.sh"
-        fi
-
-        if [ "${HAS_TYPESCRIPT_CHANGES}" == "true" ]; then
-          docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-typescript.sh"
-        fi
+            echo "::group::Build changes for ${buildlang}"
+            echo "# Build summary for ${buildlang}" >> $GITHUB_STEP_SUMMARY
+            buildpath=""
+            # For each file that is in the changed set
+            for file in $(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^$buildlang" )
+            do
+              # Split the path into the language, example, and 
+              IFS="/" read path1 path2 path3 <<< $file
+              if [[ $path1 != $buildlang ]]; then
+                continue
+              fi 
+              if [[ "$buildpath" == "$path1/$path2" ]]; then
+                continue
+              fi
+              buildpath=$path1/$path2
+              echo "Build Path ${buildpath}"
+              case $path1 in 
+              $buildlang)
+                docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-${buildlang}.sh $path2"
+                if [[ $? == 0 ]; then
+                  echo "- :o: $buildpath" >> $GITHUB_STEP_SUMMARY
+                else
+                  echo "- :x: $buildpath" >> $GITHUB_STEP_SUMMARY
+                fi 
+                ;;
+              *) ;;
+              esac
+            done
+            echo "::endgroup::"

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -14,6 +14,23 @@ jobs:
       matrix:
         language: ['csharp', 'go','python', 'java', 'typescript']
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'coretto'
+          java-version: '17'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Runs docker builds with JSII superchain
@@ -27,7 +44,7 @@ jobs:
             echo "Nothing to do"
             touch success
             echo "::endgroup::"
-            exit
+            exit 0
           fi
 
           echo "# Build summary for ${buildlang}" >> $GITHUB_STEP_SUMMARY
@@ -45,7 +62,12 @@ jobs:
             fi
             buildpath=$path1/$path2
             echo "Build Path ${buildpath}"
-            docker run --rm --net=host -t -v $PWD:$PWD -w $PWD jsii/superchain:1-buster-slim-node18 /bin/bash -c "scripts/build-${buildlang}.sh $path2"
+            
+            # make sure there's nothing funny left over.
+            git clean -dfx
+
+            scripts/build-${buildlang}.sh $path2
+            
             if [[ $? == 0 ]]; then
               echo "- :o: $buildpath" >> $GITHUB_STEP_SUMMARY
             else

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
             buildlang=${{ matrix.language }}
 
-            langfiles =  $(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^$buildlang" )
+            langfiles=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^$buildlang" )
             if [[ $langfiles == "" ]]; then 
               return
             fi

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -25,8 +25,9 @@ jobs:
           langfiles=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep "^$buildlang" )
           if [[ $langfiles == "" ]]; then 
             echo "Nothing to do"
+            touch success
             echo "::endgroup::"
-            exit 0
+            exit
           fi
 
           echo "# Build summary for ${buildlang}" >> $GITHUB_STEP_SUMMARY

--- a/scripts/build-python.sh
+++ b/scripts/build-python.sh
@@ -2,7 +2,6 @@
 set -euxo pipefail
 scriptdir=$(cd $(dirname $0) && pwd)
 
-python3 -m venv /tmp/.venv
 
 # install CDK CLI from npm, so that npx can find it later
 cd $scriptdir/../python
@@ -19,13 +18,15 @@ for requirements in $(find $scriptdir/../python -name requirements.txt  -not -pa
         echo "Building project at $(dirname $requirements)"
         [[ ! -f DO_NOT_AUTOTEST ]] || exit 0
 
+        python3 -m venv /tmp/.venv
+
         source /tmp/.venv/bin/activate
         pip install -r requirements.txt
 
         $scriptdir/synth.sh
-        
         # It is critical that we clean up the pip venv before we build the next python project
         # Otherwise, if anything gets pinned in a requirements.txt, you end up with a weird broken environment
-        pip freeze | xargs pip uninstall -y
+        rm -rf /tmp/.venv
+
     )
 done


### PR DESCRIPTION
This uses the github matrix to run each language build in parallel.

it does so by filtering out the files that are only used by that language. 

In addition to parallelizing the builds, it gives each Python build its own venv, as Python is the only language that does not have local packages by default. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
