### PR TITLE
Fix 'npm install' failure.

### DIFF
--- a/typescript/rds/mysql/package.json
+++ b/typescript/rds/mysql/package.json
@@ -12,8 +12,8 @@
   "devDependencies": {
     "@types/jest": "^26.0.10",
     "@types/node": "*",
-    "jest": "^26.4.2",
-    "ts-jest": "^26.2.0",
+    "jest": "29.6.4",
+    "ts-jest": "29.2.4",
     "ts-node": "^10.9.1",
     "aws-cdk": "*",
     "typescript": "~5.1.6"


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->
Bump `jest` and `ts-jest` to versions `29.6.4` [1] and respectively `29.2.4` [2].
```
[1]:https://github.com/aws-samples/aws-cdk-examples/pull/911
[2]:https://github.com/aws-samples/aws-cdk-examples/pull/1064
```

Fixes #1070 <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
