### PR TITLE
fix(ec2-instance): use SSM Session Manager, remove insecure SSH

### DIFF
--- a/typescript/ec2-instance/README.md
+++ b/typescript/ec2-instance/README.md
@@ -3,8 +3,8 @@
 This project demonstrates how to create an EC2 instance with AWS CDK, including:
 
 - VPC with public subnets
-- Security groups for SSH access
 - EC2 instance with Amazon Linux 2023
+- Access via AWS Systems Manager Session Manager (no open inbound ports)
 - CloudFormation Init for instance configuration
 - Asset deployment via S3
 - CloudWatch integration
@@ -22,7 +22,6 @@ You can customize the deployment with these environment variables:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `LOG_LEVEL` | Logging level | `INFO` |
-| `SSH_PUB_KEY` | Your SSH public key for instance access | ` ` (empty) |
 | `CPU_TYPE` | CPU architecture (`ARM64` or `X86`) | `ARM64` |
 | `INSTANCE_SIZE` | Instance size (`LARGE`, `XLARGE`, `XLARGE2`, `XLARGE4`) | `LARGE` |
 
@@ -41,10 +40,15 @@ npx cdk deploy
 
 ## Connecting to the Instance
 
-After deployment, the CDK will output commands to connect to your instance:
+The instance is reached with AWS Systems Manager Session Manager, not SSH. It has no open inbound ports. The instance role includes `AmazonSSMManagedInstanceCore`, so Session Manager works out of the box.
 
-- Using SSH: `ssh ec2-user@<public-dns-name>`
-- Using SSM: `aws ssm start-session --target <instance-id>`
+After deployment, the stack outputs an `ssmCommand`. Run it to open a shell on the instance (replace `<instance-id>` with the value from the output):
+
+```bash
+aws ssm start-session --target <instance-id>
+```
+
+This needs the [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) for the AWS CLI. Session Manager gives an audited shell without opening port 22 or managing SSH keys.
 
 ## Testing
 

--- a/typescript/ec2-instance/bin/app.ts
+++ b/typescript/ec2-instance/bin/app.ts
@@ -12,7 +12,6 @@ const devEnv = {
 
 const stackProps = {
   logLevel: process.env.LOG_LEVEL || 'INFO',
-  sshPubKey: process.env.SSH_PUB_KEY || ' ',
   cpuType: process.env.CPU_TYPE || 'ARM64',
   instanceSize: process.env.INSTANCE_SIZE || 'LARGE',
 };

--- a/typescript/ec2-instance/lib/constructs/server.ts
+++ b/typescript/ec2-instance/lib/constructs/server.ts
@@ -27,16 +27,10 @@ import { Construct } from 'constructs';
 
 interface ServerProps {
   vpc: Vpc;
-  sshSecurityGroup: SecurityGroup;
   logLevel: string;
-  sshPubKey: string;
   cpuType: string;
   instanceSize: string;
 }
-
-let cpuType: AmazonLinuxCpuType;
-let instanceClass: InstanceClass;
-let instanceSize: InstanceSize;
 
 export class ServerResources extends Construct {
   public instance: Instance;
@@ -99,7 +93,8 @@ export class ServerResources extends Construct {
         '/sample /home/ec2-user/sample --recursive',
     );
 
-    // Create a Security Group for the EC2 instance.  This group will allow SSH access to the EC2 instance
+    // Create a Security Group for the EC2 instance. It has no inbound rules;
+    // access is via AWS Systems Manager Session Manager, which needs none.
     const ec2InstanceSecurityGroup = new SecurityGroup(
       this,
       'ec2InstanceSecurityGroup',
@@ -107,6 +102,8 @@ export class ServerResources extends Construct {
     );
 
     // Determine the correct CPUType and Instance Class based on the props passed in
+    let cpuType: AmazonLinuxCpuType;
+    let instanceClass: InstanceClass;
     if (props.cpuType == 'ARM64') {
       cpuType = AmazonLinuxCpuType.ARM_64;
       instanceClass = InstanceClass.M7G;
@@ -116,6 +113,7 @@ export class ServerResources extends Construct {
     }
 
     // Determine the correct InstanceSize based on the props passed in
+    let instanceSize: InstanceSize;
     switch (props.instanceSize) {
       case 'large':
         instanceSize = InstanceSize.LARGE;
@@ -162,11 +160,6 @@ export class ServerResources extends Construct {
               '/etc/config.sh',
               'lib/resources/server/config/config.sh',
             ),
-            InitFile.fromString(
-              // Use CloudformationInit to write a string to the EC2 instance
-              '/home/ec2-user/.ssh/authorized_keys',
-              props.sshPubKey + '\n',
-            ),
             InitCommand.shellCommand('chmod +x /etc/config.sh'), // Use CloudformationInit to run a shell command on the EC2 instance
             InitCommand.shellCommand('/etc/config.sh'),
           ]),
@@ -181,8 +174,5 @@ export class ServerResources extends Construct {
       },
       role: serverRole,
     });
-
-    // Add the SSH Security Group to the EC2 instance
-    this.instance.addSecurityGroup(props.sshSecurityGroup);
   }
 }

--- a/typescript/ec2-instance/lib/constructs/vpc.ts
+++ b/typescript/ec2-instance/lib/constructs/vpc.ts
@@ -1,20 +1,15 @@
-import {
-  SecurityGroup,
-  Peer,
-  Port,
-  SubnetType,
-  Vpc,
-} from 'aws-cdk-lib/aws-ec2';
+import { SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
 
 export class VPCResources extends Construct {
-  public sshSecurityGroup: SecurityGroup;
   public vpc: Vpc;
 
   constructor(scope: Construct, id: string) {
     super(scope, id);
 
-    // Create a VPC with public subnets in 2 AZs
+    // Create a VPC with public subnets in 2 AZs. The instance reaches the
+    // Systems Manager endpoints over its public IP, so no NAT gateway is needed
+    // and no inbound ports are opened.
     this.vpc = new Vpc(this, 'VPC', {
       natGateways: 0,
       subnetConfiguration: [
@@ -27,15 +22,5 @@ export class VPCResources extends Construct {
       ],
       maxAzs: 2,
     });
-
-    // Create a security group for SSH
-    this.sshSecurityGroup = new SecurityGroup(this, 'SSHSecurityGroup', {
-      vpc: this.vpc,
-      description: 'Security Group for SSH',
-      allowAllOutbound: true,
-    });
-
-    // Allow SSH inbound traffic on TCP port 22
-    this.sshSecurityGroup.addIngressRule(Peer.anyIpv4(), Port.tcp(22));
   }
 }

--- a/typescript/ec2-instance/lib/ec2-stack.ts
+++ b/typescript/ec2-instance/lib/ec2-stack.ts
@@ -10,32 +10,26 @@ export class EC2Stack extends Stack {
   constructor(scope: Construct, id: string, props: EC2StackProps) {
     super(scope, id, props);
 
-    const { logLevel, sshPubKey, cpuType, instanceSize } = props;
+    const { logLevel, cpuType, instanceSize } = props;
 
     // Validate environment variables
     envValidator(props);
 
-    // Create VPC and Security Group
+    // Create VPC
     const vpcResources = new VPCResources(this, 'VPC');
 
     // Create EC2 Instance
     const serverResources = new ServerResources(this, 'EC2', {
       vpc: vpcResources.vpc,
-      sshSecurityGroup: vpcResources.sshSecurityGroup,
       logLevel: logLevel,
-      sshPubKey: sshPubKey,
       cpuType: cpuType,
       instanceSize: instanceSize.toLowerCase(),
     });
 
-    // SSM Command to start a session
+    // SSM command to start a session on the instance. Session Manager is the
+    // access path: it needs no open inbound ports and no SSH key.
     new CfnOutput(this, 'ssmCommand', {
       value: `aws ssm start-session --target ${serverResources.instance.instanceId}`,
-    });
-
-    // SSH Command to connect to the EC2 Instance
-    new CfnOutput(this, 'sshCommand', {
-      value: `ssh ec2-user@${serverResources.instance.instancePublicDnsName}`,
     });
   }
 }

--- a/typescript/ec2-instance/lib/utils/env-validator.ts
+++ b/typescript/ec2-instance/lib/utils/env-validator.ts
@@ -1,6 +1,5 @@
 export interface EC2ExampleProps {
   logLevel: string;
-  sshPubKey: string;
   cpuType: string;
   instanceSize: string;
 }

--- a/typescript/ec2-instance/test/__snapshots__/ec2-stack.test.ts.snap
+++ b/typescript/ec2-instance/test/__snapshots__/ec2-stack.test.ts.snap
@@ -3,22 +3,6 @@
 exports[`EC2Stack Snapshot test 1`] = `
 {
   "Outputs": {
-    "sshCommand": {
-      "Value": {
-        "Fn::Join": [
-          "",
-          [
-            "ssh ec2-user@",
-            {
-              "Fn::GetAtt": [
-                "EC2Instance1F00751C93ecacd2478e7d47",
-                "PublicDnsName",
-              ],
-            },
-          ],
-        ],
-      },
-    },
     "ssmCommand": {
       "Value": {
         "Fn::Join": [
@@ -26,7 +10,7 @@ exports[`EC2Stack Snapshot test 1`] = `
           [
             "aws ssm start-session --target ",
             {
-              "Ref": "EC2Instance1F00751C93ecacd2478e7d47",
+              "Ref": "EC2Instance1F00751C11d3440e276f36bf",
             },
           ],
         ],
@@ -263,7 +247,7 @@ exports[`EC2Stack Snapshot test 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "EC2Instance1F00751C93ecacd2478e7d47": {
+    "EC2Instance1F00751C11d3440e276f36bf": {
       "CreationPolicy": {
         "ResourceSignal": {
           "Count": 1,
@@ -297,14 +281,6 @@ exports[`EC2Stack Snapshot test 1`] = `
               "/etc/config.sh": {
                 "content": "#!/bin/bash -xe
 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/tmp/amazon-cloudwatch-agent.json
-",
-                "encoding": "plain",
-                "group": "root",
-                "mode": "000644",
-                "owner": "root",
-              },
-              "/home/ec2-user/.ssh/authorized_keys": {
-                "content": "
 ",
                 "encoding": "plain",
                 "group": "root",
@@ -374,12 +350,6 @@ exports[`EC2Stack Snapshot test 1`] = `
               "GroupId",
             ],
           },
-          {
-            "Fn::GetAtt": [
-              "VPCSSHSecurityGroup0495A24F",
-              "GroupId",
-            ],
-          },
         ],
         "SubnetId": {
           "Ref": "VPCServerPublicSubnet1SubnetF3987995",
@@ -408,7 +378,7 @@ aws s3 cp s3://",
                   "Ref": "EC2assetBucketC584B4AB",
                 },
                 "/sample /home/ec2-user/sample --recursive
-# fingerprint: 32d640a23cf42eea
+# fingerprint: 27a9995640ed65ef
 (
   set +e
   /opt/aws/bin/cfn-init -v --region ",
@@ -419,7 +389,7 @@ aws s3 cp s3://",
                 {
                   "Ref": "AWS::StackName",
                 },
-                " --resource EC2Instance1F00751C93ecacd2478e7d47 --url https://cloudformation.",
+                " --resource EC2Instance1F00751C11d3440e276f36bf --url https://cloudformation.",
                 {
                   "Ref": "AWS::Region",
                 },
@@ -440,7 +410,7 @@ aws s3 cp s3://",
                 {
                   "Ref": "AWS::StackName",
                 },
-                " --resource EC2Instance1F00751C93ecacd2478e7d47 --url https://cloudformation.",
+                " --resource EC2Instance1F00751C11d3440e276f36bf --url https://cloudformation.",
                 {
                   "Ref": "AWS::Region",
                 },
@@ -773,31 +743,6 @@ aws s3 cp s3://",
         ],
       },
       "Type": "AWS::EC2::InternetGateway",
-    },
-    "VPCSSHSecurityGroup0495A24F": {
-      "Properties": {
-        "GroupDescription": "Security Group for SSH",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "SecurityGroupIngress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "from 0.0.0.0/0:22",
-            "FromPort": 22,
-            "IpProtocol": "tcp",
-            "ToPort": 22,
-          },
-        ],
-        "VpcId": {
-          "Ref": "VPC61AD6880",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
     },
     "VPCServerPublicSubnet1DefaultRoute0DEC8857": {
       "DependsOn": [

--- a/typescript/ec2-instance/test/ec2-stack.test.ts
+++ b/typescript/ec2-instance/test/ec2-stack.test.ts
@@ -11,7 +11,6 @@ const devEnv = {
 
 const stackProps = {
   logLevel: 'INFO',
-  sshPubKey: '',
   cpuType: 'ARM64',
   instanceSize: 'LARGE',
 };


### PR DESCRIPTION
This makes the `typescript/ec2-instance` example use AWS Systems Manager Session Manager for access and removes the insecure, broken SSH path.

Following the README exactly deployed an instance whose security group allowed TCP 22 from `0.0.0.0/0`, so `cdk synth` and `npm test` both printed the W2508 "sensitive port 22 open to the internet" warning. The build stayed green, so nothing acted on it. The same instance could never actually be reached over SSH: `SSH_PUB_KEY` defaulted to a single space, so a placeholder `authorized_keys` was written and the emitted `ssh ec2-user@<dns>` command could not authenticate. The instance already had `AmazonSSMManagedInstanceCore` and the stack already output an `aws ssm start-session` command, so Session Manager was the working access path and the SSH ingress was not load-bearing.

The fix removes the SSH path entirely. Gone: the world-open SSH security group and its `Peer.anyIpv4()/Port.tcp(22)` ingress rule, the `authorized_keys` InitFile, the `sshPubKey` prop and `SSH_PUB_KEY` input, and the `sshCommand` output. Access is now Session Manager only, which opens no inbound ports. The instance's own security group is egress-only. While in `server.ts`, the module-scoped `cpuType`/`instanceClass`/`instanceSize` `let`s (shared mutable state in a reusable construct) are scoped to constructor locals.

After this change `cdk synth` exits 0 with no security warning, the template has no ingress rule and no `authorized_keys`, and only the `ssmCommand` output remains. The README's "Connecting to the Instance" section now documents Session Manager. Tests pass and the snapshot was regenerated (it shrinks: the SSH security group, `authorized_keys`, and `sshCommand` are gone).

Fixes #1312

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
