### PR TITLE
fix: update build-typescript.sh

### DIFF
--- a/scripts/build-typescript.sh
+++ b/scripts/build-typescript.sh
@@ -1,21 +1,39 @@
 #!/bin/bash
+#
+# This script is triggered from `build-pull-request.yml` with scripts/build-${buildlang}.sh PATH where PATH is the directory under `typescripts`.
+# Essentially, we cd into the project directory and install/build/test with yarn or npm followed by cdk synth.
+#
 set -euxo pipefail
 scriptdir=$(cd $(dirname $0) && pwd)
+projectname="$1"
 
-# Find and build all NPM projects
-for pkgJson in $(find typescript -name cdk.json | grep -v node_modules | sort); do
-    (
-        echo "=============================="
-        echo "building project: $(dirname $pkgJson)"
-        echo "=============================="
+echo "=============================="
+echo "building project: typescript/$projectname"
+echo "=============================="
 
-        cd $(dirname $pkgJson)
-        if [[ -f DO_NOT_AUTOTEST ]]; then exit 0; fi
+cd "typescript/$projectname";
 
-        rm -rf package-lock.json node_modules
-        npm install
-        npm run build
+# Check if yarn.lock exists
+if [ -f "yarn.lock" ]; then
+    echo "yarn.lock file found. Running 'yarn install'..."
+    yarn install --frozen-lockfile
+    yarn build
+    yarn test
+# Check if package-lock.json exists
+elif [ -f "package-lock.json" ]; then
+    echo "package-lock.json file found. Running 'npm ci'..."
+    npm ci
+    echo "Running 'npm build'..."
+    npm run build
+    echo "Running 'npm test'..."
+    npm test
+else
+    echo "No lock files found (yarn.lock or package-lock.json). Running 'yarn install'... "
+    yarn install
+    yarn build
+    yarn test
+fi
 
-        $scriptdir/synth.sh
-    )
-done
+$scriptdir/synth.sh
+
+exit 0


### PR DESCRIPTION
https://github.com/aws-samples/aws-cdk-examples/blob/2a494c4c30ff58bcc16b6e338cb704b16329e4aa/.github/workflows/build-pull-request.yml#L76

The `build-typescript.sh` should just build a single ts project rather than all projects

https://github.com/aws-samples/aws-cdk-examples/blob/2a494c4c30ff58bcc16b6e338cb704b16329e4aa/scripts/build-typescript.sh#L5

This PR fixes this issue and conditionally install the npm packages with yarn or npm command based on the availability of `yarn.lock` and `npm-lock.json`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
