### PR TITLE
feat(csharp): update CDK dependencies

### DIFF
--- a/csharp/CloudFront-S3-WAF/src/src.csproj
+++ b/csharp/CloudFront-S3-WAF/src/src.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.25.0" />
-    <PackageReference Include="Constructs" Version="[10.0.0,11.0.0)" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/csharp/api-cors-lambda-crud-dynamodb/src/ApiCorsLambdaCrudDynamodb/ApiCorsLambdaCrudDynamodb.csproj
+++ b/csharp/api-cors-lambda-crud-dynamodb/src/ApiCorsLambdaCrudDynamodb/ApiCorsLambdaCrudDynamodb.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <!-- Roll forward to future major versions of the netcoreapp as needed -->
     <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.1.0" />
-    <PackageReference Include="Constructs" Version="[10.0.0,11.0.0)" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/csharp/apigateway-cognito-lambda-dynamodb/src/CDK/cdk.csproj
+++ b/csharp/apigateway-cognito-lambda-dynamodb/src/CDK/cdk.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
       <!-- CDK Construct Library dependencies -->
-      <PackageReference Include="Amazon.CDK.Lib" Version="2.25.0" />
-      <PackageReference Include="Constructs" Version="[10.0.0,11.0.0)" />
+      <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+      <PackageReference Include="Constructs" Version="10.*" />
     </ItemGroup>
 </Project>

--- a/csharp/application-load-balancer/src/ApplicationLoadBalancer/ApplicationLoadBalancer.csproj
+++ b/csharp/application-load-balancer/src/ApplicationLoadBalancer/ApplicationLoadBalancer.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.0.0" />
-    <PackageReference Include="Constructs" Version="10.0.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
   </ItemGroup>
 
 </Project>

--- a/csharp/appsync-graphql-dynamodb/src/AppsyncGraphqlDynamodb/AppsyncGraphqlDynamodb.csproj
+++ b/csharp/appsync-graphql-dynamodb/src/AppsyncGraphqlDynamodb/AppsyncGraphqlDynamodb.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.0.0" />
-    <PackageReference Include="Constructs" Version="10.0.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
   </ItemGroup>
 
 </Project>

--- a/csharp/appsync-graphql-dynamodb/src/AppsyncGraphqlDynamodb/AppsyncGraphqlDynamodbStack.cs
+++ b/csharp/appsync-graphql-dynamodb/src/AppsyncGraphqlDynamodb/AppsyncGraphqlDynamodbStack.cs
@@ -53,9 +53,9 @@ namespace AppsyncGraphqlDynamodb
                 ApiId = itemsGraphQLApi.AttrApiId,
                 Name = "ItemsDynamoDataSource",
                 Type = "AMAZON_DYNAMODB",
-                DynamoDbConfig = new Dictionary<string, string>() {
-                    {"tableName", itemsTable.TableName},
-                    {"awsRegion", this.Region}
+                DynamoDbConfig = new CfnDataSource.DynamoDBConfigProperty {
+                    TableName = itemsTable.TableName,
+                    AwsRegion = this.Region
                 },
                 ServiceRoleArn = itemsTableRole.RoleArn
             });

--- a/csharp/capitalize-string/src/CapitalizeString/CapitalizeString.csproj
+++ b/csharp/capitalize-string/src/CapitalizeString/CapitalizeString.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.173.4" />
-    <PackageReference Include="Constructs" Version="10.0.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
   </ItemGroup>
 
 </Project>

--- a/csharp/classic-load-balancer/src/ClassicLoadBalancer/ClassicLoadBalancer.csproj
+++ b/csharp/classic-load-balancer/src/ClassicLoadBalancer/ClassicLoadBalancer.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.0.0" />
-    <PackageReference Include="Constructs" Version="10.0.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
   </ItemGroup>
 
 </Project>

--- a/csharp/custom-resource-cloudfront-invalidate/src/CustomResourceCloudFrontInvalidate/CustomResourceCloudFrontInvalidate.csproj
+++ b/csharp/custom-resource-cloudfront-invalidate/src/CustomResourceCloudFrontInvalidate/CustomResourceCloudFrontInvalidate.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.122.0" />
-    <PackageReference Include="Constructs" Version="[10.0.0,11.0.0)" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
   </ItemGroup>
 
 </Project>

--- a/csharp/ec2-instance-dev-server/src/Ec2InstanceDevServer/Ec2InstanceDevServer.csproj
+++ b/csharp/ec2-instance-dev-server/src/Ec2InstanceDevServer/Ec2InstanceDevServer.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.128.0" />
-    <PackageReference Include="Constructs" Version="[10.0.0,11.0.0)" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/csharp/ec2-instance/src/Ec2Instance/Ec2Instance.csproj
+++ b/csharp/ec2-instance/src/Ec2Instance/Ec2Instance.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.*" />
-    <PackageReference Include="Constructs" Version="[10.*,11.0.0)" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/csharp/elasticbeanstalk/elasticbeanstalk-bg-pipeline/src/ElasticbeanstalkBgPipeline/ElasticbeanstalkBgPipeline.csproj
+++ b/csharp/elasticbeanstalk/elasticbeanstalk-bg-pipeline/src/ElasticbeanstalkBgPipeline/ElasticbeanstalkBgPipeline.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.0.0" />
-    <PackageReference Include="Constructs" Version="10.0.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
   </ItemGroup>
 
 </Project>

--- a/csharp/elasticbeanstalk/elasticbeanstalk-bg-pipeline/src/ElasticbeanstalkBgPipeline/ElasticbeanstalkBgPipelineStack.cs
+++ b/csharp/elasticbeanstalk/elasticbeanstalk-bg-pipeline/src/ElasticbeanstalkBgPipeline/ElasticbeanstalkBgPipelineStack.cs
@@ -28,7 +28,7 @@ namespace ElasticbeanstalkBgPipeline
             var handler = new Function(this, "BlueGreenLambda", new FunctionProps
             {
                 Runtime = Runtime.PYTHON_3_7,
-                Code = Code.FromAsset("resources"),
+                Code = Amazon.CDK.AWS.Lambda.Code.FromAsset("resources"),
                 Handler = "blue_green.lambda_handler",
                 Environment = new Dictionary<string, string>
                 {

--- a/csharp/elasticbeanstalk/elasticbeanstalk-environment/src/ElasticbeanstalkEnvironment/ElasticbeanstalkEnvironment.csproj
+++ b/csharp/elasticbeanstalk/elasticbeanstalk-environment/src/ElasticbeanstalkEnvironment/ElasticbeanstalkEnvironment.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.0.0" />
-    <PackageReference Include="Constructs" Version="10.0.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
   </ItemGroup>
 
 </Project>

--- a/csharp/eventbridge-firehose-s3-cdk/src/src.csproj
+++ b/csharp/eventbridge-firehose-s3-cdk/src/src.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 <ItemGroup>
     <!-- CDK Construct Library dependencies -->
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.25.0" />
-    <PackageReference Include="Constructs" Version="[10.0.0,11.0.0)" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
 
     <!-- jsii Roslyn analyzers (un-comment to obtain compile-time checks for missing required props
     <PackageReference Include="Amazon.Jsii.Analyzers" Version="*" PrivateAssets="all" />

--- a/csharp/lambda-cron/cdk.json
+++ b/csharp/lambda-cron/cdk.json
@@ -2,7 +2,6 @@
   "app": "dotnet run --project src/LambdaCron/LambdaCron.csproj",
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
     "aws-cdk:enableDiffNoFail": "true",
     "@aws-cdk/core:stackRelativeExports": "true",
     "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,

--- a/csharp/lambda-cron/src/LambdaCron.Tests/LambdaCron.Tests.csproj
+++ b/csharp/lambda-cron/src/LambdaCron.Tests/LambdaCron.Tests.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
 
-    <PackageReference Include="Amazon.CDK" Version="1.127.0" />
-    <PackageReference Include="Amazon.CDK.Assertions" Version="1.127.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/lambda-cron/src/LambdaCron.Tests/LambdaCronTest.cs
+++ b/csharp/lambda-cron/src/LambdaCron.Tests/LambdaCronTest.cs
@@ -38,7 +38,7 @@ namespace LambdaCron.UnitTests
                       {"ZipFile", "def main(event, context):\n" + "    print(\"I'm running!\")\n"}
                   }},
                   {"Handler", "index.main"},
-                  {"Runtime", "python3.6"},
+                  {"Runtime", "python3.14"},
                   {"Timeout", 300}
                 }},
                 {"DependsOn", new [] { dependencyCapture }}

--- a/csharp/lambda-cron/src/LambdaCron/LambdaCron.csproj
+++ b/csharp/lambda-cron/src/LambdaCron/LambdaCron.csproj
@@ -8,11 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK" Version="1.127.0" />
-    <PackageReference Include="Amazon.CDK.AWS.Events" Version="1.127.0" />
-    <PackageReference Include="Amazon.CDK.AWS.Events.Targets" Version="1.127.0" />
-    <PackageReference Include="Amazon.CDK.AWS.Lambda" Version="1.127.0" />
-    <PackageReference Include="Amazon.CDK.Assertions" Version="1.127.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
   </ItemGroup>
 
 </Project>

--- a/csharp/lambda-cron/src/LambdaCron/LambdaCronStack.cs
+++ b/csharp/lambda-cron/src/LambdaCron/LambdaCronStack.cs
@@ -2,6 +2,7 @@ using Amazon.CDK;
 using Amazon.CDK.AWS.Lambda;
 using Amazon.CDK.AWS.Events.Targets;
 using Amazon.CDK.AWS.Events;
+using Constructs;
 
 namespace LambdaCron
 {
@@ -10,7 +11,7 @@ namespace LambdaCron
         public LambdaCronStack(Construct scope, string id, IStackProps props = null) : base(scope, id, props)
         {
             var lambdaFn = new Function(this, "Singleton", new FunctionProps {
-                Runtime = Runtime.PYTHON_3_6,
+                Runtime = Runtime.PYTHON_3_14,
                 Code = Code.FromInline("def main(event, context):\n" + "    print(\"I'm running!\")\n"),
                 Handler = "index.main",
                 Timeout = Duration.Seconds(300),

--- a/csharp/my-widget-service/src/MyWidgetService/MyWidgetService.csproj
+++ b/csharp/my-widget-service/src/MyWidgetService/MyWidgetService.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.143.0" />
-    <PackageReference Include="Constructs" Version="10.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
   </ItemGroup>
 
 </Project>

--- a/csharp/random-writer/src/RandomWriter/RandomWriter.csproj
+++ b/csharp/random-writer/src/RandomWriter/RandomWriter.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.143.0" />
-    <PackageReference Include="Constructs" Version="10.0.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
   </ItemGroup>
 
 </Project>

--- a/csharp/random-writer/src/RandomWriter/RandomWriterStack.cs
+++ b/csharp/random-writer/src/RandomWriter/RandomWriterStack.cs
@@ -4,6 +4,7 @@ using Amazon.CDK.AWS.DynamoDB;
 using Amazon.CDK.AWS.Events;
 using Amazon.CDK.AWS.Events.Targets;
 using Amazon.CDK.AWS.Lambda;
+using Amazon.CDK.Interfaces.Events;
 using Constructs;
 
 namespace RandomWriter
@@ -52,7 +53,7 @@ namespace RandomWriter
             table.GrantReadWriteData(Function);
         }
 
-        public IRuleTargetConfig Bind(IRule rule, string id = null)
+        public IRuleTargetConfig Bind(IRuleRef rule, string id = null)
         {
             return new LambdaFunction(Function).Bind(rule, id);
         }

--- a/csharp/static-site/src/StaticSite/StaticSite.csproj
+++ b/csharp/static-site/src/StaticSite/StaticSite.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.0.0" />
-    <PackageReference Include="Constructs" Version="10.0.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
   </ItemGroup>
 
 </Project>

--- a/csharp/static-site/src/StaticSite/StaticSiteConstruct.cs
+++ b/csharp/static-site/src/StaticSite/StaticSiteConstruct.cs
@@ -52,26 +52,25 @@ namespace StaticSite
                 Value = siteBucket.BucketName
             });
 
-            var certificateArn = new DnsValidatedCertificate(this, "SiteCertificate", new DnsValidatedCertificateProps
+            var certificate = new DnsValidatedCertificate(this, "SiteCertificate", new DnsValidatedCertificateProps
             {
                 DomainName = siteDomain,
                 HostedZone = zone
-            }).CertificateArn;
+            });
 
-            new CfnOutput(this, "Certificate", new CfnOutputProps{Value = certificateArn});
+            new CfnOutput(this, "Certificate", new CfnOutputProps{Value = certificate.CertificateArn});
 
             var behavior = new Behavior();
             behavior.IsDefaultBehavior = true;
 
             var distribution = new CloudFrontWebDistribution(this, "SiteDistribution", new CloudFrontWebDistributionProps
             {
-                AliasConfiguration = new AliasConfiguration
+                ViewerCertificate = ViewerCertificate.FromAcmCertificate(certificate, new ViewerCertificateOptions
                 {
-                    AcmCertRef = certificateArn,
-                    Names = new string[] {siteDomain},
+                    Aliases = new string[] {siteDomain},
                     SslMethod = SSLMethod.SNI,
                     SecurityPolicy = SecurityPolicyProtocol.TLS_V1_2016
-                },
+                }),
                 OriginConfigs = new ISourceConfiguration[]
                 {
                     new SourceConfiguration

--- a/csharp/static-site/src/StaticSite/StaticSiteStack.cs
+++ b/csharp/static-site/src/StaticSite/StaticSiteStack.cs
@@ -1,4 +1,5 @@
 using Amazon.CDK;
+using Constructs;
 
 namespace StaticSite
 {

--- a/csharp/stepfunctions-job-poller/src/StepfunctionsJobPoller/StepfunctionsJobPoller.csproj
+++ b/csharp/stepfunctions-job-poller/src/StepfunctionsJobPoller/StepfunctionsJobPoller.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.CDK.Lib" Version="2.0.0" />
-    <PackageReference Include="Constructs" Version="10.0.0" />
+    <PackageReference Include="Amazon.CDK.Lib" Version="[2.262.0,3.0.0)" />
+    <PackageReference Include="Constructs" Version="10.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- align all 19 C# CDK projects with current `cdk init --language=csharp` package conventions
- migrate the remaining `lambda-cron` CDK v1 application and tests to CDK v2
- update source compatibility for current AppSync, CodePipeline, EventBridge, Lambda, and CloudFront APIs
- preserve non-CDK Lambda/runtime project manifests

## Target ranges
Fresh `aws-cdk@2.1133.0` C# init output uses:
- `Amazon.CDK.Lib`: `[2.262.0,3.0.0)`
- `Constructs`: `10.*`
- target framework: `net8.0`

## Validation
- updater check: 19 scanned, 19 up-to-date, 0 pending, 0 manual migrations, 0 errors
- repository clean test/build/synth: 17 passed, 1 existing `DO_NOT_AUTOTEST` skip, 0 failed
- `lambda-cron` migration tests: 5 passed, 0 failed
- skipped static-site example separately passed clean restore, test, and build; synth requires its documented account and Route53 lookup context
- no remaining CDK v1 or split service package references
- `git diff --check`
