### PR TITLE
fix: build-typescript.sh fails if package.json is not available 

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -59,8 +59,12 @@ jobs:
           # For each file that is in the changed set
           for file in ${{ steps.changed-files-specific.outputs.all_modified_files }}
           do
+            echo "processing ${file}"
             # Split the path into the language, example, and 
             IFS="/" read path1 path2 extra <<<"$file"
+            # $path1 is the language name e.g. 'typescript'
+            # $path2 is the fist directory under the language
+            # $extra is everything else after path2
             if [[ $path1 != $buildlang ]]; then
               continue
             fi 
@@ -73,7 +77,11 @@ jobs:
             # make sure there's nothing funny left over.
             git clean -dfx
 
-            scripts/build-${buildlang}.sh $path2
+            # we should pass both $path2 and $extra to the build script
+            # for example:
+            # scripts/build-typescript.sh ecs example-name/index.ts for typescripts/ecs/example/index.ts 
+            # scripts/build-typescript.sh example index.ts for typescripts/example/index.ts 
+            scripts/build-${buildlang}.sh $path2 $extra
             
             if [[ $? == 0 ]]; then
               echo "- :o: $buildpath" >> $GITHUB_STEP_SUMMARY
@@ -82,4 +90,3 @@ jobs:
             fi 
           done
           echo "::endgroup::"
-

--- a/scripts/build-typescript.sh
+++ b/scripts/build-typescript.sh
@@ -12,9 +12,12 @@ echo "=============================="
 echo "running build for typescript/${given_path}"
 echo "=============================="
 
-
 function build_it() {
   cd $1
+  if [ -f DO_NOT_AUTOTEST ]; then 
+    echo "found DO_NOT_AUTOTEST, skip it."
+    return
+  fi
   # Check if yarn.lock exists
   if [ -f "yarn.lock" ]; then
       echo "yarn.lock file found. Running 'yarn install'..."

--- a/scripts/build-typescript.sh
+++ b/scripts/build-typescript.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 #
-# This script is triggered from `build-pull-request.yml` with scripts/build-${buildlang}.sh PATH where PATH is the directory under `typescripts`.
-# for examples at typescript/example-name which comes with package.json, we just cd into example-name to install/build/test/synth.
-# for examples at typescript/<type-name>/example-name such as typescript/ecs/example-name, we cd into the next directory level under ecs to install/build/test/synth.
+# This script is triggered by `build-pull-request.yml` with `scripts/build-${buildlang}.sh $path2 $extra`.
+# We concat the arguments for a full given_path and traverse this given_path from top down to find the first package.json
+# and run yarn/npm install/build/test and cdk synth in that directory.
 #
 set -euxo pipefail
 scriptdir=$(cd $(dirname $0) && pwd)
-firstlevel="$1"
-extra="$2"
 given_path="${1}/${2}"
 
 echo "=============================="

--- a/scripts/build-typescript.sh
+++ b/scripts/build-typescript.sh
@@ -14,7 +14,7 @@ echo "=============================="
 cd "typescript/$projectname";
 
 # Skip if package.json is not available.
-# This happens in directory like typescript/ecs which containers sub-directories for examples.
+# This happens in directory like typescript/ecs which contains sub-directories examples.
 if [ ! -f "package.json" ]; then
     echo "package.json is not available. Skip package installation"
     exit 0

--- a/scripts/build-typescript.sh
+++ b/scripts/build-typescript.sh
@@ -1,46 +1,62 @@
 #!/bin/bash
 #
 # This script is triggered from `build-pull-request.yml` with scripts/build-${buildlang}.sh PATH where PATH is the directory under `typescripts`.
-# Essentially, we cd into the project directory and install/build/test with yarn or npm followed by cdk synth.
+# for examples at typescript/example-name which comes with package.json, we just cd into example-name to install/build/test/synth.
+# for examples at typescript/<type-name>/example-name such as typescript/ecs/example-name, we cd into the next directory level under ecs to install/build/test/synth.
 #
 set -euxo pipefail
 scriptdir=$(cd $(dirname $0) && pwd)
-projectname="$1"
+firstlevel="$1"
+extra="$2"
+given_path="${1}/${2}"
 
 echo "=============================="
-echo "building project: typescript/$projectname"
+echo "running build for typescript/${given_path}"
 echo "=============================="
 
-cd "typescript/$projectname";
 
-# Skip if package.json is not available.
-# This happens in directory like typescript/ecs which contains sub-directories examples.
-if [ ! -f "package.json" ]; then
-    echo "package.json is not available. Skip package installation"
+function build_it() {
+  cd $1
+  # Check if yarn.lock exists
+  if [ -f "yarn.lock" ]; then
+      echo "yarn.lock file found. Running 'yarn install'..."
+      yarn install --frozen-lockfile
+      yarn build
+      npm run --if-present test
+  # Check if package-lock.json exists
+  elif [ -f "package-lock.json" ]; then
+      echo "package-lock.json file found. Running 'npm ci'..."
+      npm ci
+      echo "Running 'npm build'..."
+      npm run build
+      echo "Running 'npm test'..."
+      npm run --if-present test
+  else
+      echo "No lock files found (yarn.lock or package-lock.json) but package.json available. Running 'yarn install'... "
+      yarn install
+      yarn build
+      npm run --if-present test
+  fi
+  # try cdk synth
+  $scriptdir/synth.sh
+}
+
+# Split the path into individual directories
+IFS='/' read -ra dirs <<< "$given_path"
+
+# Traverse the directories from top down and check for package.json
+current_path="typescript/"
+
+# Find the first package.json and build up from the directory of it.
+# For example:
+# We only build typescript/ecs/sample1 for typescript/ecs/sample1/src/index.ts
+for dir in "${dirs[@]}"; do
+  current_path="$current_path$dir"
+  if [ -f $current_path/package.json ]; then
+    build_it ${current_path}
     exit 0
-fi
-
-# Check if yarn.lock exists
-if [ -f "yarn.lock" ]; then
-    echo "yarn.lock file found. Running 'yarn install'..."
-    yarn install --frozen-lockfile
-    yarn build
-    yarn test
-# Check if package-lock.json exists
-elif [ -f "package-lock.json" ]; then
-    echo "package-lock.json file found. Running 'npm ci'..."
-    npm ci
-    echo "Running 'npm build'..."
-    npm run build
-    echo "Running 'npm test'..."
-    npm test
-else
-    echo "No lock files found (yarn.lock or package-lock.json). Running 'yarn install'... "
-    yarn install
-    yarn build
-    yarn test
-fi
-
-$scriptdir/synth.sh
+  fi
+  current_path="${current_path}/"
+done
 
 exit 0

--- a/scripts/build-typescript.sh
+++ b/scripts/build-typescript.sh
@@ -13,6 +13,13 @@ echo "=============================="
 
 cd "typescript/$projectname";
 
+# Skip if package.json is not available.
+# This happens in directory like typescript/ecs which containers sub-directories for examples.
+if [ ! -f "package.json" ]; then
+    echo "package.json is not available. Skip package installation"
+    exit 0
+fi
+
 # Check if yarn.lock exists
 if [ -f "yarn.lock" ]; then
     echo "yarn.lock file found. Running 'yarn install'..."


### PR DESCRIPTION
This PR fixes the build-typescript.sh that fails when `package.json` is not available such as `typescript/ecs/fargate-service-with-efs` and all changed files under it, we should proceed the install/build/test/synth at `typescript/ecs/fargate-service-with-efs` instead of `typescript/ecs` and check if `package.json` is available at `typescript/ecs/fargate-service-with-efs`.

To achieve this, we should pass full path of the changed files instead of just $part2 from here:
https://github.com/aws-samples/aws-cdk-examples/blob/ef6b8a428593aca854dadae808a7c4a4596e2fd2/.github/workflows/build-pull-request.yml#L76

And allow `build-typescript.sh` to traverse the given full path from top down to proceed the directory where the first package.json comes with.

With this processing logic we can handle:

1. examples at the first level under `typescript` e.g.  `typescripts/<example-name>/package.json`
2. examples at the second level under `typescript` e.g.  `typescripts/ecs/<example-name>/package.json`
3. examples at an arbitrary level under `typescript` e.g. `typescripts/ecs/category/usecase/<example-name>/package.json`
4. include DO_NOT_AUTOTEST check as described in #894 
Last but not least, if `test` is defined in `package.json` we should `npm test` it if present. This PR adds `npm run --if-present test` for that.

This PR implements and improves the workflow.

Have already tested in my own fork.

Fixes #892 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
