### PR TITLE
Fixing KeyError in CustomResource lambda

### DIFF
--- a/typescript/custom-resource/custom-resource-handler.py
+++ b/typescript/custom-resource/custom-resource-handler.py
@@ -14,7 +14,7 @@ def main(event, context):
             raise RuntimeError('Create failure requested')
 
         # Do the thing
-        message = event['ResourceProperties']['Message']
+        message = event['ResourceProperties']['message']
         attributes = {
             'Response': 'You said "%s"' % message
         }


### PR DESCRIPTION
Fixing the property name in the input event JSON as the `custom-resource-handler.py` lambda throws the following error:

```
[ERROR]	2023-10-05T16:16:39.193Z	xxxx-xxx-xxx-xxx-xxxx	'Message'
Traceback (most recent call last):
  File "/var/task/index.py", line 17, in main
    message = event['ResourceProperties']['Message']
KeyError: 'Message'
```

I have preferred not changing the interface (maintaining the camel case), but changing the dict directly as it was just one correction VS two. Let me know.

BR
Luca

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
