### PR TITLE
Add Missing path Import to TypeScript Example

### DIFF
--- a/typescript/static-site/static-site.ts
+++ b/typescript/static-site/static-site.ts
@@ -9,6 +9,7 @@ import * as cloudfront_origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import { CfnOutput, Duration, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
+import path = require('path');
 
 export interface StaticSiteProps {
   domainName: string;
@@ -68,7 +69,7 @@ export class StaticSite extends Construct {
     });
 
     new CfnOutput(this, 'Certificate', { value: certificate.certificateArn });
-    
+
     // CloudFront distribution
     const distribution = new cloudfront.Distribution(this, 'SiteDistribution', {
       certificate: certificate,


### PR DESCRIPTION
This pull request addresses a runtime error encountered in one of the TypeScript examples due to the missing import statement for the `path` module. By adding `import path = require('path');`, this change ensures the application can correctly utilize the `path` module's functionalities, thus maintaining the stability and functionality of the example.


- [x] A reproducible test case or series of steps
`cdk diff -c accountId=123456789 -c domain=mystaticsite.com -c subdomain=www`

- [x] The version of our code being used
2.128.0 (build d995261)

- [x] Any modifications you've made relevant to the bug
just add 
`import path = require('path');`

- [x] Anything unusual about your environment or deployment
none