### PR TITLE
Adding example for Java SSM managed EC2 

### DIFF
--- a/java/backup-s3/.gitignore
+++ b/java/backup-s3/.gitignore
@@ -1,0 +1,13 @@
+.classpath.txt
+target
+.classpath
+.project
+.idea
+.settings
+.vscode
+*.iml
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+

--- a/java/backup-s3/README.md
+++ b/java/backup-s3/README.md
@@ -1,0 +1,34 @@
+# CDK Java Example
+
+This is an example of a CDK program written in Java.\
+CDK program contains code to deploy a AWS Backup Vault and backup an S3 bucket which has Resource Tags assigned to it.
+Once deployed, any object uploaded to the S3 bucket will be backed up one the backup schedule is executed, which in this example is daily.
+
+## Building
+
+To build this app, run `mvn compile`. This will download the required
+dependencies to compile the Java code.
+
+You can use your IDE to write code and unit tests, but you will need to use the
+CDK toolkit if you wish to synthesize/deploy stacks.
+
+## CDK Toolkit
+
+The [`cdk.json`](./cdk.json) file in the root of this repository includes
+instructions for the CDK toolkit on how to execute this program.
+
+Specifically, it will tell the toolkit to use the `mvn exec:java` command as the
+entry point of your application. After changing your Java code, you will be able
+to run the CDK toolkit commands as usual (Maven will recompile as needed):
+
+    $ cdk ls
+    <list all stacks in this program>
+
+    $ cdk synth
+    <cloudformation template>
+
+    $ cdk deploy
+    <deploy stack to your account>
+
+    $ cdk diff
+    <diff against deployed stack>

--- a/java/backup-s3/cdk.json
+++ b/java/backup-s3/cdk.json
@@ -1,0 +1,53 @@
+{
+  "app": "mvn -e -q compile exec:java",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "target",
+      "pom.xml",
+      "src/test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
+    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+    "@aws-cdk/aws-kms:aliasNameRef": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+    "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true
+  }
+}

--- a/java/backup-s3/pom.xml
+++ b/java/backup-s3/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.myorg</groupId>
+    <artifactId>backup-s3</artifactId>
+    <version>0.1</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cdk.version>2.89.0</cdk.version>
+        <constructs.version>[10.0.0,11.0.0)</constructs.version>
+        <junit.version>5.7.1</junit.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <mainClass>com.myorg.BackupS3App</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- AWS Cloud Development Kit -->
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>aws-cdk-lib</artifactId>
+            <version>${cdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.constructs</groupId>
+            <artifactId>constructs</artifactId>
+            <version>${constructs.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+          <version>${junit.version}</version>
+          <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/java/backup-s3/src/main/java/com/myorg/BackupS3App.java
+++ b/java/backup-s3/src/main/java/com/myorg/BackupS3App.java
@@ -1,5 +1,4 @@
 package com.myorg;
-// package com.amazonaws.cdk;
 
 import software.amazon.awscdk.App;
 

--- a/java/backup-s3/src/main/java/com/myorg/BackupS3App.java
+++ b/java/backup-s3/src/main/java/com/myorg/BackupS3App.java
@@ -1,0 +1,15 @@
+package com.myorg;
+// package com.amazonaws.cdk;
+
+import software.amazon.awscdk.App;
+
+public class BackupS3App {
+    public static void main(final String[] args) {
+        App app = new App();
+
+        new BackupS3Stack(app, "BackupS3Stack");
+
+        app.synth();
+    }
+}
+

--- a/java/backup-s3/src/main/java/com/myorg/BackupS3Stack.java
+++ b/java/backup-s3/src/main/java/com/myorg/BackupS3Stack.java
@@ -1,0 +1,144 @@
+package com.myorg;
+//package com.amazonaws.cdk;
+
+import software.constructs.Construct;
+
+import java.util.Arrays;
+import java.util.List;
+
+import software.amazon.awscdk.RemovalPolicy;
+import software.amazon.awscdk.Stack;
+import software.amazon.awscdk.StackProps;
+import software.amazon.awscdk.Tags;
+import software.amazon.awscdk.services.s3.BlockPublicAccess;
+import software.amazon.awscdk.services.s3.Bucket;
+import software.amazon.awscdk.services.s3.BucketAccessControl;
+import software.amazon.awscdk.services.s3.BucketEncryption;
+import software.amazon.awscdk.services.backup.BackupPlan;
+import software.amazon.awscdk.services.backup.BackupPlanRule;
+import software.amazon.awscdk.services.backup.BackupResource;
+import software.amazon.awscdk.services.backup.BackupSelectionOptions;
+import software.amazon.awscdk.services.backup.BackupVault;
+import software.amazon.awscdk.services.iam.ManagedPolicy;
+import software.amazon.awscdk.services.iam.PolicyStatement;
+import software.amazon.awscdk.services.iam.Role;
+import software.amazon.awscdk.services.iam.ServicePrincipal;
+
+public class BackupS3Stack extends Stack {
+  public BackupS3Stack(final Construct scope, final String id) {
+    this(scope, id, null);
+  }
+
+  public BackupS3Stack(final Construct scope, final String id, final StackProps props) {
+    super(scope, id, props);
+
+    // create s3 bucket
+    Bucket bucket = Bucket.Builder.create(this, "my-example-bucket")
+        .encryption(BucketEncryption.KMS_MANAGED)
+        .accessControl(BucketAccessControl.BUCKET_OWNER_FULL_CONTROL)
+        .blockPublicAccess(BlockPublicAccess.BLOCK_ALL)
+        .versioned(true)
+        .build();
+
+    // add daily backup tag to bucket
+    Tags.of(bucket).add("daily-backup", "true");
+
+    // create backup vault
+    BackupVault vault = BackupVault.Builder.create(this, "BackupVault")
+        .removalPolicy(RemovalPolicy.DESTROY)
+        .build();
+
+    // create backup plan
+    BackupPlan plan = BackupPlan.Builder.create(this, "BackupPlan")
+        .backupVault(vault)
+        .build();
+
+    // add Rule to Backup Plan
+    plan.addRule(BackupPlanRule.daily());
+
+    // create Backup Role
+    Role backupRole = Role.Builder.create(this, "backup-role")
+        .assumedBy(new ServicePrincipal("backup.amazonaws.com"))
+        .build();
+
+    // add managed AWS Backup Service Policy to Role
+    backupRole.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName("AWSBackupServiceRolePolicyForS3Backup"));
+
+    // add S3 Bucket Permissions to backupRole
+    backupRole.addToPolicy(PolicyStatement.Builder.create()
+        .resources(Arrays.asList("arn:aws:s3:::*"))
+        .actions(Arrays.asList(
+            "s3:GetInventoryConfiguration",
+            "s3:PutInventoryConfiguration",
+            "s3:ListBucketVersions",
+            "s3:ListBucket",
+            "s3:GetBucketVersioning",
+            "s3:GetBucketNotification",
+            "s3:PutBucketNotification",
+            "s3:GetBucketLocation",
+            "s3:GetBucketTagging"))
+        .sid("S3BucketBackupPermissions")
+        .build());
+
+    // add S3 Object Permissions to backupRole
+    backupRole.addToPolicy(PolicyStatement.Builder.create()
+        .resources(Arrays.asList("arn:aws:s3:::*/*"))
+        .actions(Arrays.asList(
+            "s3:GetObjectAcl",
+            "s3:GetObject",
+            "s3:GetObjectVersionTagging",
+            "s3:GetObjectVersionAcl",
+            "s3:GetObjectTagging",
+            "s3:GetObjectVersion"))
+        .sid("S3ObjectBackupPermissions")
+        .build());
+
+    // add S3 Global Permissions to backupRole
+    backupRole.addToPolicy(PolicyStatement.Builder.create()
+        .resources(Arrays.asList("*"))
+        .actions(Arrays.asList(
+          "s3:ListAllMyBuckets"))
+        .sid("S3GlobalPermissions")
+        .build());
+
+    // add KMS Backup Permissions to policy
+    backupRole.addToPolicy(PolicyStatement.Builder.create()
+        .resources(Arrays.asList("*"))
+        .actions(Arrays.asList(
+          "kms:Decrypt",
+          "kms:DescribeKey"))
+        .sid("KMSBackupPermissions")
+        .build());
+
+    // add Events Persmissions to backupRole
+    backupRole.addToPolicy(PolicyStatement.Builder.create()
+        .resources(Arrays.asList("arn:aws:events:*:*:rule/AwsBackupManagedRule*"))
+        .actions(Arrays.asList(
+          "events:DescribeRule",
+          "events:EnableRule",
+          "events:PutRule",
+          "events:DeleteRule",
+          "events:PutTargets",
+          "events:RemoveTargets",
+          "events:ListTargetsByRule",
+          "events:DisableRule"))
+        .sid("EventsPermissions")
+        .build());
+
+    // add Events Metrics Global Persmissions to backupRole
+    backupRole.addToPolicy(PolicyStatement.Builder.create()
+        .resources(Arrays.asList("*"))
+        .actions(Arrays.asList(
+          "cloudwatch:GetMetricData",
+          "events:ListRules"))
+        .sid("EventsMetricsGlobalPermissions")
+        .build());
+
+    // add Selection to Plan from daily-backup tag
+    plan.addSelection("Selection", BackupSelectionOptions.builder()
+        .resources(List.of(BackupResource.fromTag("daily-backup", "true")))
+        .role(backupRole)
+        .build());
+
+  }
+}

--- a/java/backup-s3/src/main/java/com/myorg/BackupS3Stack.java
+++ b/java/backup-s3/src/main/java/com/myorg/BackupS3Stack.java
@@ -1,5 +1,4 @@
 package com.myorg;
-//package com.amazonaws.cdk;
 
 import software.constructs.Construct;
 

--- a/java/ec2-instance/.gitignore
+++ b/java/ec2-instance/.gitignore
@@ -1,0 +1,13 @@
+.classpath.txt
+target
+.classpath
+.project
+.idea
+.settings
+.vscode
+*.iml
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+

--- a/java/ec2-instance/README.md
+++ b/java/ec2-instance/README.md
@@ -1,0 +1,38 @@
+# CDK Java Example
+
+This is an example of a CDK program written in Java.\
+CDK program contains code to deploy a SSM managed EC2 instance in a public VPC, with the ability to add User Data commands in line.
+The instances becomes accessabile through SSM by way of AWS Console or AWS CLI.
+
+## Building
+
+To build this app, run `mvn compile`. This will download the required
+dependencies to compile the Java code.
+
+You can use your IDE to write code and unit tests, but you will need to use the
+CDK toolkit if you wish to synthesize/deploy stacks.
+
+## CDK Toolkit
+
+The [`cdk.json`](./cdk.json) file in the root of this repository includes
+instructions for the CDK toolkit on how to execute this program.
+
+Specifically, it will tell the toolkit to use the `mvn exec:java` command as the
+entry point of your application. After changing your Java code, you will be able
+to run the CDK toolkit commands as usual (Maven will recompile as needed):
+
+    $ cdk ls
+    <list all stacks in this program>
+
+    $ cdk synth
+    <cloudformation template>
+
+    $ cdk deploy
+    <deploy stack to your account>
+
+    $ cdk diff
+    <diff against deployed stack>
+
+## Useful commands
+
+  *`aws ssm start-session --target i-xxxxxxxxx` remote session for shell access

--- a/java/ec2-instance/cdk.json
+++ b/java/ec2-instance/cdk.json
@@ -1,0 +1,53 @@
+{
+  "app": "mvn -e -q compile exec:java",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "target",
+      "pom.xml",
+      "src/test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
+    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+    "@aws-cdk/aws-kms:aliasNameRef": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+    "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true
+  }
+}

--- a/java/ec2-instance/pom.xml
+++ b/java/ec2-instance/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.myorg</groupId>
+    <artifactId>ec2-instance</artifactId>
+    <version>0.1</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cdk.version>2.89.0</cdk.version>
+        <constructs.version>[10.0.0,11.0.0)</constructs.version>
+        <junit.version>5.7.1</junit.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <mainClass>com.myorg.Ec2InstanceApp</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- AWS Cloud Development Kit -->
+        <dependency>
+            <groupId>software.amazon.awscdk</groupId>
+            <artifactId>aws-cdk-lib</artifactId>
+            <version>${cdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.constructs</groupId>
+            <artifactId>constructs</artifactId>
+            <version>${constructs.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+          <version>${junit.version}</version>
+          <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/java/ec2-instance/src/main/java/com/myorg/Ec2InstanceApp.java
+++ b/java/ec2-instance/src/main/java/com/myorg/Ec2InstanceApp.java
@@ -1,0 +1,14 @@
+package com.myorg;
+
+import software.amazon.awscdk.App;
+
+public class Ec2InstanceApp {
+    public static void main(final String[] args) {
+        App app = new App();
+
+        new Ec2InstanceStack(app, "Ec2InstanceStack");
+
+        app.synth();
+    }
+}
+

--- a/java/ec2-instance/src/main/java/com/myorg/Ec2InstanceStack.java
+++ b/java/ec2-instance/src/main/java/com/myorg/Ec2InstanceStack.java
@@ -1,0 +1,64 @@
+package com.myorg;
+
+import software.constructs.Construct;
+
+import java.util.List;
+
+import software.amazon.awscdk.Stack;
+import software.amazon.awscdk.StackProps;
+import software.amazon.awscdk.services.ec2.AmazonLinux2ImageSsmParameterProps;
+import software.amazon.awscdk.services.ec2.AmazonLinuxEdition;
+import software.amazon.awscdk.services.ec2.AmazonLinuxStorage;
+import software.amazon.awscdk.services.ec2.AmazonLinuxVirt;
+import software.amazon.awscdk.services.ec2.Instance;
+import software.amazon.awscdk.services.ec2.InstanceType;
+import software.amazon.awscdk.services.ec2.MachineImage;
+import software.amazon.awscdk.services.ec2.SubnetConfiguration;
+import software.amazon.awscdk.services.ec2.Vpc;
+import software.amazon.awscdk.services.ec2.SubnetType;
+import software.amazon.awscdk.services.iam.ManagedPolicy;
+import software.amazon.awscdk.services.iam.Role;
+import software.amazon.awscdk.services.iam.ServicePrincipal;
+
+public class Ec2InstanceStack extends Stack {
+    public Ec2InstanceStack(final Construct scope, final String id) {
+        this(scope, id, null);
+    }
+
+    public Ec2InstanceStack(final Construct scope, final String id, final StackProps props) {
+        super(scope, id, props);
+
+      // Create a new VPC
+      Vpc vpc = Vpc.Builder.create(this, "Vpc")
+        .natGateways(0)
+        .subnetConfiguration(List.of(SubnetConfiguration.builder()
+          .name("public")
+          .subnetType(SubnetType.PUBLIC)
+          .build()))
+        .build();
+
+      // Instance Role
+      Role role = Role.Builder.create(this, "InstanceRole")
+        .assumedBy(new ServicePrincipal("ec2.amazonaws.com"))
+      .build();
+
+      // Add SSM Managed Policy
+      role.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName("AmazonSSMManagedInstanceCore"));
+
+      // Launch an EC2 instance in the VPC
+      Instance instance = Instance.Builder.create(this, "Ec2Instance")
+        .instanceType(new InstanceType("t3.nano"))
+        .machineImage(MachineImage.latestAmazonLinux2(AmazonLinux2ImageSsmParameterProps.builder()
+          .edition(AmazonLinuxEdition.STANDARD)
+          .virtualization(AmazonLinuxVirt.HVM)
+          .storage(AmazonLinuxStorage.GENERAL_PURPOSE)
+          .build()))
+        .role(role)
+        .vpc(vpc)
+        .build();
+
+      // Add User Data commands
+      instance.addUserData("echo \"Hello World.\"");
+
+    }
+}

--- a/java/ec2-instance/src/test/java/com/myorg/Ec2InstanceTest.java
+++ b/java/ec2-instance/src/test/java/com/myorg/Ec2InstanceTest.java
@@ -1,0 +1,26 @@
+// package com.myorg;
+
+// import software.amazon.awscdk.App;
+// import software.amazon.awscdk.assertions.Template;
+// import java.io.IOException;
+
+// import java.util.HashMap;
+
+// import org.junit.jupiter.api.Test;
+
+// example test. To run these tests, uncomment this file, along with the
+// example resource in java/src/main/java/com/myorg/Ec2InstanceStack.java
+// public class Ec2InstanceTest {
+
+//     @Test
+//     public void testStack() throws IOException {
+//         App app = new App();
+//         Ec2InstanceStack stack = new Ec2InstanceStack(app, "test");
+
+//         Template template = Template.fromStack(stack);
+
+//         template.hasResourceProperties("AWS::SQS::Queue", new HashMap<String, Number>() {{
+//           put("VisibilityTimeout", 300);
+//         }});
+//     }
+// }


### PR DESCRIPTION
Adding a Java example for an SSM managed EC2 instance with the ability to add User Data commands in line.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
