### PR TITLE
Don't use the "var" keyword.

### DIFF
--- a/typescript/rds/mysql/mysql.ts
+++ b/typescript/rds/mysql/mysql.ts
@@ -103,15 +103,15 @@ export class Mysql extends Stack {
     super(scope, id);
 
     // default database username
-    var mysqlUsername = "dbadmin";
+    let mysqlUsername = "dbadmin";
     if (typeof props.mysqlUsername !== 'undefined') {
       mysqlUsername = props.mysqlUsername;
     }
-    var ingressSources = [];
+    let ingressSources = [];
     if (typeof props.ingressSources !== 'undefined') {
       ingressSources = props.ingressSources;
     }
-    var engineVersion = rds.MysqlEngineVersion.VER_8_0_28;
+    let engineVersion = rds.MysqlEngineVersion.VER_8_0_28;
     if (typeof props.engineVersion !== 'undefined') {
       engineVersion = props.engineVersion;
     }


### PR DESCRIPTION
Follow [AWS Prescriptive Guidance - Best practices for using the AWS CDK in TypeScript to create IaC projects](https://docs.aws.amazon.com/prescriptive-guidance/latest/best-practices-cdk-typescript-iac/typescript-best-practices.html#var-keyword).

<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->
Replace variable declarations using `var` with `let`.

Fixes #1077 <!-- Please create a new issue if none exists yet -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
