### PR TITLE
chore: update CDK CLI version for non-typescript projects

### DIFF
--- a/csharp/package.json
+++ b/csharp/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "aws-cdk": "2.1006.0"
+    "aws-cdk": "2.1133.0"
   }
 }

--- a/go/package.json
+++ b/go/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "aws-cdk": "2.1006.0"
+    "aws-cdk": "2.1133.0"
   }
 }

--- a/java/package.json
+++ b/java/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "aws-cdk": "2.1006.0"
+    "aws-cdk": "2.1133.0"
   }
 }

--- a/python/package.json
+++ b/python/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "aws-cdk": "2.1006.0"
+    "aws-cdk": "2.1133.0"
   }
 }


### PR DESCRIPTION
Bumps `aws-cdk` from 2.1006.0 to 2.1114.1 in csharp, go, java, and python project root `package.json` files.

These are the CLI-only package.json files used by non-TypeScript examples to pin the CDK CLI version.