### PR TITLE
Update NodeJS runtime to use a non-deprecated version

### DIFF
--- a/typescript/cognito-api-lambda/index.ts
+++ b/typescript/cognito-api-lambda/index.ts
@@ -11,7 +11,7 @@ export class CognitoProtectedApi extends Stack {
     const helloWorldFunction = new Function(this, 'helloWorldFunction', {
       code: new AssetCode('src'),
       handler: 'helloworld.handler',
-      runtime: Runtime.NODEJS_12_X
+      runtime: Runtime.NODEJS_18_X
     });
 
     // Rest API backed by the helloWorldFunction


### PR DESCRIPTION
fixes #880.

<!--
Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Update the Lambda runtime to NodeJS 18 so it can be deployed.

Fixes #880

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
