### PR TITLE
chore(java/eks): refresh sample code and set Amazon EKS version as 1.32

### DIFF
--- a/java/eks/fargate-cluster/pom.xml
+++ b/java/eks/fargate-cluster/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.175.1</cdk.version>
-        <kubectl.version>2.0.0</kubectl.version>
+        <cdk.version>2.198.0</cdk.version>
+        <kubectl.version>2.1.0</kubectl.version>
         <constructs.version>[10.0.0,11.0.0)</constructs.version>
         <junit.version>5.7.1</junit.version>
     </properties>
@@ -25,7 +25,7 @@
 
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
-            <artifactId>cdk-lambda-layer-kubectl-v31</artifactId>
+            <artifactId>cdk-lambda-layer-kubectl-v32</artifactId>
             <version>${kubectl.version}</version>
         </dependency>
 

--- a/java/eks/fargate-cluster/src/main/java/com/amazonaws/cdk/EksFargateStack.java
+++ b/java/eks/fargate-cluster/src/main/java/com/amazonaws/cdk/EksFargateStack.java
@@ -43,7 +43,7 @@ public class EksFargateStack extends Stack {
                 .mastersRole(clusterAdminRole)
                 .role(clusterAdminRole)
                 .endpointAccess(EndpointAccess.PUBLIC)
-                .version(KubernetesVersion.V1.32)
+                .version(KubernetesVersion.V1_32)
                 .vpc(props.getVpc())
                 .kubectlLayer(new KubectlV32Layer(this, "KubectlLayer"))
                 .vpcSubnets(List.of(SubnetSelection.builder()

--- a/java/eks/fargate-cluster/src/main/java/com/amazonaws/cdk/EksFargateStack.java
+++ b/java/eks/fargate-cluster/src/main/java/com/amazonaws/cdk/EksFargateStack.java
@@ -2,7 +2,7 @@ package com.amazonaws.cdk;
 
 import software.amazon.awscdk.CfnOutput;
 import software.amazon.awscdk.Stack;
-import software.amazon.awscdk.cdk.lambdalayer.kubectl.v31.KubectlV31Layer;
+import software.amazon.awscdk.cdk.lambdalayer.kubectl.v32.KubectlV32Layer;
 import software.amazon.awscdk.services.ec2.SubnetSelection;
 import software.amazon.awscdk.services.ec2.SubnetType;
 import software.amazon.awscdk.services.eks.*;
@@ -43,9 +43,9 @@ public class EksFargateStack extends Stack {
                 .mastersRole(clusterAdminRole)
                 .role(clusterAdminRole)
                 .endpointAccess(EndpointAccess.PUBLIC)
-                .version(KubernetesVersion.V1_31)
+                .version(KubernetesVersion.V1.32)
                 .vpc(props.getVpc())
-                .kubectlLayer(new KubectlV31Layer(this, "KubectlLayer"))
+                .kubectlLayer(new KubectlV32Layer(this, "KubectlLayer"))
                 .vpcSubnets(List.of(SubnetSelection.builder()
                         .subnetType(SubnetType.PRIVATE_WITH_EGRESS)
                         .build()))
@@ -72,7 +72,7 @@ public class EksFargateStack extends Stack {
         new CfnAddon(this, "eks-kube-proxy-addon", CfnAddonProps.builder()
                 .clusterName(eksCluster.getClusterName())
                 .addonName("kube-proxy")
-                .addonVersion("v1.31.3-eksbuild.2")
+                .addonVersion("v1.32.3-eksbuild.7")
                 .resolveConflicts("OVERWRITE")
                 .build());
 

--- a/java/eks/fargate-cluster/src/test/java/com/amazonaws/cdk/EksFargateStackTest.java
+++ b/java/eks/fargate-cluster/src/test/java/com/amazonaws/cdk/EksFargateStackTest.java
@@ -56,7 +56,7 @@ class EksFargateStackTest {
       Map.of(
         "Config", Map.of(
           "name", "SampleCluster",
-          "version", "1.31"
+          "version", "1.32"
         )
       )
     ), 1);

--- a/java/eks/fargate-cluster/src/test/resources/com/amazonaws/cdk/EksFargateStackExpected.json
+++ b/java/eks/fargate-cluster/src/test/resources/com/amazonaws/cdk/EksFargateStackExpected.json
@@ -384,7 +384,7 @@
         },
         "Config": {
           "name": "SampleCluster",
-          "version": "1.31",
+          "version": "1.32",
           "roleArn": {
             "Fn::GetAtt": [
               "EksClusterAdminRoleD3CAEBD0",
@@ -765,7 +765,7 @@
       "Type": "AWS::EKS::Addon",
       "Properties": {
         "AddonName": "kube-proxy",
-        "AddonVersion": "v1.31.3-eksbuild.2",
+        "AddonVersion": "v1.32.3-eksbuild.7",
         "ClusterName": {
           "Ref": "EksFargateCluster07FC3D2B"
         },

--- a/java/eks/private-cluster/README.md
+++ b/java/eks/private-cluster/README.md
@@ -95,10 +95,10 @@ For other packages or tools like `kubectl`, create an S3 bucket accessible from 
 Sample cloudshell session:
 
 ```
-[cloudshell-user@ip-10-2-84-204 ~]$ curl -O https://s3.us-west-2.amazonaws.com/amazon-eks/1.31.4/2025-01-10/bin/darwin/amd64/kubectl
+[cloudshell-user@ip-10-2-84-204 ~]$ curl -O https://s3.us-west-2.amazonaws.com/amazon-eks/1.32.4/2025-04-17/bin/darwin/amd64/kubectl
 
-[cloudshell-user@ip-10-2-84-204 ~]$ aws s3 cp kubectl s3://my-bucket/kubectl-1.31.4
-upload: ./kubectl to s3://my-bucket/kubectl-1.31.4
+[cloudshell-user@ip-10-2-84-204 ~]$ aws s3 cp kubectl s3://my-bucket/kubectl-1.32.4
+upload: ./kubectl to s3://my-bucket/kubectl-1.32.4
 ```
 
 ## Accessing the EKS cluster with kubectl
@@ -116,7 +116,7 @@ Test the access to the EKS cluster. Get pods and nodes
 ```
 [ssm-user@ip-10-0-0-240 ~]$ kubectl get nodes
 NAME                                           STATUS   ROLES    AGE   VERSION
-ip-10-0-0-60.ap-southeast-1.compute.internal   Ready    <none>   19h   v1.31.0-eks-a737599
+ip-10-0-0-60.ap-southeast-1.compute.internal   Ready    <none>   19h   v1.32.3-eks-473151a
 
 [ssm-user@ip-10-0-0-240 ~]$ kubectl get pods -A
 NAMESPACE     NAME                       READY   STATUS    RESTARTS        AGE

--- a/java/eks/private-cluster/pom.xml
+++ b/java/eks/private-cluster/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.175.1</cdk.version>
-        <kubectl.version>2.0.0</kubectl.version>
+        <cdk.version>2.198.0</cdk.version>
+        <kubectl.version>2.1.0</kubectl.version>
         <constructs.version>[10.0.0,11.0.0)</constructs.version>
         <junit.version>5.7.1</junit.version>
     </properties>
@@ -47,7 +47,7 @@
 
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
-            <artifactId>cdk-lambda-layer-kubectl-v31</artifactId>
+            <artifactId>cdk-lambda-layer-kubectl-v32</artifactId>
             <version>${kubectl.version}</version>
         </dependency>
 

--- a/java/eks/private-cluster/src/main/java/com/amazonaws/cdk/examples/EksPrivateClusterStack.java
+++ b/java/eks/private-cluster/src/main/java/com/amazonaws/cdk/examples/EksPrivateClusterStack.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 import software.amazon.awscdk.Stack;
 import software.amazon.awscdk.StackProps;
-import software.amazon.awscdk.cdk.lambdalayer.kubectl.v31.KubectlV31Layer;
+import software.amazon.awscdk.cdk.lambdalayer.kubectl.v32.KubectlV32Layer;
 import software.amazon.awscdk.services.autoscaling.AutoScalingGroup;
 import software.amazon.awscdk.services.ec2.BastionHostLinux;
 import software.amazon.awscdk.services.ec2.BlockDevice;
@@ -89,12 +89,12 @@ public class EksPrivateClusterStack extends Stack {
     this.cluster =
         Cluster.Builder.create(this, "eks")
             .vpc(vpc)
-            .version(KubernetesVersion.V1_31)
+            .version(KubernetesVersion.V1.32)
             .vpcSubnets(
                 List.of(SubnetSelection.builder().subnetType(SubnetType.PRIVATE_ISOLATED).build()))
             .endpointAccess(EndpointAccess.PRIVATE)
             .clusterName("eks-private")
-            .kubectlLayer(new KubectlV31Layer(this, "KubectlLayer"))
+            .kubectlLayer(new KubectlV32Layer(this, "KubectlLayer"))
             .defaultCapacity(0)
             .mastersRole(clusterAdmin)
             .placeClusterHandlerInVpc(true)

--- a/java/eks/private-cluster/src/main/java/com/amazonaws/cdk/examples/EksPrivateClusterStack.java
+++ b/java/eks/private-cluster/src/main/java/com/amazonaws/cdk/examples/EksPrivateClusterStack.java
@@ -89,7 +89,7 @@ public class EksPrivateClusterStack extends Stack {
     this.cluster =
         Cluster.Builder.create(this, "eks")
             .vpc(vpc)
-            .version(KubernetesVersion.V1.32)
+            .version(KubernetesVersion.V1_32)
             .vpcSubnets(
                 List.of(SubnetSelection.builder().subnetType(SubnetType.PRIVATE_ISOLATED).build()))
             .endpointAccess(EndpointAccess.PRIVATE)

--- a/java/eks/private-cluster/src/test/java/com/amazonaws/cdk/examples/EksPrivateClusterStackTest.java
+++ b/java/eks/private-cluster/src/test/java/com/amazonaws/cdk/examples/EksPrivateClusterStackTest.java
@@ -29,7 +29,7 @@ public class EksPrivateClusterStackTest {
                 "Config",
                 Map.of(
                     "name", "eks-private",
-                    "version", "1.31"))),
+                    "version", "1.32"))),
         1);
   }
 


### PR DESCRIPTION
### What have been improved

* Update support for [Amazon EKS 1.32](https://aws.amazon.com/about-aws/whats-new/2025/01/amazon-eks-eks-distro-kubernetes-version-1-32/)

### References

- https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_eks.KubernetesVersion.html
- https://docs.aws.amazon.com/cdk/api/v2/java/software/amazon/awscdk/services/eks/package-summary.html#quick-start-heading
- https://docs.aws.amazon.com/cdk/api/v2/java/software/amazon/awscdk/services/eks/package-summary.html#kubectl-support-heading

### Additional notes

> Required aws-cdk v2.179.0+ to support Amazon EKS 1.32+
> * https://github.com/aws/aws-cdk/releases/tag/v2.179.0

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
