### PR TITLE
Updated load balancer's instance to latest gen

### DIFF
--- a/typescript/application-load-balancer/README.md
+++ b/typescript/application-load-balancer/README.md
@@ -11,7 +11,7 @@
 ---
 <!--END STABILITY BANNER-->
 
-This example creates an AutoScalingGroup (containing a Micro-T2 EC2 machine running the Amazon Linux AMI), and an ApplicationLoadBalancer inside a shared VPC. It hooks up an open listener from the Load Balancer to the Scaling Group to indicate how many targets to balance between.
+This example creates an AutoScalingGroup (containing a AWS Graviton2 Micro-T4G EC2 machine running the Amazon Linux 2023 AMI), and an ApplicationLoadBalancer inside a shared VPC. It hooks up an open listener from the Load Balancer to the Scaling Group to indicate how many targets to balance between.
 
 For more info on using Auto Scaling with Load Balancing see the AutoScaling guide [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-load-balancer.html).
 

--- a/typescript/application-load-balancer/index.ts
+++ b/typescript/application-load-balancer/index.ts
@@ -12,8 +12,10 @@ class LoadBalancerStack extends cdk.Stack {
 
     const asg = new autoscaling.AutoScalingGroup(this, 'ASG', {
       vpc,
-      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO),
-      machineImage: new ec2.AmazonLinuxImage(),
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE4_GRAVITON, ec2.InstanceSize.MICRO),
+      machineImage: ec2.MachineImage.latestAmazonLinux2023({
+        cpuType: ec2.AmazonLinuxCpuType.ARM_64
+      })
     });
 
     const lb = new elbv2.ApplicationLoadBalancer(this, 'LB', {

--- a/typescript/classic-load-balancer/README.md
+++ b/typescript/classic-load-balancer/README.md
@@ -11,7 +11,7 @@
 ---
 <!--END STABILITY BANNER-->
 
-This example creates an AutoScalingGroup (containing a Micro-T2 EC2 machine running the Amazon Linux AMI), and a ClassicLoadBalancer inside a shared VPC. It hooks up an open listener from the Load Balancer to the Scaling Group to indicate how many targets to balance between.
+This example creates an AutoScalingGroup (containing a AWS Graviton2 Micro-T4G EC2 machine running the Amazon Linux 2023 AMI), and a ClassicLoadBalancer inside a shared VPC. It hooks up an open listener from the Load Balancer to the Scaling Group to indicate how many targets to balance between.
 
 For more info on using Auto Scaling with Load Balancing see the AutoScaling guide [here](https://docs.aws.amazon.com/autoscaling/ec2/userguide/autoscaling-load-balancer.html).
 

--- a/typescript/classic-load-balancer/index.ts
+++ b/typescript/classic-load-balancer/index.ts
@@ -12,8 +12,10 @@ class LoadBalancerStack extends cdk.Stack {
 
     const asg = new autoscaling.AutoScalingGroup(this, 'ASG', {
       vpc,
-      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO),
-      machineImage: new ec2.AmazonLinuxImage(),
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE4_GRAVITON, ec2.InstanceSize.MICRO),
+      machineImage: ec2.MachineImage.latestAmazonLinux2023({
+        cpuType: ec2.AmazonLinuxCpuType.ARM_64
+      })
     });
 
     const lb = new elb.LoadBalancer(this, 'LB', {


### PR DESCRIPTION
Updated Classic and Application Load Balancer's instance family to latest 4th Generation of Burstable instances
Updated Classic and Application Load Balancer's AMI to Amazon Linux 2023 from EOL Amazon Linux

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
