### PR TITLE
chore: Update Typescript to 5.1.6 and ts-node to 10.9.1

### DIFF
--- a/typescript/amplify-console-app/package.json
+++ b/typescript/amplify-console-app/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/api-cors-lambda-crud-dynamodb/package.json
+++ b/typescript/api-cors-lambda-crud-dynamodb/package.json
@@ -18,7 +18,7 @@
     "@types/node": "*",
     "aws-cdk": "*",
     "esbuild": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/api-websocket-lambda-dynamodb/package.json
+++ b/typescript/api-websocket-lambda-dynamodb/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/application-load-balancer/package.json
+++ b/typescript/application-load-balancer/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/appsync-graphql-dynamodb/package.json
+++ b/typescript/appsync-graphql-dynamodb/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/appsync-graphql-eventbridge/package.json
+++ b/typescript/appsync-graphql-eventbridge/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "10.17.0",
     "aws-cdk": "*",
-    "typescript": "~4.6.0",
+    "typescript": "~5.1.6",
     "ts-node": "^8.1.0"
   },
   "dependencies": {

--- a/typescript/aws-transfer-sftp-server/package.json
+++ b/typescript/aws-transfer-sftp-server/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
+    "test": "jest --config jest.config.ts",
     "cdk": "cdk"
   },
   "devDependencies": {
@@ -25,7 +25,7 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/aws-transfer-sftp-server/test/__snapshots__/aws-transfer-sftp-server.test.ts.snap
+++ b/typescript/aws-transfer-sftp-server/test/__snapshots__/aws-transfer-sftp-server.test.ts.snap
@@ -2,6 +2,29 @@
 
 exports[`SftpServerStack has required resources 1`] = `
 {
+  "Outputs": {
+    "SFTPServerEndpoint": {
+      "Description": "Server Endpoint",
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            {
+              "Fn::GetAtt": [
+                "SFTPServer",
+                "ServerId",
+              ],
+            },
+            ".server.transfer.",
+            {
+              "Ref": "AWS::Region",
+            },
+            ".amazonaws.com",
+          ],
+        ],
+      },
+    },
+  },
   "Parameters": {
     "BootstrapVersion": {
       "Default": "/cdk-bootstrap/hnb659fds/version",

--- a/typescript/classic-load-balancer/package.json
+++ b/typescript/classic-load-balancer/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/cloudwatch/evidently-client-side-evaluation-ecs/local-image/package.json
+++ b/typescript/cloudwatch/evidently-client-side-evaluation-ecs/local-image/package.json
@@ -15,6 +15,6 @@
   "devDependencies": {
     "@types/express": "^4.17.15",
     "@types/node": "^10.17.0",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   }
 }

--- a/typescript/cloudwatch/evidently-client-side-evaluation-ecs/package.json
+++ b/typescript/cloudwatch/evidently-client-side-evaluation-ecs/package.json
@@ -14,7 +14,7 @@
     "@types/express": "^4.17.15",
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "@aws-sdk/client-evidently": "^3.245.0",

--- a/typescript/cloudwatch/evidently-client-side-evaluation-lambda/package.json
+++ b/typescript/cloudwatch/evidently-client-side-evaluation-lambda/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^10.17.0",
     "aws-cdk": "^2.43.0",
     "jest": "^26.6.3",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.43.0",

--- a/typescript/codepipeline-build-deploy/package.json
+++ b/typescript/codepipeline-build-deploy/package.json
@@ -17,7 +17,7 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
-    "typescript": "~4.9.5"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "2.72.1",

--- a/typescript/cognito-api-lambda/package.json
+++ b/typescript/cognito-api-lambda/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/custom-logical-names/package.json
+++ b/typescript/custom-logical-names/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "aws-cdk": "*",
     "ts-node": "^8.1.0",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/custom-resource-provider/package.json
+++ b/typescript/custom-resource-provider/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
     "cdk": "cdk"
   },
   "devDependencies": {
@@ -15,10 +14,10 @@
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
     "jest": "^26.4.2",
-    "ts-jest": "^26.2.0",
+    "ts-jest": "^29.1.1",
     "aws-cdk": "*",
-    "ts-node": "^9.0.0",
-    "typescript": "~4.6.0"
+    "ts-node": "^10.9.1",
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/custom-resource/package.json
+++ b/typescript/custom-resource/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ddb/global-table-with-cmk/package.json
+++ b/typescript/ddb/global-table-with-cmk/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
     "cdk": "cdk"
   },
   "devDependencies": {
@@ -17,7 +16,7 @@
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "2.20.0",

--- a/typescript/ec2-ssm-local-zone/package.json
+++ b/typescript/ec2-ssm-local-zone/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
+    "test": "jest --config jest.config.ts",
     "cdk": "cdk"
   },
   "devDependencies": {
@@ -17,7 +17,7 @@
     "jest": "^29.3.1",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/cluster/package.json
+++ b/typescript/ecs/cluster/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/cross-stack-load-balancer/package.json
+++ b/typescript/ecs/cross-stack-load-balancer/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/ecs-network-load-balanced-service/package.json
+++ b/typescript/ecs/ecs-network-load-balanced-service/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/ecs-service-with-advanced-alb-config/package.json
+++ b/typescript/ecs/ecs-service-with-advanced-alb-config/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/ecs-service-with-logging/package.json
+++ b/typescript/ecs/ecs-service-with-logging/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/ecs-service-with-task-networking/package.json
+++ b/typescript/ecs/ecs-service-with-task-networking/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/ecs-service-with-task-placement/package.json
+++ b/typescript/ecs/ecs-service-with-task-placement/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/fargate-application-load-balanced-service/package.json
+++ b/typescript/ecs/fargate-application-load-balanced-service/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/fargate-service-with-auto-scaling/package.json
+++ b/typescript/ecs/fargate-service-with-auto-scaling/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/fargate-service-with-efs/package.json
+++ b/typescript/ecs/fargate-service-with-efs/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/fargate-service-with-local-image/package.json
+++ b/typescript/ecs/fargate-service-with-local-image/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/ecs/fargate-service-with-logging/package.json
+++ b/typescript/ecs/fargate-service-with-logging/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^8.10.38",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/eks/cluster/package.json
+++ b/typescript/eks/cluster/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/package.json
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/package.json
@@ -16,7 +16,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/node": "^8.10.40",
-    "typescript": "~4.6.0",
+    "typescript": "~5.1.6",
     "aws-cdk": "*"
   },
   "dependencies": {

--- a/typescript/elasticbeanstalk/elasticbeanstalk-environment/package.json
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-environment/package.json
@@ -16,7 +16,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/node": "^8.10.40",
-    "typescript": "~4.6.0",
+    "typescript": "~5.1.6",
     "aws-cdk": "*"
   },
   "dependencies": {

--- a/typescript/eventbridge-lambda/package.json
+++ b/typescript/eventbridge-lambda/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "cdk": "cdk",
-    "test": "jest --config=jest.config.js"
+    "cdk": "cdk"
   },
   "author": {
     "name": "Amazon Web Services",
@@ -20,7 +19,7 @@
     "@types/jest": "^26.0.24",
     "aws-cdk": "*",
     "jest": "^26.6.3",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/fsx-ad/package.json
+++ b/typescript/fsx-ad/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/http-proxy-apigateway/package.json
+++ b/typescript/http-proxy-apigateway/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^14.0.6",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/inspector2/package.json
+++ b/typescript/inspector2/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
+    "test": "jest --config jest.config.ts",
     "cdk": "cdk"
   },
   "devDependencies": {
@@ -19,7 +19,7 @@
     "jest": "^29.3.1",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
-    "typescript": "~4.9.3"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "2.62.0",

--- a/typescript/lambda-api-ci/package.json
+++ b/typescript/lambda-api-ci/package.json
@@ -8,7 +8,6 @@
     "build": "npm run prettier && tsc && npm run build-lambda",
     "build-lambda": "cd src && npm run build",
     "watch": "tsc -w",
-    "test": "jest",
     "cdk": "cdk",
     "prettier": "prettier --write '**/{bin,lib,src,tst}/*.ts'"
   },
@@ -23,8 +22,8 @@
     "@aws-cdk/aws-codepipeline-actions": "*",
     "@aws-cdk/aws-cloudformation": "*",
     "@types/node": "^13.7.0",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.6.0",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.1.6",
     "prettier": "^2.0.4"
   },
   "dependencies": {

--- a/typescript/lambda-api-ci/src/package.json
+++ b/typescript/lambda-api-ci/src/package.json
@@ -12,8 +12,8 @@
     "@types/node": "^13.7.0",
     "jest": "^24.9.0",
     "ts-jest": "^24.0.2",
-    "ts-node": "^8.1.0",
-    "typescript": "~4.6.0"
+    "ts-node": "^10.9.1",
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-sdk": "^2.617.0"

--- a/typescript/lambda-cloudwatch-dashboard/package.json
+++ b/typescript/lambda-cloudwatch-dashboard/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
     "cdk": "cdk"
   },
   "devDependencies": {
@@ -17,8 +16,8 @@
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "aws-cdk": "*",
-    "ts-node": "^9.0.0",
-    "typescript": "~4.6.0"
+    "ts-node": "^10.9.1",
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/lambda-cron/package.json
+++ b/typescript/lambda-cron/package.json
@@ -20,7 +20,7 @@
     "@types/jest": "^26.0.24",
     "aws-cdk": "*",
     "jest": "^26.6.3",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/lambda-layer/package.json
+++ b/typescript/lambda-layer/package.json
@@ -7,15 +7,14 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
     "cdk": "cdk"
   },
   "devDependencies": {
     "@aws-cdk/assert": "*",
     "@types/node": "10.17.27",
     "aws-cdk": "*",
-    "ts-node": "^9.0.0",
-    "typescript": "~4.6.0"
+    "ts-node": "^10.9.1",
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/lambda-manage-s3-event-notification/package.json
+++ b/typescript/lambda-manage-s3-event-notification/package.json
@@ -13,8 +13,8 @@
     "@aws-cdk/assert": "*",
     "@types/node": "^10.17.27",
     "aws-cdk": "*",
-    "ts-node": "^9.0.0",
-    "typescript": "~4.6.0"
+    "ts-node": "^10.9.1",
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/my-widget-service/package.json
+++ b/typescript/my-widget-service/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/neptune-with-vpc/package.json
+++ b/typescript/neptune-with-vpc/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
     "cdk": "cdk"
   },
   "dependencies": {
@@ -18,8 +17,8 @@
     "@types/node": "10.17.27",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
-    "ts-node": "^9.0.0",
-    "typescript": "~4.6.0",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.1.6",
     "aws-cdk": "*",
     "source-map-support": "^0.5.16"
   }

--- a/typescript/rds/aurora/package.json
+++ b/typescript/rds/aurora/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
     "cdk": "cdk"
   },
   "devDependencies": {
@@ -17,7 +16,7 @@
     "aws-cdk": "*",
     "ts-jest": "^26.2.0",
     "ts-node": "^10.9.1",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/rds/mysql/package.json
+++ b/typescript/rds/mysql/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
     "cdk": "cdk"
   },
   "devDependencies": {
@@ -17,9 +16,9 @@
     "ts-jest": "^26.2.0",
     "ts-node": "^10.9.1",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
-    "esModuleInterop": true,
+  "esModuleInterop": true,
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0",

--- a/typescript/rds/oracle/package.json
+++ b/typescript/rds/oracle/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
     "cdk": "cdk"
   },
   "devDependencies": {
@@ -17,7 +16,7 @@
     "aws-cdk": "*",
     "ts-jest": "^26.2.0",
     "ts-node": "^10.9.1",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/rekognition-lambda-s3-trigger/package.json
+++ b/typescript/rekognition-lambda-s3-trigger/package.json
@@ -7,14 +7,13 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
     "cdk": "cdk"
   },
   "devDependencies": {
     "@types/node": "10.17.27",
     "aws-cdk": "*",
     "ts-node": "^9.0.0",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "*",

--- a/typescript/resource-overrides/package.json
+++ b/typescript/resource-overrides/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "aws-cdk": "*",
     "@types/node": "^10.17.0",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/s3-kms-cross-account-replication/jest.config.ts
+++ b/typescript/s3-kms-cross-account-replication/jest.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  }
+};
+export default config;

--- a/typescript/s3-kms-cross-account-replication/package.json
+++ b/typescript/s3-kms-cross-account-replication/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
+    "test": "jest --config jest.config.ts",
     "cdk": "cdk"
   },
   "devDependencies": {
@@ -15,11 +15,11 @@
     "@types/node": "10.17.27",
     "aws-cdk": "^2.79.1",
     "cdk-nag": "^2.0.0",
-    "jest": "^26.4.2",
+    "jest": "^29.6.2",
     "prettier": "2.6.2",
-    "ts-jest": "^26.2.0",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.79.1",

--- a/typescript/s3-object-lambda/package.json
+++ b/typescript/s3-object-lambda/package.json
@@ -7,14 +7,13 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
     "cdk": "cdk"
   },
   "devDependencies": {
     "@types/node": "18.11.17",
     "aws-cdk": "*",
     "ts-node": "^10.9.1",
-    "typescript": "~4.9.4"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/servicecatalog/portfolio-with-ec2-product/lib/portfolio-with-ec2-product.ts
+++ b/typescript/servicecatalog/portfolio-with-ec2-product/lib/portfolio-with-ec2-product.ts
@@ -1,7 +1,6 @@
 import { Construct } from 'constructs';
 import { Stack, StackProps, Fn, CfnOutput, CfnParameter } from 'aws-cdk-lib';
-import { aws_iam as iam, aws_ec2 as ec2, aws_sns as sns } from 'aws-cdk-lib';
-import * as sc from '@aws-cdk/aws-servicecatalog-alpha';
+import { aws_iam as iam, aws_ec2 as ec2, aws_sns as sns, aws_servicecatalog as sc } from 'aws-cdk-lib';
 
 class Ec2CdkProductStack extends sc.ProductStack {
   constructor(scope: Construct, id: string) {

--- a/typescript/servicecatalog/portfolio-with-ec2-product/package.json
+++ b/typescript/servicecatalog/portfolio-with-ec2-product/package.json
@@ -7,21 +7,19 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
     "cdk": "cdk"
   },
   "devDependencies": {
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "jest": "^26.4.2",
-    "ts-jest": "^26.2.0",
+    "jest": "^29.6.2",
+    "ts-jest": "^29.1.1",
     "aws-cdk": "*",
-    "ts-node": "^9.0.0",
-    "typescript": "~4.6.0"
+    "ts-node": "^10.9.1",
+    "typescript": "~5.1.6"
   },
   "dependencies": {
-    "aws-cdk-lib": "*",
-    "constructs": "*",
-    "@aws-cdk/aws-servicecatalog-alpha": "*"
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/static-site/package.json
+++ b/typescript/static-site/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/node": "^10.17.0",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/stepfunctions-job-poller/package.json
+++ b/typescript/stepfunctions-job-poller/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/node": "*",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",

--- a/typescript/waf/package.json
+++ b/typescript/waf/package.json
@@ -7,21 +7,20 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest",
     "cdk": "cdk"
   },
   "devDependencies": {
     "@types/jest": "^26.0.10",
     "@types/node": "*",
     "aws-cdk": "*",
-    "typescript": "~4.6.0"
+    "typescript": "~5.1.6"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
-    "ts-node": "^9.0.0",
+    "ts-node": "^10.9.1",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
Update Typescript to 5.1.6 and ts-node to 10.9.1

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
