### PR TITLE
chore(iam): follow the best practice to use "AmazonEC2ContainerRegistryPullOnly" only

### DIFF
--- a/java/eks/fargate-cluster/src/test/resources/com/amazonaws/cdk/EksFargateStackExpected.json
+++ b/java/eks/fargate-cluster/src/test/resources/com/amazonaws/cdk/EksFargateStackExpected.json
@@ -104,7 +104,7 @@
                 {
                   "Ref": "AWS::Partition"
                 },
-                ":iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+                ":iam::aws:policy/AmazonEC2ContainerRegistryPullOnly"
               ]
             ]
           },

--- a/java/eks/private-cluster/src/main/java/com/amazonaws/cdk/examples/EksPrivateClusterStack.java
+++ b/java/eks/private-cluster/src/main/java/com/amazonaws/cdk/examples/EksPrivateClusterStack.java
@@ -175,7 +175,7 @@ public class EksPrivateClusterStack extends Stack {
     client
         .getRole()
         .addManagedPolicy(
-            ManagedPolicy.fromAwsManagedPolicyName("AmazonEC2ContainerRegistryReadOnly"));
+            ManagedPolicy.fromAwsManagedPolicyName("AmazonEC2ContainerRegistryPullOnly"));
     // access to read assets from S3 bucket e.g. kubectl, awscliv2, etc
     client
         .getRole()

--- a/typescript/eks/cluster/index.ts
+++ b/typescript/eks/cluster/index.ts
@@ -51,7 +51,7 @@ class EKSCluster extends cdk.Stack {
         assumedBy: new iam.ServicePrincipal("ec2.amazonaws.com"),
         managedPolicies: [
           "AmazonEKSWorkerNodePolicy",
-          "AmazonEC2ContainerRegistryReadOnly",
+          "AmazonEC2ContainerRegistryPullOnly",
           "AmazonEKS_CNI_Policy",
         ].map((policy) => iam.ManagedPolicy.fromAwsManagedPolicyName(policy)),
       }),


### PR DESCRIPTION
Update IAM requirements for Amazon EKS to use [AmazonEC2ContainerRegistryPullOnly](AmazonEC2ContainerRegistryPullOnly) only.

Furthermore, [AmazonEC2ContainerRegistryReadOnly](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEC2ContainerRegistryReadOnly.html) does not have required permission for [Pull-through Cache (PTR)](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html), where [AmazonEC2ContainerRegistryPullOnly](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEC2ContainerRegistryPullOnly.html) does.

Related discussion:
* https://github.com/aws/karpenter-provider-aws/issues/7956
* https://github.com/aws/karpenter-provider-aws/pull/7963
* https://github.com/eksctl-io/eksctl/issues/8318
* https://github.com/eksctl-io/eksctl/pull/8386

Fixes n/a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
