### PR TITLE
feat(python): upgrade dynamodb-lambda example to Python 3.11 runtime

### DIFF
--- a/python/dynamodb-lambda/README.md
+++ b/python/dynamodb-lambda/README.md
@@ -13,8 +13,7 @@ This project is set up like a standard Python project.  The initialization
 process also creates a virtualenv within this project, stored under the .env
 directory.  To create the virtualenv it assumes that there is a `python3`
 (or `python` for Windows) executable in your path with access to the `venv`
-package. It requires you to use Pythn 3.6 as Lambda runtime is set to Python 3.6. 
-For other python versions, please update runtime for consumer and producer functions under dynamodb_lambda/dynamodb_lambda_stack.py
+package. It requires you to use Python 3.11 as Lambda runtime is set to Python 3.11.
 If for any reason the automatic creation of the virtualenv fails,
 you can create the virtualenv manually.
 

--- a/python/dynamodb-lambda/dynamodb_lambda/dynamodb_lambda_stack.py
+++ b/python/dynamodb-lambda/dynamodb_lambda/dynamodb_lambda_stack.py
@@ -23,7 +23,7 @@ class DynamodbLambdaStack(Stack):
 
         # create producer lambda function
         producer_lambda = aws_lambda.Function(self, "producer_lambda_function",
-                                              runtime=aws_lambda.Runtime.PYTHON_3_6,
+                                              runtime=aws_lambda.Runtime.PYTHON_3_11,
                                               handler="lambda_function.lambda_handler",
                                               code=aws_lambda.Code.from_asset("./lambda/producer"))
 
@@ -34,7 +34,7 @@ class DynamodbLambdaStack(Stack):
 
         # create consumer lambda function
         consumer_lambda = aws_lambda.Function(self, "consumer_lambda_function",
-                                              runtime=aws_lambda.Runtime.PYTHON_3_6,
+                                              runtime=aws_lambda.Runtime.PYTHON_3_11,
                                               handler="lambda_function.lambda_handler",
                                               code=aws_lambda.Code.from_asset("./lambda/consumer"))
 

--- a/python/dynamodb-lambda/lambda/consumer/lambda_function.py
+++ b/python/dynamodb-lambda/lambda/consumer/lambda_function.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import decimal
 import os

--- a/python/dynamodb-lambda/lambda/producer/lambda_function.py
+++ b/python/dynamodb-lambda/lambda/producer/lambda_function.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import uuid
 import decimal

--- a/python/dynamodb-lambda/setup.py
+++ b/python/dynamodb-lambda/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
         "aws-cdk.aws_events_targets"
     ],
 
-    python_requires=">=3.6",
+    python_requires=">=3.11",
 
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -40,9 +40,7 @@ setuptools.setup(
 
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.11",
 
         "Topic :: Software Development :: Code Generators",
         "Topic :: Utilities",


### PR DESCRIPTION
```
Upgrade the `python/dynamodb-lambda` example to use Python 3.11 Lambda runtime.

### Changes:
- Updated Lambda runtime from `PYTHON_3_6` to `PYTHON_3_11` in CDK stack
- Updated `setup.py` with `python_requires=">=3.11"` and Python 3.11 classifier
- Updated README to reflect Python 3.11 requirement
- Removed unnecessary `__future__` imports

### Validation:
- `cdk synth` passes successfully
- Automated test script (`scripts/build-python.sh`) passes
- Deployed and tested Lambda functions in AWS (both return 200)

Fixes # <!-- create an issue if needed, or remove this line -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
```