### PR TITLE
feat(typescript): add AppConfig hosted configuration with Lambda Extension

### DIFF
--- a/typescript/appconfig-hosted-lambda/README.md
+++ b/typescript/appconfig-hosted-lambda/README.md
@@ -1,0 +1,92 @@
+# AppConfig Hosted Configuration with Lambda Extension
+
+<!--BEGIN STABILITY BANNER-->
+---
+
+![Stability: Stable](https://img.shields.io/badge/stability-Stable-success.svg?style=for-the-badge)
+
+> **This is a stable example.** It should successfully build out of the box.
+
+---
+<!--END STABILITY BANNER-->
+
+This example deploys an AWS AppConfig hosted configuration with feature flags, consumed by a Lambda function via the [AppConfig Lambda Extension](https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-integration-lambda-extensions.html).
+
+## Architecture
+
+```
+Lambda Function
+  │
+  │ HTTP GET localhost:2772
+  ▼
+AppConfig Lambda Extension (sidecar)
+  │
+  │ polls / caches
+  ▼
+AppConfig Service
+  └── Application: MyFeatureFlags
+      └── Environment: Production
+          └── Hosted Configuration (feature flags JSON)
+```
+
+The Lambda Extension:
+- Runs as a local HTTP server on port 2772 inside the Lambda execution environment
+- Handles configuration caching, polling, and session management
+- No need to hardcode layer ARNs - CDK's `grantReadConfig()` manages the extension automatically
+
+## Feature Flags
+
+The example deploys two feature flags:
+
+| Flag | Default |
+|------|---------|
+| `dark_mode` | enabled |
+| `new_checkout` | disabled |
+
+Update flags in the AppConfig console or by modifying the `content` in `index.ts` and redeploying.
+
+## Build
+
+```bash
+npm install
+npm run build
+```
+
+## Deploy
+
+```bash
+npx cdk deploy
+```
+
+## Test
+
+```bash
+aws lambda invoke \
+  --function-name $(aws cloudformation describe-stacks \
+    --stack-name AppConfigHostedLambdaStack \
+    --query 'Stacks[0].Outputs[?OutputKey==`FunctionName`].OutputValue' \
+    --output text) \
+  --payload '{}' \
+  output.json && cat output.json
+```
+
+Expected response:
+```json
+{
+  "statusCode": 200,
+  "body": "{\"flags\": {\"dark_mode\": true, \"new_checkout\": false}, \"message\": \"Dark mode is ON\"}"
+}
+```
+
+## How it works
+
+1. CDK creates an AppConfig Application, Environment, and HostedConfiguration with feature flag JSON
+2. `grantReadConfig()` adds the AppConfig Lambda Extension layer and IAM permissions automatically
+3. At runtime, the Lambda calls `http://localhost:2772/applications/.../configurations/...` to fetch flags
+4. The extension caches the config locally - no cold-start penalty on subsequent invocations
+
+## Cleanup
+
+```bash
+npx cdk destroy
+```

--- a/typescript/appconfig-hosted-lambda/cdk.json
+++ b/typescript/appconfig-hosted-lambda/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "npx ts-node index.ts"
+}

--- a/typescript/appconfig-hosted-lambda/index.ts
+++ b/typescript/appconfig-hosted-lambda/index.ts
@@ -1,0 +1,70 @@
+import * as cdk from "aws-cdk-lib";
+import * as appconfig from "aws-cdk-lib/aws-appconfig";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as path from "path";
+import { Construct } from "constructs";
+
+export class AppConfigHostedLambdaStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // AppConfig application and environment
+    const app = new appconfig.Application(this, "App", {
+      applicationName: "MyFeatureFlags",
+    });
+
+    const env = new appconfig.Environment(this, "Env", {
+      application: app,
+      environmentName: "Production",
+    });
+
+    // Hosted configuration with feature flags
+    new appconfig.HostedConfiguration(this, "Config", {
+      application: app,
+      deployTo: [env],
+      type: appconfig.ConfigurationType.FEATURE_FLAGS,
+      content: appconfig.ConfigurationContent.fromInlineJson(
+        JSON.stringify({
+          version: "1",
+          flags: {
+            dark_mode: { name: "dark_mode" },
+            new_checkout: { name: "new_checkout" },
+          },
+          values: {
+            dark_mode: { enabled: true },
+            new_checkout: { enabled: false },
+          },
+        })
+      ),
+      deploymentStrategy: appconfig.DeploymentStrategy.fromDeploymentStrategyId(
+        this, "Strategy",
+        appconfig.DeploymentStrategyId.ALL_AT_ONCE
+      ),
+    });
+
+    // Lambda function that reads feature flags via the AppConfig Lambda Extension
+    const fn = new lambda.Function(this, "Fn", {
+      runtime: lambda.Runtime.PYTHON_3_12,
+      handler: "index.handler",
+      code: lambda.Code.fromAsset(path.join(__dirname, "lambda")),
+      timeout: cdk.Duration.seconds(10),
+      environment: {
+        APPCONFIG_APP: app.applicationId,
+        APPCONFIG_ENV: env.environmentId,
+        APPCONFIG_CONFIG: "MyFeatureFlags",
+        // Prefetch config during extension init to reduce cold start latency
+        AWS_APPCONFIG_EXTENSION_PREFETCH_LIST: "/applications/MyFeatureFlags/environments/Production/configurations/MyFeatureFlags",
+      },
+    });
+
+    // Grant the Lambda permission to read the configuration
+    env.grantReadConfig(fn);
+
+    // Outputs
+    new cdk.CfnOutput(this, "FunctionName", { value: fn.functionName });
+    new cdk.CfnOutput(this, "ApplicationId", { value: app.applicationId });
+  }
+}
+
+const app = new cdk.App();
+new AppConfigHostedLambdaStack(app, "AppConfigHostedLambdaStack");

--- a/typescript/appconfig-hosted-lambda/lambda/index.py
+++ b/typescript/appconfig-hosted-lambda/lambda/index.py
@@ -1,0 +1,50 @@
+"""Lambda handler that reads feature flags from AppConfig via the Lambda Extension.
+
+The AppConfig Lambda Extension runs as a local HTTP server on port 2772.
+It handles caching, polling, and session management automatically.
+"""
+
+import json
+import os
+import urllib.request
+
+APPCONFIG_APP = os.environ["APPCONFIG_APP"]
+APPCONFIG_ENV = os.environ["APPCONFIG_ENV"]
+APPCONFIG_CONFIG = os.environ["APPCONFIG_CONFIG"]
+
+EXTENSION_URL = (
+    f"http://localhost:2772/applications/{APPCONFIG_APP}"
+    f"/environments/{APPCONFIG_ENV}"
+    f"/configurations/{APPCONFIG_CONFIG}"
+)
+
+
+def get_config() -> dict:
+    """Fetch configuration from the AppConfig Lambda Extension."""
+    req = urllib.request.Request(EXTENSION_URL)
+    with urllib.request.urlopen(req) as response:
+        return json.loads(response.read())
+
+
+def is_enabled(config: dict, flag_name: str) -> bool:
+    """Check if a feature flag is enabled."""
+    return config.get("values", {}).get(flag_name, {}).get("enabled", False)
+
+
+def handler(event, context):
+    config = get_config()
+
+    flags = {
+        flag: is_enabled(config, flag)
+        for flag in config.get("flags", {})
+    }
+
+    print(f"Feature flags: {json.dumps(flags)}")
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "flags": flags,
+            "message": "Dark mode is ON" if flags.get("dark_mode") else "Dark mode is OFF",
+        }),
+    }

--- a/typescript/appconfig-hosted-lambda/package.json
+++ b/typescript/appconfig-hosted-lambda/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "appconfig-hosted-lambda",
+  "version": "1.0.0",
+  "description": "AppConfig hosted configuration with Lambda Extension for feature flags",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "cdk": "cdk"
+  },
+  "author": {
+    "name": "Amazon Web Services",
+    "url": "https://aws.amazon.com",
+    "organization": true
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "aws-cdk": "2.1126.0",
+    "typescript": "~5.7.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "2.259.0",
+    "constructs": "^10.0.0"
+  }
+}

--- a/typescript/appconfig-hosted-lambda/tsconfig.json
+++ b/typescript/appconfig-hosted-lambda/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["es2020"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false
+  },
+  "exclude": ["cdk.out"]
+}


### PR DESCRIPTION
Adds a clean, minimal example of AWS AppConfig feature flags consumed by a Lambda function via the AppConfig Lambda Extension.

## What this demonstrates

- AppConfig L2 constructs (`Application`, `Environment`, `HostedConfiguration`)
- Feature flag configuration type with JSON content
- `grantReadConfig()` which automatically adds the Lambda Extension layer and IAM permissions
- Lambda reading flags at runtime via the Extension's local HTTP endpoint (`localhost:2772`)

## Key difference from existing evidently examples

- **No hardcoded layer ARNs** - `grantReadConfig()` manages the extension layer automatically
- **Pure AppConfig** - no Evidently dependency, just feature flags
- **Uses L2 constructs** - not CfnApplication/CfnEnvironment
- **Minimal** - ~65 lines of CDK, ~50 lines of Lambda handler

Fixes #360

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0