### PR TITLE
remove duplicate visibility timeout, explicitly use Duration type

### DIFF
--- a/python/s3-sns-sqs-lambda-chain/s3_sns_sqs_lambda_chain/s3_sns_sqs_lambda_chain_stack.py
+++ b/python/s3-sns-sqs-lambda-chain/s3_sns_sqs_lambda_chain/s3_sns_sqs_lambda_chain_stack.py
@@ -35,9 +35,8 @@ class S3SnsSqsLambdaChainStack(Stack):
     upload_queue = sqs.Queue(
       self,
       id="sample_queue_id",
-      visibility_timeout=Duration.seconds(30),
       dead_letter_queue=dead_letter_queue,
-      visibility_timeout = LAMBDA_TIMEOUT * 6
+      visibility_timeout = Duration.seconds(LAMBDA_TIMEOUT * 6)
     )
 
     sqs_subscription = sns_subs.SqsSubscription(

--- a/python/s3-sns-sqs-lambda-chain/s3_sns_sqs_lambda_chain/s3_sns_sqs_lambda_chain_stack.py
+++ b/python/s3-sns-sqs-lambda-chain/s3_sns_sqs_lambda_chain/s3_sns_sqs_lambda_chain_stack.py
@@ -90,7 +90,7 @@ class S3SnsSqsLambdaChainStack(Stack):
                                 runtime=_lambda.Runtime.PYTHON_3_9,
                                 handler="lambda_function.handler",
                                 code=_lambda.Code.from_asset(path=lambda_dir),
-                                timeout = LAMBDA_TIMEOUT
+                                timeout = Duration.seconds(LAMBDA_TIMEOUT)
                                )
 
     # This binds the lambda to the SQS Queue


### PR DESCRIPTION
Fixes #884 

Duplicate parameter visibilityTimeout in  `python/s3-sns-sqs-lambda-chain/s3_sns_sqs_lambda_chain/s3_sns_sqs_lambda_chain_stack.py`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
