### PR TITLE
feat(typescript): add MWAA Lambda DynamoDB approval workflow

### DIFF
--- a/typescript/airflow-lambda-dynamodb-approval/README.md
+++ b/typescript/airflow-lambda-dynamodb-approval/README.md
@@ -1,0 +1,91 @@
+# MWAA with Lambda Invocation and DynamoDB Human Approval
+
+<!--BEGIN STABILITY BANNER-->
+---
+
+![Stability: Stable](https://img.shields.io/badge/stability-Stable-success.svg?style=for-the-badge)
+
+> **This is a stable example.** It should successfully build out of the box.
+
+---
+<!--END STABILITY BANNER-->
+
+This example deploys an Amazon MWAA (Managed Workflows for Apache Airflow) environment with two DAGs demonstrating common integration patterns:
+
+1. **Lambda Invocation** - Airflow invokes a Lambda function and processes the response
+2. **DynamoDB Human Approval** - A sensor-based workflow that waits for manual approval in DynamoDB before proceeding
+
+## Architecture
+
+```
+                          ┌──────────────────┐
+                          │   Airflow DAG    │
+                          │ (Lambda Invoke)  │
+                          └────────┬─────────┘
+                                   │ invoke
+                                   ▼
+┌─────────┐   DAGs    ┌──────────────────┐    ┌──────────────┐
+│   S3    │◄──────────│      MWAA        │───►│    Lambda    │
+│ Bucket  │           │   Environment    │    │   Function   │
+└─────────┘           └────────┬─────────┘    └──────────────┘
+                               │
+                               │ put/get/sensor
+                               ▼
+                      ┌──────────────────┐
+                      │    DynamoDB      │◄── Human approves
+                      │  Approval Table  │    via AWS Console
+                      └──────────────────┘
+```
+
+## Build
+
+```bash
+npm install
+npm run build
+```
+
+## Deploy
+
+```bash
+npx cdk deploy
+```
+
+Note the outputs:
+- **MwaaWebServerUrl** - Airflow web UI (requires AWS Console login)
+- **ApprovalTableName** - DynamoDB table for the approval workflow
+- **DemoFunctionName** - Lambda function invoked by the DAG
+
+## Usage
+
+### Lambda Invoke DAG
+
+1. Open the Airflow UI via the `MwaaWebServerUrl` output
+2. Trigger the `lambda_invoke` DAG
+3. View task logs to see the Lambda response
+
+### DynamoDB Approval DAG
+
+1. Trigger the `ddb_approval_workflow` DAG
+2. The DAG creates a PENDING item in DynamoDB and waits
+3. In the AWS Console, open DynamoDB, find the item, and change `approval_status` to `APPROVED`
+4. The DAG detects the change and completes processing
+
+## Cleanup
+
+```bash
+npx cdk destroy
+```
+
+## Security Notes
+
+This example follows CDK best practices:
+- Uses `grantInvoke()`, `grantRead()`, and `grantReadWriteData()` for scoped IAM
+- No `expose_config` in Airflow settings
+- SQS and CloudWatch Logs permissions scoped to MWAA-specific resources
+- KMS permissions conditioned via `kms:ViaService`
+- All DAGs use `schedule=None` to avoid unintended costs
+
+For production, additionally consider:
+- `PRIVATE_ONLY` web access mode with VPC endpoints
+- Point-in-time recovery on DynamoDB
+- S3 bucket encryption with customer-managed KMS key

--- a/typescript/airflow-lambda-dynamodb-approval/cdk.json
+++ b/typescript/airflow-lambda-dynamodb-approval/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "npx ts-node index.ts"
+}

--- a/typescript/airflow-lambda-dynamodb-approval/dags/ddb_approval_dag.py
+++ b/typescript/airflow-lambda-dynamodb-approval/dags/ddb_approval_dag.py
@@ -1,0 +1,110 @@
+"""DAG demonstrating a human approval workflow using DynamoDB.
+
+Flow:
+  1. Creates a PENDING approval request in DynamoDB
+  2. Sensors poll until approval_status is changed to APPROVED
+  3. After approval, processes the request
+
+To approve: update the item in DynamoDB and set approval_status = "APPROVED".
+"""
+import json
+from datetime import datetime
+
+import boto3
+import pendulum
+from airflow.decorators import dag, task
+from airflow.providers.amazon.aws.sensors.dynamodb import DynamoDBValueSensor
+
+# The table name is output by the CDK stack. Update this if you customized it.
+APPROVAL_TABLE = "MwaaApprovalWorkflowStack"
+
+
+def _get_table_name() -> str:
+    """Resolve the approval table by CDK stack output prefix."""
+    dynamodb = boto3.client("dynamodb")
+    paginator = dynamodb.get_paginator("list_tables")
+    for page in paginator.paginate():
+        for name in page["TableNames"]:
+            if name.startswith(APPROVAL_TABLE):
+                return name
+    raise RuntimeError(f"No DynamoDB table found with prefix {APPROVAL_TABLE}")
+
+
+@dag(
+    dag_id="ddb_approval_workflow",
+    start_date=pendulum.datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["dynamodb", "approval", "demo"],
+    description="Human approval workflow - waits for APPROVED status in DynamoDB",
+)
+def ddb_approval_dag():
+    @task
+    def create_approval_request(**context):
+        """Insert a PENDING approval request into DynamoDB."""
+        table_name = _get_table_name()
+        process_id = context["dag_run"].run_id
+
+        item = {
+            "id": process_id,
+            "requester": "airflow-demo",
+            "amount": 25000,
+            "reason": "Quarterly budget allocation",
+            "approval_status": "PENDING",
+            "created_at": datetime.now().isoformat(),
+        }
+
+        dynamodb = boto3.resource("dynamodb")
+        table = dynamodb.Table(table_name)
+        table.put_item(Item=item)
+
+        print(f"Created approval request: {process_id}")
+        print(f"Table: {table_name}")
+        print("To approve: set approval_status to APPROVED in DynamoDB console")
+        return {"process_id": process_id, "table_name": table_name}
+
+    @task
+    def process_approved(**context):
+        """Process the request after human approval."""
+        table_name = _get_table_name()
+        process_id = context["dag_run"].run_id
+
+        dynamodb = boto3.resource("dynamodb")
+        table = dynamodb.Table(table_name)
+        response = table.get_item(Key={"id": process_id})
+        item = response.get("Item", {})
+
+        print(f"Approved request: {json.dumps(item, default=str, indent=2)}")
+
+        # Mark as processed
+        table.update_item(
+            Key={"id": process_id},
+            UpdateExpression="SET approval_status = :s, processed_at = :t",
+            ExpressionAttributeValues={
+                ":s": "PROCESSED",
+                ":t": datetime.now().isoformat(),
+            },
+        )
+        print("Request processed successfully")
+        return item
+
+    request = create_approval_request()
+
+    wait_for_approval = DynamoDBValueSensor(
+        task_id="wait_for_approval",
+        table_name="{{ ti.xcom_pull(task_ids='create_approval_request')['table_name'] }}",
+        partition_key_name="id",
+        partition_key_value="{{ ti.xcom_pull(task_ids='create_approval_request')['process_id'] }}",
+        attribute_name="approval_status",
+        attribute_value="APPROVED",
+        poke_interval=30,
+        timeout=60 * 60 * 24,  # 24 hours
+        mode="reschedule",
+    )
+
+    approved = process_approved()
+
+    request >> wait_for_approval >> approved
+
+
+ddb_approval_dag()

--- a/typescript/airflow-lambda-dynamodb-approval/dags/lambda_invoke_dag.py
+++ b/typescript/airflow-lambda-dynamodb-approval/dags/lambda_invoke_dag.py
@@ -1,0 +1,63 @@
+"""DAG demonstrating Lambda invocation from Airflow using boto3."""
+import json
+from datetime import datetime
+
+import boto3
+import pendulum
+from airflow.decorators import dag, task
+
+DEMO_FUNCTION_NAME = "MwaaApprovalWorkflowStack-DemoFunction"
+
+
+@dag(
+    dag_id="lambda_invoke",
+    start_date=pendulum.datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["lambda", "demo"],
+    description="Invoke a Lambda function from Airflow and process the response",
+)
+def lambda_invoke_dag():
+    @task
+    def invoke_lambda():
+        client = boto3.client("lambda")
+        # Find the demo function by prefix (CDK adds a suffix)
+        paginator = client.get_paginator("list_functions")
+        function_name = None
+        for page in paginator.paginate():
+            for fn in page["Functions"]:
+                if fn["FunctionName"].startswith(DEMO_FUNCTION_NAME):
+                    function_name = fn["FunctionName"]
+                    break
+            if function_name:
+                break
+
+        if not function_name:
+            raise RuntimeError(f"No function found with prefix {DEMO_FUNCTION_NAME}")
+
+        payload = {
+            "message": "Hello from Airflow!",
+            "timestamp": datetime.now().isoformat(),
+        }
+
+        response = client.invoke(
+            FunctionName=function_name,
+            InvocationType="RequestResponse",
+            Payload=json.dumps(payload),
+        )
+        result = json.loads(response["Payload"].read())
+        print(f"Lambda response: {json.dumps(result, indent=2)}")
+        return result
+
+    @task
+    def process_result(result: dict):
+        body = json.loads(result.get("body", "{}"))
+        print(f"Lambda processed at: {body.get('processed_at')}")
+        print(f"Request ID: {body.get('request_id')}")
+        return body
+
+    result = invoke_lambda()
+    process_result(result)
+
+
+lambda_invoke_dag()

--- a/typescript/airflow-lambda-dynamodb-approval/index.ts
+++ b/typescript/airflow-lambda-dynamodb-approval/index.ts
@@ -1,0 +1,185 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as s3 from "aws-cdk-lib/aws-s3";
+import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as mwaa from "aws-cdk-lib/aws-mwaa";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import { Construct } from "constructs";
+
+export class MwaaApprovalWorkflowStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // VPC for MWAA (requires private subnets with NAT)
+    const vpc = new ec2.Vpc(this, "Vpc", {
+      maxAzs: 2,
+      natGateways: 1,
+      subnetConfiguration: [
+        { cidrMask: 24, name: "public", subnetType: ec2.SubnetType.PUBLIC },
+        { cidrMask: 24, name: "private", subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+      ],
+    });
+
+    // S3 bucket for DAGs (versioning required by MWAA)
+    const dagsBucket = new s3.Bucket(this, "DagsBucket", {
+      versioned: true,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+    });
+
+    // Upload DAGs to S3
+    new s3deploy.BucketDeployment(this, "DeployDags", {
+      sources: [s3deploy.Source.asset("./dags")],
+      destinationBucket: dagsBucket,
+      destinationKeyPrefix: "dags",
+    });
+
+    // DynamoDB table for approval workflow
+    const approvalTable = new dynamodb.Table(this, "ApprovalTable", {
+      partitionKey: { name: "id", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+    });
+
+    // Demo Lambda function invoked by Airflow
+    const demoFunction = new lambda.Function(this, "DemoFunction", {
+      runtime: lambda.Runtime.PYTHON_3_12,
+      handler: "index.handler",
+      code: lambda.Code.fromAsset("lambda"),
+      timeout: cdk.Duration.seconds(30),
+      memorySize: 128,
+    });
+
+    // MWAA execution role
+    const mwaaRole = new iam.Role(this, "MwaaRole", {
+      assumedBy: new iam.ServicePrincipal("airflow-env.amazonaws.com"),
+    });
+
+    // S3 access for DAGs bucket
+    dagsBucket.grantRead(mwaaRole);
+
+    // DynamoDB access scoped to approval table
+    approvalTable.grantReadWriteData(mwaaRole);
+
+    // Lambda invoke scoped to demo function
+    demoFunction.grantInvoke(mwaaRole);
+
+    // CloudWatch Logs for MWAA (scoped to airflow log groups)
+    mwaaRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: [
+          "logs:CreateLogStream",
+          "logs:CreateLogGroup",
+          "logs:PutLogEvents",
+          "logs:GetLogEvents",
+          "logs:GetLogRecord",
+          "logs:GetLogGroupFields",
+          "logs:GetQueryResults",
+        ],
+        resources: [
+          `arn:aws:logs:${this.region}:${this.account}:log-group:airflow-*`,
+        ],
+      })
+    );
+
+    // SQS for Airflow Celery executor (MWAA-managed queues)
+    mwaaRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: [
+          "sqs:ChangeMessageVisibility",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:GetQueueUrl",
+          "sqs:ReceiveMessage",
+          "sqs:SendMessage",
+        ],
+        resources: [
+          `arn:aws:sqs:${this.region}:${this.account}:airflow-celery-*`,
+        ],
+      })
+    );
+
+    // KMS for MWAA encryption (conditioned to SQS/S3 usage)
+    mwaaRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ["kms:Decrypt", "kms:DescribeKey", "kms:GenerateDataKey*", "kms:Encrypt"],
+        resources: ["*"],
+        conditions: {
+          StringEquals: {
+            "kms:ViaService": [
+              `sqs.${this.region}.amazonaws.com`,
+              `s3.${this.region}.amazonaws.com`,
+            ],
+          },
+        },
+      })
+    );
+
+    // CloudWatch Metrics (required by MWAA, no resource-level scoping available)
+    mwaaRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ["cloudwatch:PutMetricData"],
+        resources: ["*"],
+        conditions: {
+          StringEquals: { "cloudwatch:namespace": "AWS/MWAA" },
+        },
+      })
+    );
+
+    // Security group for MWAA
+    const sg = new ec2.SecurityGroup(this, "MwaaSg", {
+      vpc,
+      description: "MWAA environment security group",
+      allowAllOutbound: true,
+    });
+    sg.addIngressRule(sg, ec2.Port.allTraffic(), "Self-referencing rule for MWAA");
+
+    // MWAA environment
+    const mwaaEnv = new mwaa.CfnEnvironment(this, "MwaaEnv", {
+      name: `mwaa-approval-${this.region}`,
+      dagS3Path: "dags",
+      executionRoleArn: mwaaRole.roleArn,
+      sourceBucketArn: dagsBucket.bucketArn,
+      networkConfiguration: {
+        subnetIds: vpc.privateSubnets.map((s) => s.subnetId),
+        securityGroupIds: [sg.securityGroupId],
+      },
+      environmentClass: "mw1.small",
+      maxWorkers: 2,
+      minWorkers: 1,
+      airflowVersion: "2.9.2",
+      webserverAccessMode: "PUBLIC_ONLY",
+      airflowConfigurationOptions: {
+        "core.default_timezone": "UTC",
+      },
+      loggingConfiguration: {
+        dagProcessingLogs: { enabled: true, logLevel: "INFO" },
+        schedulerLogs: { enabled: true, logLevel: "INFO" },
+        taskLogs: { enabled: true, logLevel: "INFO" },
+        webserverLogs: { enabled: true, logLevel: "INFO" },
+        workerLogs: { enabled: true, logLevel: "INFO" },
+      },
+    });
+
+    // Outputs
+    new cdk.CfnOutput(this, "MwaaWebServerUrl", {
+      value: `https://${mwaaEnv.attrWebserverUrl}`,
+    });
+    new cdk.CfnOutput(this, "ApprovalTableName", {
+      value: approvalTable.tableName,
+    });
+    new cdk.CfnOutput(this, "DemoFunctionName", {
+      value: demoFunction.functionName,
+    });
+    new cdk.CfnOutput(this, "DagsBucketName", {
+      value: dagsBucket.bucketName,
+    });
+  }
+}
+
+const app = new cdk.App();
+new MwaaApprovalWorkflowStack(app, "MwaaApprovalWorkflowStack");

--- a/typescript/airflow-lambda-dynamodb-approval/lambda/index.py
+++ b/typescript/airflow-lambda-dynamodb-approval/lambda/index.py
@@ -1,0 +1,17 @@
+import json
+import datetime
+
+
+def handler(event, context):
+    """Demo Lambda invoked by Airflow to process a payload and return a result."""
+    print(f"Received event: {json.dumps(event)}")
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "status": "success",
+            "processed_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "message": event.get("message", "Hello from Lambda!"),
+            "request_id": context.aws_request_id,
+        }),
+    }

--- a/typescript/airflow-lambda-dynamodb-approval/package.json
+++ b/typescript/airflow-lambda-dynamodb-approval/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "airflow-lambda-dynamodb-approval",
+  "version": "1.0.0",
+  "description": "MWAA with Lambda invocation and DynamoDB human approval workflow",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "cdk": "cdk"
+  },
+  "author": {
+    "name": "Amazon Web Services",
+    "url": "https://aws.amazon.com",
+    "organization": true
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "aws-cdk": "2.1119.0",
+    "typescript": "~5.7.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "2.201.0",
+    "constructs": "^10.0.0"
+  }
+}

--- a/typescript/airflow-lambda-dynamodb-approval/tsconfig.json
+++ b/typescript/airflow-lambda-dynamodb-approval/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false
+  },
+  "exclude": ["cdk.out"]
+}


### PR DESCRIPTION
## Description

Adds a clean MWAA (Managed Workflows for Apache Airflow) example demonstrating two common patterns:

1. **Lambda Invocation** - Airflow DAG invokes a Lambda function and processes the response
2. **DynamoDB Human Approval** - Sensor-based workflow that waits for manual approval in DynamoDB

This is a rewrite of #1207 with the following improvements:

### Security fixes
- Uses CDK grant methods (`grantInvoke`, `grantRead`, `grantReadWriteData`) instead of wildcard IAM
- CloudWatch Logs scoped to `airflow-*` log groups
- SQS permissions scoped to `${account}:airflow-celery-*`
- KMS conditioned via `kms:ViaService`
- CloudWatch Metrics conditioned to `AWS/MWAA` namespace
- No `webserver.expose_config`

### Other improvements
- Lambda runtime: Python 3.12 (was 3.9)
- All DAGs use `schedule=None` (no accidental cost)
- Modern Airflow TaskFlow API with `@dag`/`@task` decorators
- Airflow 2.9.2 (was 2.7.2)
- Removed redundant `example_dag` that added no value
- Flat project structure (single `index.ts`, no bin/lib split)
- CDK synth verified

Supersedes #1207

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0