### PR TITLE
Chore: pin tj-actions/changed-files

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -33,7 +33,7 @@ jobs:
       # Get the list of changed files, excluding Markdown files
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
         with:
           files: ${{ matrix.language }}/**
           files_ignore: '**/*.md'


### PR DESCRIPTION
Pin the Github action tj-actions/changed-files to version e9772d140489982e0e3704fea5ee93d536f1e275

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
