### PR TITLE
feat(python): update CDK dependencies

### DIFF
--- a/python/amazon-connect/requirements.txt
+++ b/python/amazon-connect/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib==2.153.0
-constructs>=10.0.0,<11.0.0
-cdk-nag>=2.28.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
+cdk-nag>=2.28.0,<3.0.0

--- a/python/amazon-verified-permissions-rest-api/requirements.txt
+++ b/python/amazon-verified-permissions-rest-api/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib==2.219.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 cdklabs.cdk-verified-permissions==0.3.0

--- a/python/api-cors-lambda/requirements.txt
+++ b/python/api-cors-lambda/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/api-eventbridge-lambda/requirements.txt
+++ b/python/api-eventbridge-lambda/requirements.txt
@@ -1,5 +1,5 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 aws_lambda_powertools
 types-boto3
 types-setuptools

--- a/python/api-sqs-lambda/requirements.txt
+++ b/python/api-sqs-lambda/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 types-setuptools

--- a/python/api-stages-lambda/requirements.txt
+++ b/python/api-stages-lambda/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 types-setuptools

--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/requirements.txt
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.77.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/application-load-balancer/requirements.txt
+++ b/python/application-load-balancer/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 # Work around for jsii#413

--- a/python/appsync-graphql-dynamodb/requirements.txt
+++ b/python/appsync-graphql-dynamodb/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/athena-s3-glue/requirements.txt
+++ b/python/athena-s3-glue/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.115.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/backup-s3/requirements.txt
+++ b/python/backup-s3/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.20.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/batch/batch-arm64-instance-type/requirements.txt
+++ b/python/batch/batch-arm64-instance-type/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.140.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/batch/batch-using-fargate/requirements.txt
+++ b/python/batch/batch-using-fargate/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.140.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/batch/batch-with-EC2/requirements.txt
+++ b/python/batch/batch-with-EC2/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.140.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/cdk-validator-cfnguard/requirements.txt
+++ b/python/cdk-validator-cfnguard/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib==2.87.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 cdklabs.cdk-validator-cfnguard>=0.0.51

--- a/python/classic-load-balancer/requirements.txt
+++ b/python/classic-load-balancer/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 # Work around for jsii#413

--- a/python/codepipeline-build-deploy-github-manual/requirements.txt
+++ b/python/codepipeline-build-deploy-github-manual/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib==2.154.1
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 

--- a/python/codepipeline-build-deploy/requirements.txt
+++ b/python/codepipeline-build-deploy/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib==2.158.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 

--- a/python/codepipeline-docker-build/requirements.txt
+++ b/python/codepipeline-docker-build/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/cross-account-eventbridge-in-organization/event_bridge_cross_account/ConsumerStack.py
+++ b/python/cross-account-eventbridge-in-organization/event_bridge_cross_account/ConsumerStack.py
@@ -65,7 +65,7 @@ class ConsumerStack(Stack):
         lambda_function = _lambda.Function(
             self,
             "ConsumerLambda",
-            runtime=_lambda.Runtime.PYTHON_3_12,
+            runtime=_lambda.Runtime.PYTHON_3_14,
             handler="consumer.handler",
             timeout=Duration.seconds(30),
             code=_lambda.Code.from_asset("./lambda/consumer"),

--- a/python/cross-account-eventbridge-in-organization/event_bridge_cross_account/ProducerStack.py
+++ b/python/cross-account-eventbridge-in-organization/event_bridge_cross_account/ProducerStack.py
@@ -110,7 +110,7 @@ class ProducerStack(Stack):
         lambda_function = _lambda.Function(
             self,
             "ProducerLambda",
-            runtime=_lambda.Runtime.PYTHON_3_12,
+            runtime=_lambda.Runtime.PYTHON_3_14,
             handler="producer.handler",
             timeout=Duration.seconds(30),
             code=_lambda.Code.from_asset("./lambda/producer"),

--- a/python/cross-account-eventbridge-in-organization/requirements.txt
+++ b/python/cross-account-eventbridge-in-organization/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0,<11.0.0
-cdk_nag>=2.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
+cdk_nag>=2.0.0,<3.0.0

--- a/python/cross-stack-resources/native-objects/requirements.txt
+++ b/python/cross-stack-resources/native-objects/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 pytest
 types-setuptools

--- a/python/cross-stack-resources/raw-strings/requirements.txt
+++ b/python/cross-stack-resources/raw-strings/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 pytest
 types-setuptools

--- a/python/custom-resource/requirements.txt
+++ b/python/custom-resource/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/datasync-s3/requirements.txt
+++ b/python/datasync-s3/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.79.1
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/ddb/global-table-with-cmk/requirements.txt
+++ b/python/ddb/global-table-with-cmk/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.20.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/docker-app-with-asg-alb/requirements.txt
+++ b/python/docker-app-with-asg-alb/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 types-setuptools

--- a/python/dynamodb-lambda/requirements.txt
+++ b/python/dynamodb-lambda/requirements.txt
@@ -1,5 +1,5 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 boto3
 botocore
 types-setuptools

--- a/python/ec2-alarms-to-opsitem/requirements.txt
+++ b/python/ec2-alarms-to-opsitem/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.41.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/ec2-cloudwatch/requirements.txt
+++ b/python/ec2-cloudwatch/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 types-setuptools

--- a/python/ec2/instance/requirements.txt
+++ b/python/ec2/instance/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/ecs-schedulescaling/requirements.txt
+++ b/python/ecs-schedulescaling/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.111.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/ecs-serviceconnect/requirements.txt
+++ b/python/ecs-serviceconnect/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib==2.147.1
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 cdk_ecr_deployment

--- a/python/ecs/cluster/requirements.txt
+++ b/python/ecs/cluster/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/ecs/ecs-load-balanced-service/requirements.txt
+++ b/python/ecs/ecs-load-balanced-service/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/ecs/ecs-service-with-advanced-alb-config/requirements.txt
+++ b/python/ecs/ecs-service-with-advanced-alb-config/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/ecs/ecs-service-with-task-networking/requirements.txt
+++ b/python/ecs/ecs-service-with-task-networking/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/ecs/ecs-service-with-task-placement/requirements.txt
+++ b/python/ecs/ecs-service-with-task-placement/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/ecs/fargate-load-balanced-service/requirements.txt
+++ b/python/ecs/fargate-load-balanced-service/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/ecs/fargate-service-with-autoscaling/requirements.txt
+++ b/python/ecs/fargate-service-with-autoscaling/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 # Work around for jsii#413

--- a/python/ecs/fargate-service-with-efs/requirements.txt
+++ b/python/ecs/fargate-service-with-efs/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.144.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/emr/requirements.txt
+++ b/python/emr/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/eventbridge-mesh/multiple-consumers/requirements.txt
+++ b/python/eventbridge-mesh/multiple-consumers/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.186.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/eventbridge-mesh/single-consumer/requirements.txt
+++ b/python/eventbridge-mesh/single-consumer/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.186.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/existing-vpc-new-ec2-ebs-userdata/requirements.txt
+++ b/python/existing-vpc-new-ec2-ebs-userdata/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 types-setuptools

--- a/python/image-content-search/requirements.txt
+++ b/python/image-content-search/requirements.txt
@@ -1,5 +1,5 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 awscli
 boto3
 botocore

--- a/python/iot-msk-lambda-pipeline/requirements.txt
+++ b/python/iot-msk-lambda-pipeline/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib==2.33.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 aws-cdk.aws-msk-alpha<=2.36.0a0

--- a/python/iotcore/requirements.txt
+++ b/python/iotcore/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.101.1
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/lambda-cloudwatch-dashboard/pyproject.toml
+++ b/python/lambda-cloudwatch-dashboard/pyproject.toml
@@ -4,8 +4,8 @@ version = "0.0.2"
 description = "CloudWatch Dashboard Sample"
 readme = "README.md"
 dependencies = [
-    "aws-cdk-lib>=2.0.0,<3",
-    "constructs>=10.0.0,<11"
+    "aws-cdk-lib>=2.262.0,<3.0.0",
+    "constructs>=10.5.0,<11.0.0"
 ]
 requires-python = ">=3.9,<4"
 classifiers = [

--- a/python/lambda-cloudwatch-dashboard/requirements.txt
+++ b/python/lambda-cloudwatch-dashboard/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0,<3
-constructs>=10.0.0,<11
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/lambda-cron/requirements.txt
+++ b/python/lambda-cron/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 pytest

--- a/python/lambda-from-container/requirements.txt
+++ b/python/lambda-from-container/requirements.txt
@@ -1,5 +1,5 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 ##
 ## jsii must be 1.14.1 or better on Python 3.7
 ##

--- a/python/lambda-layer/requirements.txt
+++ b/python/lambda-layer/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/lambda-nag/app.py
+++ b/python/lambda-nag/app.py
@@ -51,7 +51,7 @@ class LambdaNagExampleStack(Stack):
             handler="index.handler",
             timeout=Duration.seconds(30),
             role=lambda_func_role,
-            runtime=lambda_.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_14,
         )
 
 app = App()

--- a/python/lambda-nag/requirements.txt
+++ b/python/lambda-nag/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.140.0
-constructs>=10.0.0
-cdk-nag
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
+cdk-nag>=2.0.0,<3.0.0

--- a/python/lambda-s3-trigger/requirements.txt
+++ b/python/lambda-s3-trigger/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/lambda-triggered-by-existing-kinesis-stream/requirements.txt
+++ b/python/lambda-triggered-by-existing-kinesis-stream/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/lambda-with-existing-s3-code/requirements.txt
+++ b/python/lambda-with-existing-s3-code/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/my-widget-service/requirements.txt
+++ b/python/my-widget-service/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 types-setuptools

--- a/python/new-vpc-alb-asg-mysql/requirements.txt
+++ b/python/new-vpc-alb-asg-mysql/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 types-setuptools

--- a/python/opensearch-simple-domain/requirements.txt
+++ b/python/opensearch-simple-domain/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.59.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/opensearch/ctcwl-oss/requirements.txt
+++ b/python/opensearch/ctcwl-oss/requirements.txt
@@ -1,5 +1,5 @@
-aws-cdk-lib==2.81.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 requests_aws4auth==1.2.2
 opensearch-py==2.2.0
 awscli

--- a/python/opensearch/ddb-zero-etl/requirements.txt
+++ b/python/opensearch/ddb-zero-etl/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.127.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/opensearch/os-vpc-provision/requirements.txt
+++ b/python/opensearch/os-vpc-provision/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.35.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/rds/aurora/requirements.txt
+++ b/python/rds/aurora/requirements.txt
@@ -1,11 +1,11 @@
 ##
 ## CDK
 ##
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 
 ##
 ## If your project uses cdk version 1.x.x use cdk-nag ^1.0.0
 ## If your project uses cdk version 2.x.x use cdk-nag ^2.0.0
 ##
-cdk_nag>=2.0.0
+cdk_nag>=2.0.0,<3.0.0

--- a/python/rds/mysql/requirements.txt
+++ b/python/rds/mysql/requirements.txt
@@ -1,11 +1,11 @@
 ##
 ## CDK
 ##
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 
 ##
 ## If your project uses cdk version 1.x.x use cdk-nag ^1.0.0
 ## If your project uses cdk version 2.x.x use cdk-nag ^2.0.0
 ##
-cdk_nag>=2.0.0
+cdk_nag>=2.0.0,<3.0.0

--- a/python/rds/oracle/requirements.txt
+++ b/python/rds/oracle/requirements.txt
@@ -1,11 +1,11 @@
 ##
 ## CDK
 ##
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 
 ##
 ## If your project uses cdk version 1.x.x use cdk-nag ^1.0.0
 ## If your project uses cdk version 2.x.x use cdk-nag ^2.0.0
 ##
-cdk_nag>=2.0.0
+cdk_nag>=2.0.0,<3.0.0

--- a/python/rekognition-lambda-s3-trigger/requirements.txt
+++ b/python/rekognition-lambda-s3-trigger/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 types-boto3
 types-setuptools

--- a/python/rekognition-video-processor/requirements.txt
+++ b/python/rekognition-video-processor/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.81.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/route53-failover/requirements.txt
+++ b/python/route53-failover/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.146.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/s3-eventbridge-ecs/requirements.txt
+++ b/python/s3-eventbridge-ecs/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.89.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/s3-object-lambda/requirements.txt
+++ b/python/s3-object-lambda/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 types-boto3

--- a/python/s3-sns-sqs-lambda-chain/requirements.txt
+++ b/python/s3-sns-sqs-lambda-chain/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib>=2.12.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/sagemaker-multimodel-endpoint/requirements.txt
+++ b/python/sagemaker-multimodel-endpoint/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.10.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 requests
 boto3

--- a/python/serverless-backend/requirements.txt
+++ b/python/serverless-backend/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.20.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/servicecatalog/portfolio-with-ec2-product/requirements.txt
+++ b/python/servicecatalog/portfolio-with-ec2-product/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0rc1
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 aws-cdk.aws_servicecatalog_alpha==2.8.0a0

--- a/python/ssh-into-emr-cluster/requirements.txt
+++ b/python/ssh-into-emr-cluster/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.115.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/stepfunctions/requirements.txt
+++ b/python/stepfunctions/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 types-setuptools

--- a/python/url-shortener/requirements.txt
+++ b/python/url-shortener/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 boto3
 types-setuptools

--- a/python/vpc-ec2-local-zones/requirements.txt
+++ b/python/vpc-ec2-local-zones/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.51.0
-constructs>=10.0.0,<11.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0

--- a/python/waf/requirements.txt
+++ b/python/waf/requirements.txt
@@ -1,5 +1,5 @@
-aws-cdk-lib>=2.0.0
-constructs>=10.0.0
+aws-cdk-lib>=2.262.0,<3.0.0
+constructs>=10.5.0,<11.0.0
 ##
 ## jsii must be 1.14.1 or better on Python 3.7
 ##


### PR DESCRIPTION
## Summary
- align all 78 Python CDK applications with current `cdk init --language=python` dependency ranges
- synchronize the existing `pyproject.toml`
- bound six cdk-nag consumers to the compatible 2.x API
- update three Lambda declarations to Python 3.14 to satisfy current AwsSolutions-L1 validation
- preserve nested application/runtime requirements and project-specific commands

## Target ranges
```text
aws-cdk-lib>=2.262.0,<3.0.0
constructs>=10.5.0,<11.0.0
```

## Validation
- updater check - 78 scanned, 78 up-to-date, 0 pending, 0 errors
- full repository Python validation - 76 build+synth passes, 2 existing `DO_NOT_AUTOTEST` skips, 0 failures
- all six cdk-nag consumers resolve compatible cdk-nag 2.38.2
- `git diff --check`
