### PR TITLE
chore(typescript/lambda-layer-stack.ts): update sample to use node 18 (#999)

### DIFF
--- a/typescript/api-cors-lambda-crud-dynamodb/index.ts
+++ b/typescript/api-cors-lambda-crud-dynamodb/index.ts
@@ -35,7 +35,7 @@ export class ApiLambdaCrudDynamoDBStack extends Stack {
         PRIMARY_KEY: 'itemId',
         TABLE_NAME: dynamoTable.tableName,
       },
-      runtime: Runtime.NODEJS_14_X,
+      runtime: Runtime.NODEJS_18_X,
     }
 
     // Create a Lambda function for each of the CRUD operations

--- a/typescript/lambda-layer/lib/lambda-layer-stack.ts
+++ b/typescript/lambda-layer/lib/lambda-layer-stack.ts
@@ -9,12 +9,12 @@ export class LambdaLayerStack extends cdk.Stack {
     const layer = new lambda.LayerVersion(this, 'HelperLayer', {
       code: lambda.Code.fromAsset('resources/layers/helper'),
       description: 'Common helper utility',
-      compatibleRuntimes: [lambda.Runtime.NODEJS_14_X],
+      compatibleRuntimes: [lambda.Runtime.NODEJS_18_X],
       removalPolicy: cdk.RemovalPolicy.DESTROY
     });
 
     const fn = new lambda.Function(this, 'LambdaFunction', {
-        runtime: lambda.Runtime.NODEJS_14_X,
+        runtime: lambda.Runtime.NODEJS_18_X,
         code: lambda.Code.fromAsset('resources/lambda'),
         handler: 'index.handler',
         layers: [layer]


### PR DESCRIPTION
<!--
Due to AWS no longer supporting NODEJS_12_X, all Lambda runtimes using an older version than NODEJS_18_X should be upgraded.  https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/


-->

Fixes # <!-- [Please create a new issue if none exists yet](https://github.com/aws-samples/aws-cdk-examples/issues/961) -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
