### PR TITLE
docs(codepipeline-build-deploy): document how to update app code post-deploy

### DIFF
--- a/go/codepipeline-build-deploy/README.md
+++ b/go/codepipeline-build-deploy/README.md
@@ -71,6 +71,36 @@ After a successful deployment, CDK will output a public endpoint for:
   - ECR image repository
   - Lambda functions
 
+## Updating the Application Code
+
+The pipeline's source is the AWS CodeCommit repository the stack creates (`simple-app-code-repo`), **not** this `codepipeline-build-deploy` directory. At deploy time, the stack seeds that repository with the contents of the local `app/` folder on the `main` branch. To change the application and trigger a new pipeline run, work against that CodeCommit repository:
+
+1. Set up Git credentials for CodeCommit. The simplest option is [`git-remote-codecommit`](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-git-remote-codecommit.html):
+
+   ```sh
+   pip install git-remote-codecommit
+   ```
+
+2. Clone the seeded repository (replace `<region>` with the Region you deployed to):
+
+   ```sh
+   git clone codecommit::<region>://simple-app-code-repo
+   cd simple-app-code-repo
+   ```
+
+3. Edit the application code, then commit and push to the `main` branch:
+
+   ```sh
+   # make your changes
+   git add .
+   git commit -m "Update application"
+   git push origin main
+   ```
+
+4. The push to `main` automatically triggers the pipeline. Open the AWS CodePipeline console and select `ImageBuildDeployPipeline` to watch the build and deploy stages run. You do **not** need to click `Release change` for a normal code update - that button is only for manually re-running the pipeline against the current source.
+
+> **Note:** Clone the CodeCommit repository the stack created rather than adding it as a remote of this example directory. The example directory contains the CDK app, while the CodeCommit repository contains only the seeded `app/` contents that the pipeline builds.
+
 ## Further Improvements
 
 - Add [manual approval actions](https://docs.aws.amazon.com/codepipeline/latest/userguide/approvals-action-add.html) to the CodePipeline workflow.

--- a/python/codepipeline-build-deploy/README.md
+++ b/python/codepipeline-build-deploy/README.md
@@ -75,6 +75,36 @@ After a successful deployment, CDK will output a public endpoint for:
   - ECR image repository
   - Lambda functions
 
+## Updating the Application Code
+
+The pipeline's source is the AWS CodeCommit repository the stack creates (`simple-app-code-repo`), **not** this `codepipeline-build-deploy` directory. At deploy time, the stack seeds that repository with the contents of the local `app/` folder on the `main` branch. To change the application and trigger a new pipeline run, work against that CodeCommit repository:
+
+1. Set up Git credentials for CodeCommit. The simplest option is [`git-remote-codecommit`](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-git-remote-codecommit.html):
+
+   ```sh
+   pip install git-remote-codecommit
+   ```
+
+2. Clone the seeded repository (replace `<region>` with the Region you deployed to):
+
+   ```sh
+   git clone codecommit::<region>://simple-app-code-repo
+   cd simple-app-code-repo
+   ```
+
+3. Edit the application code, then commit and push to the `main` branch:
+
+   ```sh
+   # make your changes
+   git add .
+   git commit -m "Update application"
+   git push origin main
+   ```
+
+4. The push to `main` automatically triggers the pipeline. Open the AWS CodePipeline console and select `ImageBuildDeployPipeline` to watch the build and deploy stages run. You do **not** need to click `Release change` for a normal code update - that button is only for manually re-running the pipeline against the current source.
+
+> **Note:** Clone the CodeCommit repository the stack created rather than adding it as a remote of this example directory. The example directory contains the CDK app, while the CodeCommit repository contains only the seeded `app/` contents that the pipeline builds.
+
 ## Further Improvements
 
 - Add [manual approval actions](https://docs.aws.amazon.com/codepipeline/latest/userguide/approvals-action-add.html) to the CodePipeline workflow.

--- a/typescript/codepipeline-build-deploy/README.md
+++ b/typescript/codepipeline-build-deploy/README.md
@@ -72,6 +72,36 @@ After a successful deployment, CDK will output a public endpoint for:
   - ECR image repository
   - Lambda functions
 
+## Updating the Application Code
+
+The pipeline's source is the AWS CodeCommit repository the stack creates (`simple-code-repo`), **not** this `codepipeline-build-deploy` directory. At deploy time, the stack seeds that repository with the contents of the local `app/` folder on the `main` branch. To change the application and trigger a new pipeline run, work against that CodeCommit repository:
+
+1. Set up Git credentials for CodeCommit. The simplest option is [`git-remote-codecommit`](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-git-remote-codecommit.html):
+
+   ```sh
+   pip install git-remote-codecommit
+   ```
+
+2. Clone the seeded repository (replace `<region>` with the Region you deployed to):
+
+   ```sh
+   git clone codecommit::<region>://simple-code-repo
+   cd simple-code-repo
+   ```
+
+3. Edit the application code, then commit and push to the `main` branch:
+
+   ```sh
+   # make your changes
+   git add .
+   git commit -m "Update application"
+   git push origin main
+   ```
+
+4. The push to `main` automatically triggers the pipeline. Open the AWS CodePipeline console and select `ImageBuildDeployPipeline` to watch the build and deploy stages run. You do **not** need to click `Release change` for a normal code update - that button is only for manually re-running the pipeline against the current source.
+
+> **Note:** Clone the CodeCommit repository the stack created rather than adding it as a remote of this example directory. The example directory contains the CDK app, while the CodeCommit repository contains only the seeded `app/` contents that the pipeline builds.
+
 ## Further Improvements
 
 - Add [manual approval actions](https://docs.aws.amazon.com/codepipeline/latest/userguide/approvals-action-add.html) to the CodePipeline workflow.


### PR DESCRIPTION
This documents how a developer updates the application code after deploying the `codepipeline-build-deploy` example, which the READMEs previously did not explain.

The examples showed how to deploy the CI/CD pipeline, but stopped there. A developer following the README had no guidance on the actual inner loop: after `cdk deploy`, how do you change code and trigger the pipeline? The stack seeds an AWS CodeCommit repository from the local `app/` folder at deploy time and the pipeline sources from that repo on the `main` branch, but none of that was written down. The existing "Testing" step only mentioned clicking `Release change` in the console, which re-runs the pipeline against the current source rather than showing how to push a change.

This adds an "Updating the Application Code" section to the TypeScript, Python, and Go READMEs. It covers setting up CodeCommit credentials with `git-remote-codecommit`, cloning the stack-created repository, and committing to `main` to auto-trigger the pipeline. It uses the correct per-language repository name (`simple-code-repo` for TypeScript, `simple-app-code-repo` for Python and Go) and clarifies that the seeded CodeCommit repo, not the example directory, is the pipeline's source.

Documentation-only change. No CDK code, tests, or synth output were modified.

Fixes #855

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
