### PR TITLE
Update api_sqs_lambda_stack.py -- fix the python 3.7 unsupported problem

### DIFF
--- a/python/api-sqs-lambda/api_sqs_lambda/api_sqs_lambda_stack.py
+++ b/python/api-sqs-lambda/api_sqs_lambda/api_sqs_lambda_stack.py
@@ -69,7 +69,7 @@ class ApiSqsLambdaStack(Stack):
         #Creating Lambda function that will be triggered by the SQS Queue
         sqs_lambda = _lambda.Function(self,'SQSTriggerLambda',
             handler='lambda-handler.handler',
-            runtime=_lambda.Runtime.PYTHON_3_7,
+            runtime=_lambda.Runtime.PYTHON_3_11,
             code=_lambda.Code.from_asset('lambda'),
         )
 


### PR DESCRIPTION
<!--
Explain what changed and why.



Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-examples/blob/master/CONTRIBUTING.md
-->

3_7 -> 3_11
fix the python 3.7 unsupported problem
"The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. "

Fixes # <!-- Please create a new issue if none exists yet -->


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
