### PR TITLE
adding "AWS Route 53 Backup Solution"

### DIFF
--- a/python/AWS-Route53-Backup-Solution/LICENSE.md
+++ b/python/AWS-Route53-Backup-Solution/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Pedram Jahangiri
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/python/AWS-Route53-Backup-Solution/README.md
+++ b/python/AWS-Route53-Backup-Solution/README.md
@@ -18,13 +18,14 @@ Before you can deploy this application, ensure you have the following installed:
 1. Clone the repository:
    ```bash
    git clone https://github.com/iut62elec/AWS-Route53-Backup-Solution.git
+   cd AWS-Route53-Backup-Solution
 
 2. Configure your AWS profile (replace xxx with your profile name):
     ```bash
     export AWS_PROFILE=xxx
 3. Set up a Python virtual environment and install AWS CDK and Node.js version 18 and the required Python libraries:
     ```bash
-    python -m venv .venv
+    python3.11 -m venv .venv
     source .venv/bin/activate
     npm install -g aws-cdk@latest
     npm update -g aws-cdk
@@ -45,4 +46,21 @@ Before you can deploy this application, ensure you have the following installed:
 4. EventBridge Rule: Triggers the Lambda function on a scheduled basis.
 
 
+
+    
+## Removing the Solution
+Run the following command in your terminal where the CDK project is initialized:
+
+```bash
+cdk destroy
+```
+
+## Contributing
 Feel free to contribute to this project by submitting pull requests or reporting issues. Your feedback is appreciated!
+
+
+## License
+This project is licensed under the MIT License.
+
+## Disclaimer
+This repository and its contents are not endorsed by or affiliated with Amazon Web Services (AWS) or any other third-party entities. It represents my personal viewpoints and not those of my past or current employers. All third-party libraries, modules, plugins, and SDKs are the property of their respective owners.

--- a/python/AWS-Route53-Backup-Solution/README.md
+++ b/python/AWS-Route53-Backup-Solution/README.md
@@ -1,0 +1,48 @@
+# AWS Route 53 Backup Solution
+
+## Overview
+This repository contains an AWS Cloud Development Kit (CDK) application for backing up AWS Route 53 zone records. As of today (April 2024) AWS does not provide a native backup service for Route 53, making it essential to have a custom solution to safeguard DNS records. This CDK application automatically provisions resources to back up Route 53 zones to an S3 bucket, scheduling backups to occur every day.
+
+## Author
+Pedram Jahangiri
+
+## Prerequisites
+Before you can deploy this application, ensure you have the following installed:
+- Node.js and NPM
+- AWS CLI
+- Python 3.x and pip
+- AWS CDK
+
+## Setup and Deployment
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/iut62elec/AWS-Route53-Backup-Solution.git
+
+2. Configure your AWS profile (replace xxx with your profile name):
+    ```bash
+    export AWS_PROFILE=xxx
+3. Set up a Python virtual environment and install AWS CDK and Node.js version 18 and the required Python libraries:
+    ```bash
+    python -m venv .venv
+    source .venv/bin/activate
+    npm install -g aws-cdk@latest
+    npm update -g aws-cdk
+    nvm install 18
+    nvm use 18
+    pip install --upgrade pip
+    pip install aws-cdk.aws-s3 aws-cdk.aws-lambda aws-cdk.aws-events aws-cdk.aws-events-targets aws-cdk.aws-iam
+
+4. Bootstrap CDK (replace aws://xxx/us-east-1 with your AWS account and region) and deploy the stack:
+    ```bash
+    cdk bootstrap aws://xxx/us-east-1
+    cdk deploy
+
+## Application Components
+1. S3 Bucket: Stores the Route 53 zone backups.
+2. Lambda Function: Executes the backup process every day, writing the zone records to the S3 bucket.
+3. IAM Roles: Ensures the Lambda function has necessary permissions to access Route 53 and S3.
+4. EventBridge Rule: Triggers the Lambda function on a scheduled basis.
+
+
+Feel free to contribute to this project by submitting pull requests or reporting issues. Your feedback is appreciated!

--- a/python/AWS-Route53-Backup-Solution/app.py
+++ b/python/AWS-Route53-Backup-Solution/app.py
@@ -1,0 +1,57 @@
+from aws_cdk import core
+import os
+
+from aws_cdk import (
+    aws_s3 as s3,
+    aws_lambda as _lambda,
+    aws_events as events,
+    aws_events_targets as targets,
+    aws_iam as iam,
+    core
+)
+
+class R53BackupStack(core.Stack):
+
+    def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        # S3 bucket for backups
+        bucket = s3.Bucket(self, "R53BackupBucket")
+
+        # Lambda function for R53 backups
+        lambda_function_name='r53_backup'
+        lambda_fn = _lambda.Function(
+            self, "R53BackupFunction",
+            runtime=_lambda.Runtime.PYTHON_3_9,
+            handler=f"index.lambda_handler",
+            code=_lambda.Code.asset(f'lambda/{lambda_function_name}'),  # Adjust path as needed
+            environment={
+                'BUCKET_NAME': bucket.bucket_name
+            },
+            timeout = core.Duration.minutes(5)
+        )
+
+        # IAM role permissions
+        bucket.grant_put(lambda_fn)
+        lambda_fn.add_to_role_policy(iam.PolicyStatement(
+            actions=["route53:ListHostedZones", "route53:ListResourceRecordSets"],
+            resources=["*"]
+        ))
+
+        # EventBridge rule to trigger Lambda every day
+        rule = events.Rule(
+            self, "Rule",
+            schedule=events.Schedule.cron(
+                minute='0',
+                hour='1',
+                month='*',
+                year='*',
+                day='*'
+            )
+        )
+        rule.add_target(targets.LambdaFunction(lambda_fn))
+
+
+app = core.App()
+R53BackupStack(app, "R53BackupStack")
+app.synth()

--- a/python/AWS-Route53-Backup-Solution/app.py
+++ b/python/AWS-Route53-Backup-Solution/app.py
@@ -37,8 +37,7 @@ class R53BackupStack(core.Stack):
             actions=["route53:ListHostedZones", "route53:ListResourceRecordSets"],
             resources=["*"]
         ))
-
-        # EventBridge rule to trigger Lambda every day
+         # EventBridge rule to trigger Lambda every day at 1:00 AM UTC
         rule = events.Rule(
             self, "Rule",
             schedule=events.Schedule.cron(

--- a/python/AWS-Route53-Backup-Solution/cdk.json
+++ b/python/AWS-Route53-Backup-Solution/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/python/AWS-Route53-Backup-Solution/lambda/r53_backup/index.py
+++ b/python/AWS-Route53-Backup-Solution/lambda/r53_backup/index.py
@@ -1,0 +1,32 @@
+import boto3
+import json
+import os
+from datetime import datetime
+
+def lambda_handler(event, context):
+    client = boto3.client('route53')
+    s3 = boto3.client('s3')
+    #bucket_name = 'xxxx' 
+    bucket_name=os.environ.get('BUCKET_NAME')
+
+    today = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")  # Current timestamp
+
+    # Get the list of all hosted zones
+    hosted_zones = client.list_hosted_zones()
+    for zone in hosted_zones['HostedZones']:
+        zone_id = zone['Id'].split('/')[-1]  # Extract the Zone ID
+        records_response = client.list_resource_record_sets(HostedZoneId=zone_id)
+        
+        # Format the record sets into JSON
+        formatted_records = json.dumps(records_response['ResourceRecordSets'], indent=4)
+        
+        
+        object_key = f'{zone_id}/{today}/R53Backup-{zone_id}.json'
+        
+        # Save to S3
+        s3.put_object(Bucket=bucket_name, Key=object_key, Body=formatted_records)
+
+    return {
+        'statusCode': 200,
+        'body': json.dumps('Backup successful for all zones!')
+    }


### PR DESCRIPTION


This repository contains an AWS Cloud Development Kit (CDK) application for backing up AWS Route 53 zone records. As of today (April 2024) AWS does not provide a native backup service for Route 53, making it essential to have a custom solution to safeguard DNS records. This CDK application automatically provisions resources to back up Route 53 zones to an S3 bucket, scheduling backups to occur every day.

