### PR TITLE
feat(java): update CDK dependencies

### DIFF
--- a/java/alb-multi-rule-response/pom.xml
+++ b/java/alb-multi-rule-response/pom.xml
@@ -39,13 +39,13 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>[2.0.0,)</version>
+            <version>[2.262.0,3.0.0)</version>
         </dependency>
 
         <dependency>
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
-            <version>[10.0.0,)</version>
+            <version>[10.5.0,11.0.0)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/api-cors-lambda-crud-dynamodb/cdk/pom.xml
+++ b/java/api-cors-lambda-crud-dynamodb/cdk/pom.xml
@@ -42,13 +42,13 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>[2.0.0,)</version>
+            <version>[2.262.0,3.0.0)</version>
         </dependency>
 
         <dependency>
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
-            <version>[10.0.0,)</version>
+            <version>[10.5.0,11.0.0)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/application-load-balancer/pom.xml
+++ b/java/application-load-balancer/pom.xml
@@ -9,8 +9,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdk.version>2.171.1</cdk.version>
-    <constructs.version>[10.0.0,11.0.0)</constructs.version>
+    <cdk.version>[2.262.0,3.0.0)</cdk.version>
+    <constructs.version>[10.5.0,11.0.0)</constructs.version>
     <junit.version>5.7.1</junit.version>
     <maven.compiler.target>22</maven.compiler.target>
     <maven.compiler.source>22</maven.compiler.source>

--- a/java/backup-s3/pom.xml
+++ b/java/backup-s3/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.89.0</cdk.version>
-        <constructs.version>[10.0.0,11.0.0)</constructs.version>
+        <cdk.version>[2.262.0,3.0.0)</cdk.version>
+        <constructs.version>[10.5.0,11.0.0)</constructs.version>
         <junit.version>5.7.1</junit.version>
     </properties>
 

--- a/java/classic-load-balancer/pom.xml
+++ b/java/classic-load-balancer/pom.xml
@@ -55,13 +55,13 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>[2.0.0,)</version>
+            <version>[2.262.0,3.0.0)</version>
         </dependency>
 
         <dependency>
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
-            <version>[10.0.0,)</version>
+            <version>[10.5.0,11.0.0)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/codebuild/project/pom.xml
+++ b/java/codebuild/project/pom.xml
@@ -39,13 +39,13 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>[2.0.0,)</version>
+            <version>[2.262.0,3.0.0)</version>
         </dependency>
 
         <dependency>
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
-            <version>[10.0.0,)</version>
+            <version>[10.5.0,11.0.0)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/codebuild/reportgroup/pom.xml
+++ b/java/codebuild/reportgroup/pom.xml
@@ -39,13 +39,13 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>[2.0.0,)</version>
+            <version>[2.262.0,3.0.0)</version>
         </dependency>
 
         <dependency>
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
-            <version>[10.0.0,)</version>
+            <version>[10.5.0,11.0.0)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/codebuild/sourceCredential/pom.xml
+++ b/java/codebuild/sourceCredential/pom.xml
@@ -39,13 +39,13 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>[2.0.0,)</version>
+            <version>[2.262.0,3.0.0)</version>
         </dependency>
 
         <dependency>
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
-            <version>[10.0.0,)</version>
+            <version>[10.5.0,11.0.0)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/cognito-api-lambda/pom.xml
+++ b/java/cognito-api-lambda/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.158.0</cdk.version>
-        <constructs.version>[10.0.0,11.0.0)</constructs.version>
+        <cdk.version>[2.262.0,3.0.0)</cdk.version>
+        <constructs.version>[10.5.0,11.0.0)</constructs.version>
         <junit.version>5.7.1</junit.version>
     </properties>
 

--- a/java/custom-logical-names/pom.xml
+++ b/java/custom-logical-names/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.143.0</cdk.version>
-        <constructs.version>[10.0.0,11.0.0)</constructs.version>
+        <cdk.version>[2.262.0,3.0.0)</cdk.version>
+        <constructs.version>[10.5.0,11.0.0)</constructs.version>
         <junit.version>5.7.1</junit.version>
     </properties>
 

--- a/java/custom-resource/cdk/pom.xml
+++ b/java/custom-resource/cdk/pom.xml
@@ -45,13 +45,13 @@
     <dependency>
         <groupId>software.amazon.awscdk</groupId>
         <artifactId>aws-cdk-lib</artifactId>
-        <version>[2.0.0,)</version>
+        <version>[2.262.0,3.0.0)</version>
     </dependency>
 
     <dependency>
         <groupId>software.constructs</groupId>
         <artifactId>constructs</artifactId>
-        <version>[10.0.0,)</version>
+        <version>[10.5.0,11.0.0)</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/ec2-instance/pom.xml
+++ b/java/ec2-instance/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.89.0</cdk.version>
-        <constructs.version>[10.0.0,11.0.0)</constructs.version>
+        <cdk.version>[2.262.0,3.0.0)</cdk.version>
+        <constructs.version>[10.5.0,11.0.0)</constructs.version>
         <junit.version>5.7.1</junit.version>
     </properties>
 

--- a/java/ecs/fargate-load-balanced-service/pom.xml
+++ b/java/ecs/fargate-load-balanced-service/pom.xml
@@ -39,13 +39,13 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>[2.0.0,)</version>
+            <version>[2.262.0,3.0.0)</version>
         </dependency>
 
         <dependency>
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
-            <version>[10.0.0,)</version>
+            <version>[10.5.0,11.0.0)</version>
         </dependency>
 
         <dependency>

--- a/java/eks/fargate-cluster/pom.xml
+++ b/java/eks/fargate-cluster/pom.xml
@@ -9,9 +9,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.235.1</cdk.version>
+        <cdk.version>[2.262.0,3.0.0)</cdk.version>
         <kubectl.version>2.0.0</kubectl.version>
-        <constructs.version>[10.0.0,11.0.0)</constructs.version>
+        <constructs.version>[10.5.0,11.0.0)</constructs.version>
         <junit.version>5.7.1</junit.version>
     </properties>
 

--- a/java/eks/private-cluster/pom.xml
+++ b/java/eks/private-cluster/pom.xml
@@ -9,9 +9,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.235.1</cdk.version>
+        <cdk.version>[2.262.0,3.0.0)</cdk.version>
         <kubectl.version>2.0.0</kubectl.version>
-        <constructs.version>[10.0.0,11.0.0)</constructs.version>
+        <constructs.version>[10.5.0,11.0.0)</constructs.version>
         <junit.version>5.7.1</junit.version>
     </properties>
 

--- a/java/eks/private-cluster/src/test/java/com/amazonaws/cdk/examples/EksPrivateClusterStackTest.java
+++ b/java/eks/private-cluster/src/test/java/com/amazonaws/cdk/examples/EksPrivateClusterStackTest.java
@@ -1,27 +1,21 @@
 package com.amazonaws.cdk.examples;
 
 import java.util.Map;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.awscdk.App;
 import software.amazon.awscdk.assertions.Match;
 import software.amazon.awscdk.assertions.Template;
 
 public class EksPrivateClusterStackTest {
-  private static Template template;
-
-  @BeforeAll
-  static void setUp() {
+  private static Template synthesizeTemplate() {
     final App app = new App();
     final EksPrivateClusterStack stack = new EksPrivateClusterStack(app, "EksPrivateCluster");
-    template = Template.fromStack(stack);
+    return Template.fromStack(stack);
   }
 
   @Test
   public void testEksClusterNameVersion() {
-    final App app = new App();
-    final EksPrivateClusterStack stack = new EksPrivateClusterStack(app, "EksPrivateCluster");
-    template = Template.fromStack(stack);
+    final Template template = synthesizeTemplate();
     template.resourcePropertiesCountIs(
         "Custom::AWSCDK-EKS-Cluster",
         Match.objectLike(
@@ -35,9 +29,7 @@ public class EksPrivateClusterStackTest {
 
   @Test
   public void testEksClusterEndpointAccess() {
-    final App app = new App();
-    final EksPrivateClusterStack stack = new EksPrivateClusterStack(app, "EksPrivateCluster");
-    template = Template.fromStack(stack);
+    final Template template = synthesizeTemplate();
     template.resourcePropertiesCountIs(
         "Custom::AWSCDK-EKS-Cluster",
         Match.objectLike(
@@ -53,11 +45,13 @@ public class EksPrivateClusterStackTest {
 
   @Test
   public void testNoInternetGateway() {
+    final Template template = synthesizeTemplate();
     template.resourceCountIs("AWS::EC2::InternetGateway", 0);
   }
 
   @Test
   public void testNoNatGateway() {
+    final Template template = synthesizeTemplate();
     template.resourceCountIs("AWS::EC2::NatGateway", 0);
   }
 }

--- a/java/eventbridge-lambda/pom.xml
+++ b/java/eventbridge-lambda/pom.xml
@@ -9,8 +9,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdk.version>2.158.0</cdk.version>
-    <constructs.version>[10.0.0,11.0.0)</constructs.version>
+    <cdk.version>[2.262.0,3.0.0)</cdk.version>
+    <constructs.version>[10.5.0,11.0.0)</constructs.version>
     <junit.version>5.7.1</junit.version>
   </properties>
 

--- a/java/hello-world/pom.xml
+++ b/java/hello-world/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>[2.0.0,)</version>
+            <version>[2.262.0,3.0.0)</version>
         </dependency>
 
         <dependency>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
-            <version>[10.0.0,)</version>
+            <version>[10.5.0,11.0.0)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/http-proxy-apigateway/pom.xml
+++ b/java/http-proxy-apigateway/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.171.1</cdk.version>
-        <constructs.version>[10.0.0,11.0.0)</constructs.version>
+        <cdk.version>[2.262.0,3.0.0)</cdk.version>
+        <constructs.version>[10.5.0,11.0.0)</constructs.version>
         <junit.version>5.7.1</junit.version>
         <maven.compiler.target>22</maven.compiler.target>
         <maven.compiler.source>22</maven.compiler.source>

--- a/java/lambda-cron/pom.xml
+++ b/java/lambda-cron/pom.xml
@@ -55,13 +55,13 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>[2.0.0,)</version>
+            <version>[2.262.0,3.0.0)</version>
         </dependency>
 
         <dependency>
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
-            <version>[10.0.0,)</version>
+            <version>[10.5.0,11.0.0)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/my-widget-service/pom.xml
+++ b/java/my-widget-service/pom.xml
@@ -58,13 +58,13 @@
 		<dependency>
 				<groupId>software.amazon.awscdk</groupId>
 				<artifactId>aws-cdk-lib</artifactId>
-				<version>[2.0.0,)</version>
+				<version>[2.262.0,3.0.0)</version>
 		</dependency>
 
 		<dependency>
 				<groupId>software.constructs</groupId>
 				<artifactId>constructs</artifactId>
-				<version>[10.0.0,)</version>
+				<version>[10.5.0,11.0.0)</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/resource-overrides/pom.xml
+++ b/java/resource-overrides/pom.xml
@@ -56,13 +56,13 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>[2.0.0,)</version>
+            <version>[2.262.0,3.0.0)</version>
         </dependency>
 
         <dependency>
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
-            <version>[10.0.0,)</version>
+            <version>[10.5.0,11.0.0)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->

--- a/java/s3-lambda-s3/cdk/pom.xml
+++ b/java/s3-lambda-s3/cdk/pom.xml
@@ -47,13 +47,13 @@
     <dependency>
         <groupId>software.amazon.awscdk</groupId>
         <artifactId>aws-cdk-lib</artifactId>
-        <version>[2.0.0,)</version>
+        <version>[2.262.0,3.0.0)</version>
     </dependency>
 
     <dependency>
         <groupId>software.constructs</groupId>
         <artifactId>constructs</artifactId>
-        <version>[10.0.0,)</version>
+        <version>[10.5.0,11.0.0)</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/s3-object-lambda/infra/pom.xml
+++ b/java/s3-object-lambda/infra/pom.xml
@@ -12,8 +12,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>17</maven.compiler.release>
     <java.version>17</java.version>
-    <cdk.version>2.171.1</cdk.version>
-    <constructs.version>[10.0.0,11.0.0)</constructs.version>
+    <cdk.version>[2.262.0,3.0.0)</cdk.version>
+    <constructs.version>[10.5.0,11.0.0)</constructs.version>
     <junit.version>5.7.1</junit.version>
     <lombok.version>1.18.34</lombok.version>
   </properties>

--- a/java/stepfunctions-job-poller/pom.xml
+++ b/java/stepfunctions-job-poller/pom.xml
@@ -54,13 +54,13 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>[2.0.0,)</version>
+            <version>[2.262.0,3.0.0)</version>
         </dependency>
 
         <dependency>
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
-            <version>[10.0.0,)</version>
+            <version>[10.5.0,11.0.0)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->

--- a/java/waf/pom.xml
+++ b/java/waf/pom.xml
@@ -55,13 +55,13 @@
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>[2.0.0,)</version>
+            <version>[2.262.0,3.0.0)</version>
         </dependency>
 
         <dependency>
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
-            <version>[10.0.0,)</version>
+            <version>[10.5.0,11.0.0)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/junit/junit -->


### PR DESCRIPTION
## Summary
- align all 25 Java CDK applications with current `cdk init --language=java` Maven ranges
- support both property-backed and direct dependency declarations
- make EKS private-cluster tests independent of legacy Surefire execution order
- leave aggregator and Lambda runtime POMs without CDK dependencies unchanged

## Target ranges
```xml
<cdk.version>[2.262.0,3.0.0)</cdk.version>
<constructs.version>[10.5.0,11.0.0)</constructs.version>
```

## Validation
- updater check - 25 scanned, 25 up-to-date, 0 pending, 0 errors
- clean Maven compile/test and CDK synth - 25 passed, 0 failed
- EKS private-cluster tests - 4 run, 0 failures, 0 errors
- `git diff --check`
