### PR TITLE
fix(typescript): remove hardcoded bucket name from static-site

### DIFF
--- a/typescript/static-site/static-site.ts
+++ b/typescript/static-site/static-site.ts
@@ -32,8 +32,6 @@ export class StaticSite extends Construct {
 
     // Content bucket
     const siteBucket = new s3.Bucket(this, 'SiteBucket', {
-      bucketName: siteDomain,
-      publicReadAccess: false,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
 
       /**


### PR DESCRIPTION
CloudFront with Origin Access Control (OAC) does not require the S3 bucket name to match the domain. The hardcoded `bucketName: siteDomain` was causing deployment failures when re-deploying (#1022) because CloudFormation can't create a bucket that already exists from a prior run.

Changes:
- Remove `bucketName: siteDomain` - let CDK auto-generate the name
- Remove redundant `publicReadAccess: false` (`BlockPublicAccess.BLOCK_ALL` already covers it)

With CloudFront + OAC, routing is: Route53 → CloudFront (domain names configured) → S3 (any bucket name). The bucket name is irrelevant to the domain resolution.

Fixes #1022

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0