### PR TITLE
Fix(ts): Fix aws-cdk-lib versioning.

### DIFF
--- a/typescript/amplify-console-app/cdk.json
+++ b/typescript/amplify-console-app/cdk.json
@@ -1,3 +1,3 @@
 {
-    "app": "node index"
+    "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/amplify-console-app/package.json
+++ b/typescript/amplify-console-app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "appsync-graphql-dynamodb",
+  "name": "amplify-console-app",
   "version": "1.0.0",
   "description": "Running an Amplify Console App static site from a GitHub repository, with a trigger on the master branch",
   "private": true,
@@ -14,12 +14,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/api-cors-lambda-crud-dynamodb/cdk.json
+++ b/typescript/api-cors-lambda-crud-dynamodb/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/api-cors-lambda-crud-dynamodb/lambdas/package.json
+++ b/typescript/api-cors-lambda-crud-dynamodb/lambdas/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "*",
+    "@types/node": "20.6.3",
     "@types/uuid": "*"
   },
   "dependencies": {

--- a/typescript/api-cors-lambda-crud-dynamodb/package.json
+++ b/typescript/api-cors-lambda-crud-dynamodb/package.json
@@ -15,13 +15,13 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "*",
-    "aws-cdk": "*",
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
     "esbuild": "*",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/api-websocket-lambda-dynamodb/cdk.json
+++ b/typescript/api-websocket-lambda-dynamodb/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/api-websocket-lambda-dynamodb/package.json
+++ b/typescript/api-websocket-lambda-dynamodb/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^10.17.0",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/application-load-balancer/cdk.json
+++ b/typescript/application-load-balancer/cdk.json
@@ -1,3 +1,3 @@
 {
-    "app": "node index"
+    "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/application-load-balancer/package.json
+++ b/typescript/application-load-balancer/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^10.17.0",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/aws-transfer-sftp-server/cdk.json
+++ b/typescript/aws-transfer-sftp-server/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "npx node -r ts-node/register main.ts",
+  "app": "npx ts-node --prefer-ts-exts main.ts",
   "watch": {
     "include": [
       "**"

--- a/typescript/aws-transfer-sftp-server/package.json
+++ b/typescript/aws-transfer-sftp-server/package.json
@@ -19,16 +19,16 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.2",
-    "@types/node": "18.15.11",
-    "aws-cdk": "*",
-    "jest": "^29.5.0",
-    "ts-jest": "^29.1.0",
+    "@types/jest": "^29.5.5",
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/backup-s3/package.json
+++ b/typescript/backup-s3/package.json
@@ -10,17 +10,17 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.10",
-    "@types/node": "10.17.27",
-    "jest": "^26.4.2",
-    "ts-jest": "^26.2.0",
-    "aws-cdk": "2.80.0",
-    "ts-node": "^9.0.0",
-    "typescript": "~4.6.0"
+    "@types/jest": "^29.5.5",
+    "@types/node": "20.6.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "aws-cdk": "2.99.1",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.80.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.21"
   }
 }

--- a/typescript/classic-load-balancer/cdk.json
+++ b/typescript/classic-load-balancer/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/classic-load-balancer/package.json
+++ b/typescript/classic-load-balancer/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^10.17.0",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/codepipeline-build-deploy/package.json
+++ b/typescript/codepipeline-build-deploy/package.json
@@ -11,16 +11,16 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/jest": "^29.4.0",
-    "@types/node": "18.14.6",
-    "aws-cdk": "2.72.1",
-    "jest": "^29.5.0",
-    "ts-jest": "^29.0.5",
+    "@types/jest": "^29.5.5",
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.80.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0",
     "jest-junit": "^16.0.0",
     "source-map-support": "^0.5.21"

--- a/typescript/cognito-api-lambda/cdk.json
+++ b/typescript/cognito-api-lambda/cdk.json
@@ -1,3 +1,3 @@
 {
-    "app": "node index"
+    "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/cognito-api-lambda/package.json
+++ b/typescript/cognito-api-lambda/package.json
@@ -13,12 +13,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^10.17.0",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/custom-logical-names/cdk.json
+++ b/typescript/custom-logical-names/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "npx ts-node index.ts"
+  "app": "npx ts-node --prefer-ts-exts index.ts"
 }

--- a/typescript/custom-logical-names/package.json
+++ b/typescript/custom-logical-names/package.json
@@ -10,13 +10,13 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "aws-cdk": "*",
-    "ts-node": "^8.1.0",
-    "typescript": "~5.1.6"
+    "aws-cdk": "2.99.1",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0",
-    "source-map-support": "^0.5.9"
+    "source-map-support": "^0.5.21"
   }
 }

--- a/typescript/custom-resource-provider/cdk.json
+++ b/typescript/custom-resource-provider/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/custom-resource-provider/package.json
+++ b/typescript/custom-resource-provider/package.json
@@ -10,18 +10,17 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "*",
-    "@types/jest": "^26.0.10",
-    "@types/node": "10.17.27",
-    "jest": "^26.4.2",
+    "@types/jest": "^29.5.5",
+    "@types/node": "20.6.3",
+    "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
-    "aws-cdk": "*",
+    "aws-cdk": "2.99.1",
     "ts-node": "^10.9.1",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.21"
   }
 }

--- a/typescript/custom-resource/cdk.json
+++ b/typescript/custom-resource/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/custom-resource/package.json
+++ b/typescript/custom-resource/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^10.17.0",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/ec2-ssm-local-zone/cdk.json
+++ b/typescript/ec2-ssm-local-zone/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "npx node -r ts-node/register main.ts",
+  "app": "npx ts-node --prefer-ts-exts main.ts",
   "watch": {
     "include": [
       "**"

--- a/typescript/ec2-ssm-local-zone/package.json
+++ b/typescript/ec2-ssm-local-zone/package.json
@@ -11,16 +11,16 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/jest": "^29.2.4",
-    "@types/node": "18.11.15",
-    "aws-cdk": "*",
-    "jest": "^29.3.1",
-    "ts-jest": "^29.0.3",
+    "@types/jest": "^29.5.5",
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/cluster/cdk.json
+++ b/typescript/ecs/cluster/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/ecs/cluster/package.json
+++ b/typescript/ecs/cluster/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/cross-stack-load-balancer/cdk.json
+++ b/typescript/ecs/cross-stack-load-balancer/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/ecs/cross-stack-load-balancer/package.json
+++ b/typescript/ecs/cross-stack-load-balancer/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/ecs-network-load-balanced-service/cdk.json
+++ b/typescript/ecs/ecs-network-load-balanced-service/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/ecs/ecs-network-load-balanced-service/package.json
+++ b/typescript/ecs/ecs-network-load-balanced-service/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/ecs-service-with-advanced-alb-config/cdk.json
+++ b/typescript/ecs/ecs-service-with-advanced-alb-config/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/ecs/ecs-service-with-advanced-alb-config/package.json
+++ b/typescript/ecs/ecs-service-with-advanced-alb-config/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/ecs-service-with-logging/cdk.json
+++ b/typescript/ecs/ecs-service-with-logging/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/ecs/ecs-service-with-logging/package.json
+++ b/typescript/ecs/ecs-service-with-logging/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/ecs-service-with-task-networking/cdk.json
+++ b/typescript/ecs/ecs-service-with-task-networking/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/ecs/ecs-service-with-task-networking/package.json
+++ b/typescript/ecs/ecs-service-with-task-networking/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/ecs-service-with-task-placement/cdk.json
+++ b/typescript/ecs/ecs-service-with-task-placement/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/ecs/ecs-service-with-task-placement/package.json
+++ b/typescript/ecs/ecs-service-with-task-placement/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/fargate-application-load-balanced-service/cdk.json
+++ b/typescript/ecs/fargate-application-load-balanced-service/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/ecs/fargate-application-load-balanced-service/package.json
+++ b/typescript/ecs/fargate-application-load-balanced-service/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/fargate-service-with-auto-scaling/cdk.json
+++ b/typescript/ecs/fargate-service-with-auto-scaling/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/ecs/fargate-service-with-auto-scaling/package.json
+++ b/typescript/ecs/fargate-service-with-auto-scaling/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/fargate-service-with-efs/package.json
+++ b/typescript/ecs/fargate-service-with-efs/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/fargate-service-with-local-image/cdk.json
+++ b/typescript/ecs/fargate-service-with-local-image/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/ecs/fargate-service-with-local-image/package.json
+++ b/typescript/ecs/fargate-service-with-local-image/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/ecs/fargate-service-with-logging/cdk.json
+++ b/typescript/ecs/fargate-service-with-logging/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/ecs/fargate-service-with-logging/package.json
+++ b/typescript/ecs/fargate-service-with-logging/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.38",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/cdk.json
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/cdk.json
@@ -4,5 +4,5 @@
     "green_env": "green",
     "app_name": "myapp"
   },
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/package.json
+++ b/typescript/elasticbeanstalk/elasticbeanstalk-bg-pipeline/package.json
@@ -15,13 +15,13 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^8.10.40",
-    "typescript": "~5.1.6",
-    "aws-cdk": "*"
+    "@types/node": "20.6.3",
+    "typescript": "~5.2.2",
+    "aws-cdk": "2.99.1"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0",
-    "source-map-support": "^0.5.9"
+    "source-map-support": "^0.5.21"
   }
 }

--- a/typescript/eventbridge-lambda/cdk.json
+++ b/typescript/eventbridge-lambda/cdk.json
@@ -1,3 +1,3 @@
 {
-    "app": "node index"
+    "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/eventbridge-lambda/package.json
+++ b/typescript/eventbridge-lambda/package.json
@@ -15,14 +15,14 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^10.17.0",
-    "@types/jest": "^26.0.24",
-    "aws-cdk": "*",
-    "jest": "^26.6.3",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "@types/jest": "^29.5.5",
+    "aws-cdk": "2.99.1",
+    "jest": "^29.7.0",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/fsx-ad/cdk.json
+++ b/typescript/fsx-ad/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/fsx-ad/package.json
+++ b/typescript/fsx-ad/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^10.17.0",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/http-proxy-apigateway/cdk.json
+++ b/typescript/http-proxy-apigateway/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/http-proxy-apigateway/package.json
+++ b/typescript/http-proxy-apigateway/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^14.0.6",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/inspector2/package.json
+++ b/typescript/inspector2/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ec2-ssm-local-zone",
+  "name": "inspect2",
   "version": "0.1.0",
   "bin": {
     "ec2-ssm-local-zone": "ts-node bin/main.ts"
@@ -13,16 +13,16 @@
   "devDependencies": {
     "@aws-sdk/client-inspector2": "^3.258.0",
     "@types/aws-lambda": "^8.10.109",
-    "@types/jest": "^29.2.4",
-    "@types/node": "18.11.15",
+    "@types/jest": "^29.5.5",
+    "@types/node": "20.6.3",
     "esbuild": "^0.17.4",
-    "jest": "^29.3.1",
-    "ts-jest": "^29.0.5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.80.0",
-    "constructs": "^10.1.190"
+    "aws-cdk-lib": "2.99.1",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/inspector2/test/__snapshots__/inspector2-enable-delegated-admin-account-resource.test.ts.snap
+++ b/typescript/inspector2/test/__snapshots__/inspector2-enable-delegated-admin-account-resource.test.ts.snap
@@ -2,109 +2,6 @@
 
 exports[`Inspector2EnableDelegatedAdminAccountResource creates required resources 1`] = `
 {
-  "Mappings": {
-    "DefaultCrNodeVersionMap": {
-      "af-south-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-east-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-northeast-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-northeast-2": {
-        "value": "nodejs16.x",
-      },
-      "ap-northeast-3": {
-        "value": "nodejs16.x",
-      },
-      "ap-south-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-south-2": {
-        "value": "nodejs16.x",
-      },
-      "ap-southeast-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-southeast-2": {
-        "value": "nodejs16.x",
-      },
-      "ap-southeast-3": {
-        "value": "nodejs16.x",
-      },
-      "ca-central-1": {
-        "value": "nodejs16.x",
-      },
-      "cn-north-1": {
-        "value": "nodejs16.x",
-      },
-      "cn-northwest-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-central-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-central-2": {
-        "value": "nodejs16.x",
-      },
-      "eu-north-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-south-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-south-2": {
-        "value": "nodejs16.x",
-      },
-      "eu-west-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-west-2": {
-        "value": "nodejs16.x",
-      },
-      "eu-west-3": {
-        "value": "nodejs16.x",
-      },
-      "me-central-1": {
-        "value": "nodejs16.x",
-      },
-      "me-south-1": {
-        "value": "nodejs16.x",
-      },
-      "sa-east-1": {
-        "value": "nodejs16.x",
-      },
-      "us-east-1": {
-        "value": "nodejs16.x",
-      },
-      "us-east-2": {
-        "value": "nodejs16.x",
-      },
-      "us-gov-east-1": {
-        "value": "nodejs16.x",
-      },
-      "us-gov-west-1": {
-        "value": "nodejs16.x",
-      },
-      "us-iso-east-1": {
-        "value": "nodejs14.x",
-      },
-      "us-iso-west-1": {
-        "value": "nodejs14.x",
-      },
-      "us-isob-east-1": {
-        "value": "nodejs14.x",
-      },
-      "us-west-1": {
-        "value": "nodejs16.x",
-      },
-      "us-west-2": {
-        "value": "nodejs16.x",
-      },
-    },
-  },
   "Parameters": {
     "BootstrapVersion": {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -122,7 +19,7 @@ exports[`Inspector2EnableDelegatedAdminAccountResource creates required resource
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "bb459fac5f6b4b052aac9803443226d161a5cfe96f4648b21f9e4912c698bf30.zip",
+          "S3Key": "a524840909b73225567052baa4f50f81f3f2444186a5011d26e441ac674adb81.zip",
         },
         "Handler": "index.handler",
         "Role": {
@@ -131,15 +28,7 @@ exports[`Inspector2EnableDelegatedAdminAccountResource creates required resource
             "Arn",
           ],
         },
-        "Runtime": {
-          "Fn::FindInMap": [
-            "DefaultCrNodeVersionMap",
-            {
-              "Ref": "AWS::Region",
-            },
-            "value",
-          ],
-        },
+        "Runtime": "nodejs18.x",
         "Timeout": 120,
       },
       "Type": "AWS::Lambda::Function",

--- a/typescript/inspector2/test/__snapshots__/inspector2-enable-resources.test.ts.snap
+++ b/typescript/inspector2/test/__snapshots__/inspector2-enable-resources.test.ts.snap
@@ -2,109 +2,6 @@
 
 exports[`Inspector2EnableResource creates required resources 1`] = `
 {
-  "Mappings": {
-    "DefaultCrNodeVersionMap": {
-      "af-south-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-east-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-northeast-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-northeast-2": {
-        "value": "nodejs16.x",
-      },
-      "ap-northeast-3": {
-        "value": "nodejs16.x",
-      },
-      "ap-south-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-south-2": {
-        "value": "nodejs16.x",
-      },
-      "ap-southeast-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-southeast-2": {
-        "value": "nodejs16.x",
-      },
-      "ap-southeast-3": {
-        "value": "nodejs16.x",
-      },
-      "ca-central-1": {
-        "value": "nodejs16.x",
-      },
-      "cn-north-1": {
-        "value": "nodejs16.x",
-      },
-      "cn-northwest-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-central-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-central-2": {
-        "value": "nodejs16.x",
-      },
-      "eu-north-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-south-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-south-2": {
-        "value": "nodejs16.x",
-      },
-      "eu-west-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-west-2": {
-        "value": "nodejs16.x",
-      },
-      "eu-west-3": {
-        "value": "nodejs16.x",
-      },
-      "me-central-1": {
-        "value": "nodejs16.x",
-      },
-      "me-south-1": {
-        "value": "nodejs16.x",
-      },
-      "sa-east-1": {
-        "value": "nodejs16.x",
-      },
-      "us-east-1": {
-        "value": "nodejs16.x",
-      },
-      "us-east-2": {
-        "value": "nodejs16.x",
-      },
-      "us-gov-east-1": {
-        "value": "nodejs16.x",
-      },
-      "us-gov-west-1": {
-        "value": "nodejs16.x",
-      },
-      "us-iso-east-1": {
-        "value": "nodejs14.x",
-      },
-      "us-iso-west-1": {
-        "value": "nodejs14.x",
-      },
-      "us-isob-east-1": {
-        "value": "nodejs14.x",
-      },
-      "us-west-1": {
-        "value": "nodejs16.x",
-      },
-      "us-west-2": {
-        "value": "nodejs16.x",
-      },
-    },
-  },
   "Parameters": {
     "BootstrapVersion": {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -122,7 +19,7 @@ exports[`Inspector2EnableResource creates required resources 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "bb459fac5f6b4b052aac9803443226d161a5cfe96f4648b21f9e4912c698bf30.zip",
+          "S3Key": "a524840909b73225567052baa4f50f81f3f2444186a5011d26e441ac674adb81.zip",
         },
         "Handler": "index.handler",
         "Role": {
@@ -131,15 +28,7 @@ exports[`Inspector2EnableResource creates required resources 1`] = `
             "Arn",
           ],
         },
-        "Runtime": {
-          "Fn::FindInMap": [
-            "DefaultCrNodeVersionMap",
-            {
-              "Ref": "AWS::Region",
-            },
-            "value",
-          ],
-        },
+        "Runtime": "nodejs18.x",
         "Timeout": 120,
       },
       "Type": "AWS::Lambda::Function",
@@ -236,7 +125,7 @@ exports[`Inspector2EnableResource creates required resources 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5fa1330271b8967d9254ba2d4a07144f8acefe8b77e6d6bba38261373a50d5f8.zip",
+          "S3Key": "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555.zip",
         },
         "Handler": "index.handler",
         "Role": {
@@ -245,15 +134,8 @@ exports[`Inspector2EnableResource creates required resources 1`] = `
             "Arn",
           ],
         },
-        "Runtime": {
-          "Fn::FindInMap": [
-            "DefaultCrNodeVersionMap",
-            {
-              "Ref": "AWS::Region",
-            },
-            "value",
-          ],
-        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
     },

--- a/typescript/inspector2/test/__snapshots__/inspector2-monitoring-resource.test.ts.snap
+++ b/typescript/inspector2/test/__snapshots__/inspector2-monitoring-resource.test.ts.snap
@@ -2,109 +2,6 @@
 
 exports[`Inspector2MonitoringResource creates required resources 1`] = `
 {
-  "Mappings": {
-    "DefaultCrNodeVersionMap": {
-      "af-south-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-east-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-northeast-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-northeast-2": {
-        "value": "nodejs16.x",
-      },
-      "ap-northeast-3": {
-        "value": "nodejs16.x",
-      },
-      "ap-south-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-south-2": {
-        "value": "nodejs16.x",
-      },
-      "ap-southeast-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-southeast-2": {
-        "value": "nodejs16.x",
-      },
-      "ap-southeast-3": {
-        "value": "nodejs16.x",
-      },
-      "ca-central-1": {
-        "value": "nodejs16.x",
-      },
-      "cn-north-1": {
-        "value": "nodejs16.x",
-      },
-      "cn-northwest-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-central-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-central-2": {
-        "value": "nodejs16.x",
-      },
-      "eu-north-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-south-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-south-2": {
-        "value": "nodejs16.x",
-      },
-      "eu-west-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-west-2": {
-        "value": "nodejs16.x",
-      },
-      "eu-west-3": {
-        "value": "nodejs16.x",
-      },
-      "me-central-1": {
-        "value": "nodejs16.x",
-      },
-      "me-south-1": {
-        "value": "nodejs16.x",
-      },
-      "sa-east-1": {
-        "value": "nodejs16.x",
-      },
-      "us-east-1": {
-        "value": "nodejs16.x",
-      },
-      "us-east-2": {
-        "value": "nodejs16.x",
-      },
-      "us-gov-east-1": {
-        "value": "nodejs16.x",
-      },
-      "us-gov-west-1": {
-        "value": "nodejs16.x",
-      },
-      "us-iso-east-1": {
-        "value": "nodejs14.x",
-      },
-      "us-iso-west-1": {
-        "value": "nodejs14.x",
-      },
-      "us-isob-east-1": {
-        "value": "nodejs14.x",
-      },
-      "us-west-1": {
-        "value": "nodejs16.x",
-      },
-      "us-west-2": {
-        "value": "nodejs16.x",
-      },
-    },
-  },
   "Parameters": {
     "BootstrapVersion": {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -385,7 +282,7 @@ exports[`Inspector2MonitoringResource creates required resources 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5fa1330271b8967d9254ba2d4a07144f8acefe8b77e6d6bba38261373a50d5f8.zip",
+          "S3Key": "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555.zip",
         },
         "Handler": "index.handler",
         "Role": {
@@ -394,15 +291,8 @@ exports[`Inspector2MonitoringResource creates required resources 1`] = `
             "Arn",
           ],
         },
-        "Runtime": {
-          "Fn::FindInMap": [
-            "DefaultCrNodeVersionMap",
-            {
-              "Ref": "AWS::Region",
-            },
-            "value",
-          ],
-        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
     },

--- a/typescript/inspector2/test/__snapshots__/inspector2-update-org-config-resource.test.ts.snap
+++ b/typescript/inspector2/test/__snapshots__/inspector2-update-org-config-resource.test.ts.snap
@@ -2,109 +2,6 @@
 
 exports[`Inspector2UpdateOrganizationConfigurationResource creates required resources 1`] = `
 {
-  "Mappings": {
-    "DefaultCrNodeVersionMap": {
-      "af-south-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-east-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-northeast-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-northeast-2": {
-        "value": "nodejs16.x",
-      },
-      "ap-northeast-3": {
-        "value": "nodejs16.x",
-      },
-      "ap-south-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-south-2": {
-        "value": "nodejs16.x",
-      },
-      "ap-southeast-1": {
-        "value": "nodejs16.x",
-      },
-      "ap-southeast-2": {
-        "value": "nodejs16.x",
-      },
-      "ap-southeast-3": {
-        "value": "nodejs16.x",
-      },
-      "ca-central-1": {
-        "value": "nodejs16.x",
-      },
-      "cn-north-1": {
-        "value": "nodejs16.x",
-      },
-      "cn-northwest-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-central-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-central-2": {
-        "value": "nodejs16.x",
-      },
-      "eu-north-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-south-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-south-2": {
-        "value": "nodejs16.x",
-      },
-      "eu-west-1": {
-        "value": "nodejs16.x",
-      },
-      "eu-west-2": {
-        "value": "nodejs16.x",
-      },
-      "eu-west-3": {
-        "value": "nodejs16.x",
-      },
-      "me-central-1": {
-        "value": "nodejs16.x",
-      },
-      "me-south-1": {
-        "value": "nodejs16.x",
-      },
-      "sa-east-1": {
-        "value": "nodejs16.x",
-      },
-      "us-east-1": {
-        "value": "nodejs16.x",
-      },
-      "us-east-2": {
-        "value": "nodejs16.x",
-      },
-      "us-gov-east-1": {
-        "value": "nodejs16.x",
-      },
-      "us-gov-west-1": {
-        "value": "nodejs16.x",
-      },
-      "us-iso-east-1": {
-        "value": "nodejs14.x",
-      },
-      "us-iso-west-1": {
-        "value": "nodejs14.x",
-      },
-      "us-isob-east-1": {
-        "value": "nodejs14.x",
-      },
-      "us-west-1": {
-        "value": "nodejs16.x",
-      },
-      "us-west-2": {
-        "value": "nodejs16.x",
-      },
-    },
-  },
   "Parameters": {
     "BootstrapVersion": {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -122,7 +19,7 @@ exports[`Inspector2UpdateOrganizationConfigurationResource creates required reso
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "bb459fac5f6b4b052aac9803443226d161a5cfe96f4648b21f9e4912c698bf30.zip",
+          "S3Key": "a524840909b73225567052baa4f50f81f3f2444186a5011d26e441ac674adb81.zip",
         },
         "Handler": "index.handler",
         "Role": {
@@ -131,15 +28,7 @@ exports[`Inspector2UpdateOrganizationConfigurationResource creates required reso
             "Arn",
           ],
         },
-        "Runtime": {
-          "Fn::FindInMap": [
-            "DefaultCrNodeVersionMap",
-            {
-              "Ref": "AWS::Region",
-            },
-            "value",
-          ],
-        },
+        "Runtime": "nodejs18.x",
         "Timeout": 120,
       },
       "Type": "AWS::Lambda::Function",

--- a/typescript/lambda-api-ci/package.json
+++ b/typescript/lambda-api-ci/package.json
@@ -12,25 +12,17 @@
     "prettier": "prettier --write '**/{bin,lib,src,tst}/*.ts'"
   },
   "devDependencies": {
-    "aws-cdk": "*",
-    "@aws-cdk/core": "*",
-    "@aws-cdk/assert": "*",
-    "@aws-cdk/aws-apigateway": "*",
-    "@aws-cdk/aws-codebuild": "*",
-    "@aws-cdk/aws-codecommit": "*",
-    "@aws-cdk/aws-codepipeline": "*",
-    "@aws-cdk/aws-codepipeline-actions": "*",
-    "@aws-cdk/aws-cloudformation": "*",
-    "@types/node": "^13.7.0",
+    "aws-cdk": "2.99.1",
+    "@types/node": "20.6.3",
     "ts-node": "^10.9.1",
-    "typescript": "~5.1.6",
+    "typescript": "~5.2.2",
     "prettier": "^2.0.4"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0",
     "aws-sdk": "^2.617.0",
-    "source-map-support": "^0.5.9"
+    "source-map-support": "^0.5.21"
   },
   "description": "* `npm run build`   compile typescript to js  * `npm run watch`   watch for changes and compile  * `npm run test`    perform the jest unit tests  * `cdk deploy`      deploy this stack to your default AWS account/region  * `cdk diff`        compare deployed stack with current state  * `cdk synth`       emits the synthesized CloudFormation template",
   "main": "jest.config.js",

--- a/typescript/lambda-api-ci/src/package.json
+++ b/typescript/lambda-api-ci/src/package.json
@@ -9,11 +9,11 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@types/node": "^13.7.0",
-    "jest": "^24.9.0",
-    "ts-jest": "^24.0.2",
+    "@types/node": "20.6.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2"
   },
   "dependencies": {
     "aws-sdk": "^2.617.0"

--- a/typescript/lambda-cloudwatch-dashboard/package.json
+++ b/typescript/lambda-cloudwatch-dashboard/package.json
@@ -10,18 +10,17 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "*",
-    "@types/jest": "^26.0.10",
-    "@types/node": "10.17.27",
-    "jest": "^26.4.2",
-    "ts-jest": "^26.2.0",
-    "aws-cdk": "*",
+    "@types/jest": "^29.5.5",
+    "@types/node": "20.6.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "aws-cdk": "2.99.1",
     "ts-node": "^10.9.1",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.21"
   }
 }

--- a/typescript/lambda-cron/cdk.json
+++ b/typescript/lambda-cron/cdk.json
@@ -1,3 +1,3 @@
 {
-    "app": "node index"
+    "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/lambda-cron/package.json
+++ b/typescript/lambda-cron/package.json
@@ -16,14 +16,14 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^10.17.0",
-    "@types/jest": "^26.0.24",
-    "aws-cdk": "*",
-    "jest": "^26.6.3",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "@types/jest": "^29.5.5",
+    "aws-cdk": "2.99.1",
+    "jest": "^29.7.0",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/lambda-layer/package.json
+++ b/typescript/lambda-layer/package.json
@@ -10,15 +10,14 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "*",
-    "@types/node": "10.17.27",
-    "aws-cdk": "*",
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
     "ts-node": "^10.9.1",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.21"
   }
 }

--- a/typescript/lambda-manage-s3-event-notification/package.json
+++ b/typescript/lambda-manage-s3-event-notification/package.json
@@ -10,15 +10,14 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "*",
-    "@types/node": "^10.17.27",
-    "aws-cdk": "*",
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
     "ts-node": "^10.9.1",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.21"
   }
 }

--- a/typescript/lambda-manage-s3-event-notification/package.json
+++ b/typescript/lambda-manage-s3-event-notification/package.json
@@ -20,4 +20,5 @@
     "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"
+  }
 }

--- a/typescript/my-widget-service/cdk.json
+++ b/typescript/my-widget-service/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "node index"
+  "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/my-widget-service/package.json
+++ b/typescript/my-widget-service/package.json
@@ -15,13 +15,13 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^10.17.0",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0",
-    "source-map-support": "*"
+    "source-map-support": "^0.5.21"
   }
 }

--- a/typescript/rekognition-lambda-s3-trigger/package.json
+++ b/typescript/rekognition-lambda-s3-trigger/package.json
@@ -10,15 +10,15 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/node": "10.17.27",
-    "aws-cdk": "*",
-    "ts-node": "^9.0.0",
-    "typescript": "~5.1.6"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "*",
+    "aws-cdk-lib": "2.99.1",
     "aws-sdk": "^2.1062.0",
-    "source-map-support": "^0.5.16",
-    "constructs": "*"
+    "source-map-support": "^0.5.21",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/resource-overrides/cdk.json
+++ b/typescript/resource-overrides/cdk.json
@@ -1,3 +1,3 @@
 {
-    "app": "node index"
+    "app": "npx ts-node --prefer-ts-exts index"
 }

--- a/typescript/resource-overrides/package.json
+++ b/typescript/resource-overrides/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "aws-cdk": "*",
-    "@types/node": "^10.17.0",
-    "typescript": "~5.1.6"
+    "aws-cdk": "2.99.1",
+    "@types/node": "20.6.3",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/route53-resolver-dns-firewall/package.json
+++ b/typescript/route53-resolver-dns-firewall/package.json
@@ -15,12 +15,12 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "10.17.27",
-    "aws-cdk": "2.80.0",
-    "typescript": "^4.9.3"
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.80.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"
   }

--- a/typescript/s3-kms-cross-account-replication/package.json
+++ b/typescript/s3-kms-cross-account-replication/package.json
@@ -11,19 +11,19 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.10",
-    "@types/node": "10.17.27",
-    "aws-cdk": "^2.79.1",
+    "@types/jest": "^29.5.5",
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
     "cdk-nag": "^2.0.0",
-    "jest": "^29.6.2",
+    "jest": "^29.7.0",
     "prettier": "2.6.2",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.79.1",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.21"
   }
 }

--- a/typescript/s3-object-lambda/package.json
+++ b/typescript/s3-object-lambda/package.json
@@ -10,15 +10,15 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/node": "18.11.17",
-    "aws-cdk": "*",
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
     "ts-node": "^10.9.1",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "aws-sdk": "^2.1281.0",
-    "constructs": "^10.1.190",
+    "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"
   }
 }

--- a/typescript/secrets-manager-rotation/package.json
+++ b/typescript/secrets-manager-rotation/package.json
@@ -15,17 +15,17 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^26.0.10",
-    "@types/node": "10.17.27",
-    "aws-cdk": "*",
-    "jest": "^26.4.2",
-    "ts-jest": "^26.2.0",
-    "ts-node": "^9.0.0",
-    "typescript": "~3.9.7"
+    "@types/jest": "^29.5.5",
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "*",
-    "@aws-cdk/aws-lambda-python-alpha": "*",
-    "constructs": "*"
+    "aws-cdk-lib": "2.99.1",
+    "@aws-cdk/aws-lambda-python-alpha": "2.99.1-alpha.0",
+    "constructs": "^10.0.0"
   }
 }

--- a/typescript/servicecatalog/portfolio-with-ec2-product/package.json
+++ b/typescript/servicecatalog/portfolio-with-ec2-product/package.json
@@ -10,16 +10,16 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.10",
-    "@types/node": "10.17.27",
-    "jest": "^29.6.2",
+    "@types/jest": "^29.5.5",
+    "@types/node": "20.6.3",
+    "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
-    "aws-cdk": "*",
+    "aws-cdk": "2.99.1",
     "ts-node": "^10.9.1",
-    "typescript": "~5.1.6"
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0"
   }
 }

--- a/typescript/waf/package.json
+++ b/typescript/waf/package.json
@@ -10,17 +10,17 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.10",
-    "@types/node": "*",
-    "aws-cdk": "*",
-    "typescript": "~5.1.6"
+    "@types/jest": "^29.5.5",
+    "@types/node": "20.6.3",
+    "aws-cdk": "2.99.1",
+    "typescript": "~5.2.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.0.0",
+    "aws-cdk-lib": "2.99.1",
     "constructs": "^10.0.0",
-    "jest": "^26.4.2",
-    "ts-jest": "^26.2.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.21"
   }
 }


### PR DESCRIPTION
There is an issue with package.json version where each app was different. Some would grab latest, any version, pinned to certain that would cause sporadic issues with building at certain times. Changed all the packages that by default cdk uses to follow the same syntax. Working on workflow that will auto update to the same versions and syntax as cdk provides on init.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
