### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AWS CDK Examples
 
+[![gitcgr](https://gitcgr.com/badge/aws-samples/aws-cdk-examples.svg)](https://gitcgr.com/aws-samples/aws-cdk-examples)
+
 This repository contains a set of example projects for the [AWS Cloud Development
 Kit](https://github.com/aws/aws-cdk).
 


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/aws-samples/aws-cdk-examples.svg)](https://gitcgr.com/aws-samples/aws-cdk-examples)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).