### PR TITLE
fix(python/batch-arm64-instance-type): removed optimal instance classes with ARM base batch cluster

### DIFF
--- a/python/batch/batch-arm64-instance-type/app.py
+++ b/python/batch/batch-arm64-instance-type/app.py
@@ -25,7 +25,8 @@ class BatchEC2Stack(Stack):
             batch_environment = batch.ManagedEc2EcsComputeEnvironment(self, name,
                 spot=True,
                 spot_bid_percentage=75,
-                instance_types=[ec2.InstanceType("a1.medium"),ec2.InstanceType("a1.large")],
+                instance_types=[ec2.InstanceType("c7g.medium"),ec2.InstanceType("c7g.large")],
+                use_optimal_instance_classes=False,
                 vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_NAT),
                 vpc=vpc
             )


### PR DESCRIPTION
To solve this "arm-based instance type cannot be used with other instance types., " this error, removed optimal instance option.

<!--
AWS Batch cluster cannot be created with ARM and optimal option as it select other arch instance type. 

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

Fixes # arm-based instance type cannot be used with other instance types., 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
