### PR TITLE
Remove unnecessary process.exit(1); after throw new Error()

### DIFF
--- a/typescript/rds/aurora/aurora.ts
+++ b/typescript/rds/aurora/aurora.ts
@@ -152,7 +152,6 @@ export class Aurora extends Stack {
     const dbs = ['mysql', 'postgresql'];
     if (!dbs.includes(props.engine!)) {
       throw new Error('Unknown Engine Please Use mysql or postgresql');
-      process.exit(1);
     }
     if (backupRetentionDays < 14) {
       backupRetentionDays = 14;


### PR DESCRIPTION
This pull request removes the process.exit(1); 

statement that follows the throw new Error('Unknown Engine Please Use mysql or postgresql'); line. 
The process.exit(1); is unnecessary because once an error is thrown, the execution of the code is halted, and the process.exit(1); will never be reached.

- [x] A reproducible test case or series of steps
`cdk diff`

- [x] The version of our code being used
2.134.0 (build 265d769)

- [x] Any modifications you've made relevant to the bug
As you can see just delete
```
process.exit(1);
```

- [x] Anything unusual about your environment or deployment
none

By removing the process.exit(1); statement, we can improve the code readability and maintain consistency with the error handling mechanism in the AWS CDK stack definition file. The throw new Error() statement is sufficient to handle the error and stop the execution of the code when an unknown engine is encountered.