### PR TITLE
Fix: Typescript npm install command and update other language package

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -98,9 +98,11 @@ jobs:
             echo "- $dir"
           done
 
-          # install CDK CLI from npm, so that npx can find it later
-          cd ./${{ matrix.language }}
-          npm install
+          # install CDK CLI from npm if not typescript, so that npx can find it later
+          if [[ ${{ matrix.language }} != 'typescript' ]]; then
+            cd ./${{ matrix.language }}
+            npm install -g aws-cdk
+          fi
 
           # Run the build_file function in parallel for each project to be built
           # Halt the execution if any of the build_file invocations fail

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -99,6 +99,7 @@ jobs:
           done
 
           # install CDK CLI from npm if not typescript, so that npx can find it later
+          # ts will use the one from the particular cdk app
           if [[ ${{ matrix.language }} != 'typescript' ]]; then
             cd ./${{ matrix.language }}
             npm install -g aws-cdk

--- a/csharp/package.json
+++ b/csharp/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "aws-cdk": "^2.0.0-rc.32"
+    "aws-cdk": "^2.0.0"
   }
 }

--- a/go/package.json
+++ b/go/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "aws-cdk": "^2.0.0-rc.32"
+    "aws-cdk": "^2.0.0"
   }
 }

--- a/java/package.json
+++ b/java/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "aws-cdk": "^2.0.0-rc.32"
+    "aws-cdk": "^2.0.0"
   }
 }

--- a/python/package.json
+++ b/python/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "aws-cdk": "^2.0.0-rc.32"
+    "aws-cdk": "^2.0.0"
   }
 }


### PR DESCRIPTION
- Update !typescript package.json to use at least use stable 2.0
- If not a typescript then install the cdk cli otherwise use the cdk cli version from the ts cdk app. 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
